### PR TITLE
fix install patch for Alien 7330 XL on 7312 and Alien 7330 SL on 7320

### DIFF
--- a/patches/scripts/100-7312_7330.sh
+++ b/patches/scripts/100-7312_7330.sh
@@ -4,8 +4,7 @@ echo1 "adapt firmware for 7312"
 #echo2 "moving default config dir"
 isFreetzType 7312_7330_XL && defdir=7322
 isFreetzType 7312_7330_SL && defdir=HW188
-#mv ${FILESYSTEM_MOD_DIR}/etc/default.Fritz_Box_${defdir} \
-mv ${FILESYSTEM_MOD_DIR}/etc/default.Fritz_Box_HW188 \
+mv ${FILESYSTEM_MOD_DIR}/etc/default.Fritz_Box_${defdir} \
    ${FILESYSTEM_MOD_DIR}/etc/default.Fritz_Box_HW189
 
 echo2 "patching rc.S and rc.conf"
@@ -16,5 +15,5 @@ modsed 's/CONFIG_VERSION_MAJOR=.*$/CONFIG_VERSION_MAJOR="117"/g' "${FILESYSTEM_M
 modsed 's/CONFIG_ETH_COUNT=.*$/CONFIG_ETH_COUNT="1"/g' "${FILESYSTEM_MOD_DIR}/etc/init.d/rc.conf"
 # patch install script to accept firmware from 73330 SL
 echo2 "applying install patch"
-modsed "s/mips34_16MB_dect441_1eth_1geth_1ab_2usb_host_wlan11n_01118/mips34_16MB_dect441_1eth_1ab_wlan11n_40508/g" "${FIRMWARE_MOD_DIR}/var/install"
-
+isFreetzType 7312_7330_XL && modsed "s/mips34_16MB_dect441_1eth_1geth_1ab_pots_2usb_host_wlan11n_41167/mips34_16MB_dect441_1eth_1ab_wlan11n_40508/g" "${FIRMWARE_MOD_DIR}/var/install"
+isFreetzType 7312_7330_SL && modsed "s/mips34_16MB_dect441_1eth_1geth_1ab_2usb_host_wlan11n_01118/mips34_16MB_dect441_1eth_1ab_wlan11n_40508/g" "${FIRMWARE_MOD_DIR}/var/install"

--- a/patches/scripts/100-7320_7330.sh
+++ b/patches/scripts/100-7320_7330.sh
@@ -37,4 +37,5 @@ modsed "s/GCOV_PREFIX_STRIP=.*$/GCOV_PREFIX_STRIP=\"3\"/g" "${FILESYSTEM_MOD_DIR
 
 # patch install script to accept firmware from 7330
 echo2 "applying install patch"
-modsed "s/mips34_16MB_dect441_1eth_1geth_1ab_pots_2usb_host_wlan11n_41167/mips34_16MB_dect441_2eth_1ab_2usb_host_wlan11n_37273/g" "${FIRMWARE_MOD_DIR}/var/install"
+isFreetzType 7320_7330_XL && modsed "s/mips34_16MB_dect441_1eth_1geth_1ab_pots_2usb_host_wlan11n_41167/mips34_16MB_dect441_2eth_1ab_2usb_host_wlan11n_37273/g" "${FIRMWARE_MOD_DIR}/var/install"
+isFreetzType 7320_7330_SL && modsed "s/mips34_16MB_dect441_1eth_1geth_1ab_2usb_host_wlan11n_01118/mips34_16MB_dect441_2eth_1ab_2usb_host_wlan11n_37273/g" "${FIRMWARE_MOD_DIR}/var/install"


### PR DESCRIPTION
ermöglicht die Installation des Alien 7330 (ohne SL) auf 7312 und Alien 7330 SL auf 7320.