### PR TITLE
Update push_firmware

### DIFF
--- a/tools/push_firmware
+++ b/tools/push_firmware
@@ -497,7 +497,7 @@ prepare_image
 # IPs
 [ ! $ip ] && ip=192.168.178.1
 oa="unknown"
-for horst in $(hostname -I); do
+for horst in $(ip -4 -o addr show scope global | grep -Po 'inet \K[\d.]+'); do
 	[ ${horst%.*} == ${ip%.*} ] && oa=$horst
 done
 if [ "$oa" == "unknown" ]; then


### PR DESCRIPTION
Switch to iproute2 command, since `-I` option of `hostname` command is not available on all systems. At least on Arch, it isn't. Resolves an issue of not being able to ftp correctly.