### PR TITLE
MbedTLS: bump to 2.24.0 / adds support for CHACHA20-POLY1305 cipher

### DIFF
--- a/make/libs/mbedtls/mbedtls.mk
+++ b/make/libs/mbedtls/mbedtls.mk
@@ -1,6 +1,6 @@
-$(call PKG_INIT_LIB, 2.7.17)
+$(call PKG_INIT_LIB, 2.24.0)
 $(PKG)_SOURCE:=mbedtls-$($(PKG)_VERSION).tar.gz
-$(PKG)_SOURCE_SHA1:=2f252362d768409ee75bdfbe6b756011baa0c254
+$(PKG)_SOURCE_SHA1:=1bd2b5f5b8b8f970331a6da0065d64b424abdbed
 $(PKG)_SITE:=https://github.com/ARMmbed/mbedtls/archive,https://tls.mbed.org/download
 
 $(PKG)_LIBNAMES_SHORT      := crypto tls x509

--- a/make/libs/mbedtls/patches/010-versioned_so.patch
+++ b/make/libs/mbedtls/patches/010-versioned_so.patch
@@ -1,12 +1,12 @@
 --- library/Makefile
 +++ library/Makefile
-@@ -31,9 +31,17 @@
+@@ -39,9 +39,17 @@
  endif
  endif
  
--SOEXT_TLS=so.10
--SOEXT_X509=so.0
--SOEXT_CRYPTO=so.2
+-SOEXT_TLS=so.13
+-SOEXT_X509=so.1
+-SOEXT_CRYPTO=so.5
 +VERSION=0.0.0
 +VERSION_MAJOR=$(word 1,$(subst ., ,$(VERSION)))
 +VERSION_MINOR=$(word 2,$(subst ., ,$(VERSION)))
@@ -19,41 +19,41 @@
 +SOEXT_X509=so.$(VERSION)
 +SOEXT_CRYPTO=so.$(VERSION)
  
- # Set DLEXT=dylib to compile as a shared library for Mac OS X
- DLEXT ?= so
-@@ -100,9 +108,11 @@
+ # Set AR_DASH= (empty string) to use an ar implementation that does not accept
+ # the - prefix for command line options (e.g. llvm-ar)
+@@ -191,9 +199,10 @@
  
  libmbedtls.$(SOEXT_TLS): $(OBJS_TLS) libmbedx509.so
  	echo "  LD    $@"
 -	$(CC) -shared -Wl,-soname,$@ -L. -lmbedcrypto -lmbedx509 $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@ $(OBJS_TLS)
+-
 +	$(CC) -shared -Wl,-soname,$(call MAJOR_MINOR_ONLY,$@) -L. -lmbedcrypto -lmbedx509 $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@ $(OBJS_TLS)
- 
  libmbedtls.so: libmbedtls.$(SOEXT_TLS)
 +	echo "  LN    $(call MAJOR_MINOR_ONLY,$<) -> $<"
 +	ln -sf $< $(call MAJOR_MINOR_ONLY,$<)
  	echo "  LN    $@ -> $<"
  	ln -sf $< $@
  
-@@ -123,9 +133,11 @@
+@@ -218,9 +227,10 @@
  
  libmbedx509.$(SOEXT_X509): $(OBJS_X509) libmbedcrypto.so
  	echo "  LD    $@"
 -	$(CC) -shared -Wl,-soname,$@ -L. -lmbedcrypto $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@ $(OBJS_X509)
+-
 +	$(CC) -shared -Wl,-soname,$(call MAJOR_MINOR_ONLY,$@) -L. -lmbedcrypto $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@ $(OBJS_X509)
- 
  libmbedx509.so: libmbedx509.$(SOEXT_X509)
 +	echo "  LN    $(call MAJOR_MINOR_ONLY,$<) -> $<"
 +	ln -sf $< $(call MAJOR_MINOR_ONLY,$<)
  	echo "  LN    $@ -> $<"
  	ln -sf $< $@
  
-@@ -146,9 +158,11 @@
+@@ -245,9 +255,10 @@
  
  libmbedcrypto.$(SOEXT_CRYPTO): $(OBJS_CRYPTO)
  	echo "  LD    $@"
 -	$(CC) -shared -Wl,-soname,$@ $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@ $(OBJS_CRYPTO)
+-
 +	$(CC) -shared -Wl,-soname,$(call MAJOR_MINOR_ONLY,$@) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@ $(OBJS_CRYPTO)
- 
  libmbedcrypto.so: libmbedcrypto.$(SOEXT_CRYPTO)
 +	echo "  LN    $(call MAJOR_MINOR_ONLY,$<) -> $<"
 +	ln -sf $< $(call MAJOR_MINOR_ONLY,$<)

--- a/make/libs/mbedtls/patches/020-LFS_controlled_by_freetz.patch
+++ b/make/libs/mbedtls/patches/020-LFS_controlled_by_freetz.patch
@@ -1,11 +1,11 @@
 --- library/Makefile
-+++ library/Makefile
-@@ -5,7 +5,7 @@
- WARNING_CFLAGS ?=  -Wall -W -Wdeclaration-after-statement
- LDFLAGS ?=
- 
--LOCAL_CFLAGS = $(WARNING_CFLAGS) -I../include -D_FILE_OFFSET_BITS=64
-+LOCAL_CFLAGS = $(WARNING_CFLAGS) -I../include
++++ library/Makefile	
+@@ -9,7 +9,7 @@
+ # Note that . needs to be included explicitly for the sake of library
+ # files that are not in the /library directory (which currently means
+ # under /3rdparty).
+-LOCAL_CFLAGS = $(WARNING_CFLAGS) -I. -I../include -D_FILE_OFFSET_BITS=64
++LOCAL_CFLAGS = $(WARNING_CFLAGS) -I. -I../include
  LOCAL_LDFLAGS =
  
  ifdef DEBUG


### PR DESCRIPTION
adds CHACHA20-POLY1305 cipher for data and tls. Still NO support for TLS1.3 !!
Using this cipher with openvpn 2.5.x for the data and tls control channel, try to set
(for example) these ciphers  in the server/client openvpn.conf :

`tls-cipher TLS-ECDHE-RSA-WITH-CHACHA20-POLY1305-SHA256:TLS-ECDHE-ECDSA-WITH-CHACHA20-POLY1305-SHA256:TLS-ECDHE-ECDSA-WITH-AES-256-GCM-SHA384:TLS-ECDHE-RSA-WITH-AES-256-GCM-SHA384:TLS-DHE-RSA-WITH-AES-256-GCM-SHA384 `
`data-ciphers CHACHA20-POLY1305:AES-256-GCM`
`cipher CHACHA20-POLY1305`

To show all available ciphers with openvpn in freetz, try the following commands in the FritzBox command shell :

`openvpn  --show-ciphers` (for Data Channel)
`openvpn  --show-tls`         (for Control Channel)

