### PR TITLE
Add 3490 alien for 3370

### DIFF
--- a/config/mod/download.in
+++ b/config/mod/download.in
@@ -336,8 +336,8 @@ menu "Download options"
 		default "@AVM/{fritzbox-3390/deutschland/fritz.os,fritzbox.wlan_3390/firmware/deutsch}"                            if FREETZ_TYPE_3390 && FREETZ_TYPE_LANG_DE
 		default "@AVM/fritzbox.wlan_3390/firmware/{english,belgium}"                                                       if FREETZ_TYPE_3390 && FREETZ_TYPE_LANG_EN
 		#
-		default "@AVM/{fritzbox-3490/deutschland/fritz.os,fritzbox.3490/firmware/deutsch}"                                 if (FREETZ_TYPE_3490 || FREETZ_TYPE_3390_3490) && FREETZ_TYPE_LANG_DE
-		default "@AVM/{fritzbox-3490/{other,belgium}/fritz.os,fritzbox.3490/firmware/{english,belgium}}"                   if (FREETZ_TYPE_3490 || FREETZ_TYPE_3390_3490) && FREETZ_TYPE_LANG_EN
+		default "@AVM/{fritzbox-3490/deutschland/fritz.os,fritzbox.3490/firmware/deutsch}"                                 if (FREETZ_TYPE_3490 || FREETZ_TYPE_3370_3490 || FREETZ_TYPE_3390_3490) && FREETZ_TYPE_LANG_DE
+		default "@AVM/{fritzbox-3490/{other,belgium}/fritz.os,fritzbox.3490/firmware/{english,belgium}}"                   if (FREETZ_TYPE_3490 || FREETZ_TYPE_3370_3490 || FREETZ_TYPE_3390_3490) && FREETZ_TYPE_LANG_EN
 		#
 		default "@AVM/fritzbox-4020/{other,deutschland}/fritz.os"                                                          if FREETZ_TYPE_4020
 		#

--- a/config/mod/prefix.in
+++ b/config/mod/prefix.in
@@ -148,6 +148,7 @@ config FREETZ_TYPE_PREFIX_ALIEN_HARDWARE
 	default "W920V_"            if FREETZ_TYPE_W920V_7570
 	default "DVB-c_"            if FREETZ_TYPE_1759_1750
 	default "3170_"             if FREETZ_TYPE_3170_7170
+	default "3370_"             if FREETZ_TYPE_3370_3490
 	default "3390_"             if FREETZ_TYPE_3390_3490
 	default "7112_"             if FREETZ_TYPE_7112_7170
 	default "7113_"             if FREETZ_TYPE_7113_7170

--- a/config/ui/firmware.in
+++ b/config/ui/firmware.in
@@ -933,8 +933,14 @@ choice
 		help
 			Enable this to compile an alien image for Repeater DVB-c based on a 1750E image.
 
+	config FREETZ_TYPE_3370_3490
+                bool "3370 - No wlan, no usb!"
+                depends on FREETZ_TYPE_3490
+                help
+                        Enable this to compile an alien image for FritzBox 3370 based on a 3490 image.
+
 	config FREETZ_TYPE_3390_3490
-		bool "3390 - No wlan!"
+		bool "3390 - No wlan, no usb!"
 		depends on FREETZ_TYPE_3490
 		select FREETZ_REMOVE_WLAN
 		help

--- a/docs/FIRMWARES.md
+++ b/docs/FIRMWARES.md
@@ -65,12 +65,13 @@ Currently supported devices and firmwares
   - 103.06.55 rev38670 {GER}
   - 103.06.30 rev31156 {INT}
   - 103.06.52 rev34161 {INT}
+  - Alien 3490 (No wlan, no usb!)
 * __Fritz!Box WLAN 3390__
   - 121.06.30 rev30889 {GER}
   - 121.06.55 rev38670 {GER}
   - 121.06.30 rev31156 {INT}
   - 121.06.52 rev33299 {INT}
-  - Alien 3490 (No wlan!)
+  - Alien 3490 (No wlan, no usb!)
 
 * __Fritz!Box WLAN 3490__
   - 140.06.31 rev31064 {GER}

--- a/patches/scripts/100-3370_3490.sh
+++ b/patches/scripts/100-3370_3490.sh
@@ -1,0 +1,16 @@
+isFreetzType 3370_3490 || return 0
+echo1 "adapt firmware for 3370"
+
+echo2 "moving default config dir"
+mv ${FILESYSTEM_MOD_DIR}/etc/default.Fritz_Box_HW212 \
+   ${FILESYSTEM_MOD_DIR}/etc/default.Fritz_Box_3370
+
+echo2 "patching rc.S and rc.conf"
+modsed 's/CONFIG_USB_XHCI=.*$/CONFIG_USB_XHCI="n"/g' "${FILESYSTEM_MOD_DIR}/etc/init.d/rc.conf"
+modsed 's/CONFIG_INSTALL_TYPE=.*$/CONFIG_INSTALL_TYPE="mips34_512MB_vdsl_4eth_2usb_host_wlan11n_26029"/g' "${FILESYSTEM_MOD_DIR}/etc/init.d/rc.conf"
+modsed 's/CONFIG_PRODUKT=.*$/CONFIG_PRODUKT="Fritz_Box_3370"/g' "${FILESYSTEM_MOD_DIR}/etc/init.d/rc.conf"
+modsed 's/CONFIG_PRODUKT_NAME=.*$/CONFIG_PRODUKT_NAME="FRITZ!Box WLAN 3370"/g' "${FILESYSTEM_MOD_DIR}/etc/init.d/rc.conf"
+modsed 's/CONFIG_VERSION_MAJOR=.*$/CONFIG_VERSION_MAJOR="103"/g' "${FILESYSTEM_MOD_DIR}/etc/init.d/rc.conf"
+
+echo2 "applying install patch"
+modsed "s/mips34_512MB_vdsl_4geth_2usb_host_offloadwlan11n_17525/mips34_512MB_vdsl_4eth_2usb_host_wlan11n_26029/g" "${FIRMWARE_MOD_DIR}/var/install"


### PR DESCRIPTION
Ermöglicht für die FritzBox WLAN 3370 eine 3490 Alien-Firmware zu nutzen. WLAN ohne Funktion, im Ereignislog gibt es ein Eintrag, dass das WLAN nicht initialisiert werden konnte. Ebenso funktioniert USB (noch) nicht.