### PR TITLE
Add alien for 3270v3

### DIFF
--- a/config/mod/download.in
+++ b/config/mod/download.in
@@ -380,8 +380,8 @@ menu "Download options"
 		default "@AVM/fritzbox.fon_wlan_7270_v2/firmware/deutsch,@1&1/7270v2"                                              if ((FREETZ_TYPE_7270_V2 && ! FREETZ_TYPE_ALIEN_HARDWARE) || FREETZ_TYPE_7270_V1_V2 || FREETZ_TYPE_7570_7270 ) && FREETZ_TYPE_LANG_DE
 		default "@AVM/fritzbox.fon_wlan_7270_v2/firmware/english"                                                          if ((FREETZ_TYPE_7270_V2 && ! FREETZ_TYPE_ALIEN_HARDWARE) || FREETZ_TYPE_7270_V1_V2 || FREETZ_TYPE_7570_7270 ) && FREETZ_TYPE_LANG_EN
 		#
-		default "@AVM/fritzbox.fon_wlan_7270_v3/firmware/deutsch,@1&1/7270v3"                                              if ((FREETZ_TYPE_7270_V3 && ! FREETZ_TYPE_ALIEN_HARDWARE) || FREETZ_TYPE_7240_7270                          ) && FREETZ_TYPE_LANG_DE
-		default "@AVM/fritzbox.fon_wlan_7270_v3/firmware/english"                                                          if ((FREETZ_TYPE_7270_V3 && ! FREETZ_TYPE_ALIEN_HARDWARE) || FREETZ_TYPE_7240_7270 || FREETZ_TYPE_7570_7270 ) && FREETZ_TYPE_LANG_EN
+		default "@AVM/fritzbox.fon_wlan_7270_v3/firmware/deutsch,@1&1/7270v3"                                              if ((FREETZ_TYPE_7270_V3 && ! FREETZ_TYPE_ALIEN_HARDWARE) || FREETZ_TYPE_7240_7270 || FREETZ_TYPE_3270_V3_7270_V3 ) && FREETZ_TYPE_LANG_DE
+		default "@AVM/fritzbox.fon_wlan_7270_v3/firmware/english"                                                          if ((FREETZ_TYPE_7270_V3 && ! FREETZ_TYPE_ALIEN_HARDWARE) || FREETZ_TYPE_7240_7270 || FREETZ_TYPE_7570_7270 || FREETZ_TYPE_3270_V3_7270_V3) && FREETZ_TYPE_LANG_EN
 		#
 		default "@AVM/{fritzbox-7272/deutschland/fritz.os,fritzbox.7272/firmware/deutsch},@1&1/7272"                       if FREETZ_TYPE_7272 && FREETZ_TYPE_LANG_DE
 		default "@AVM/{fritzbox-7272/other/fritz.os,fritzbox.7272/firmware/english}"                                       if FREETZ_TYPE_7272 && FREETZ_TYPE_LANG_EN
@@ -668,11 +668,11 @@ menu "Download options"
 		default "FRITZ.Box_7270v2.Int.54.05.24.image"                                          if ((FREETZ_TYPE_7270_V2 && ! FREETZ_TYPE_ALIEN_HARDWARE) || FREETZ_TYPE_7270_V1_V2 || FREETZ_TYPE_7570_7270 ) && FREETZ_TYPE_LANG_EN && FREETZ_TYPE_FIRMWARE_05_2X
 		default "FRITZ.Box_Fon_WLAN_7270_16.en-de-es-it-fr.54.05.53.image"                     if ((FREETZ_TYPE_7270_V2 && ! FREETZ_TYPE_ALIEN_HARDWARE) || FREETZ_TYPE_7270_V1_V2 || FREETZ_TYPE_7570_7270 ) && FREETZ_TYPE_LANG_EN && FREETZ_TYPE_FIRMWARE_05_5X
 		#
-		default "FRITZ.Box_7270v3.Beta.74.05.23-27582.image"                                   if ((FREETZ_TYPE_7270_V3 && ! FREETZ_TYPE_ALIEN_HARDWARE) || FREETZ_TYPE_7240_7270                          ) && FREETZ_TYPE_LANG_DE && FREETZ_TYPE_FIRMWARE_05_2X
-		default "FRITZ.Box_Fon_WLAN_7270_v3.74.05.54.image"                                    if ((FREETZ_TYPE_7270_V3 && ! FREETZ_TYPE_ALIEN_HARDWARE) || FREETZ_TYPE_7240_7270                          ) && FREETZ_TYPE_LANG_DE && FREETZ_TYPE_FIRMWARE_05_5X
-		default "FRITZ.Box_Fon_WLAN_7270_v3.74.06.06.image"                                    if ((FREETZ_TYPE_7270_V3 && ! FREETZ_TYPE_ALIEN_HARDWARE) || FREETZ_TYPE_7240_7270                          ) && FREETZ_TYPE_LANG_DE && FREETZ_TYPE_FIRMWARE_06_0X
-		default "FRITZ.Box_7270_v3.Int.74.05.24.image"                                         if ((FREETZ_TYPE_7270_V3 && ! FREETZ_TYPE_ALIEN_HARDWARE) || FREETZ_TYPE_7240_7270 || FREETZ_TYPE_7570_7270 ) && FREETZ_TYPE_LANG_EN && FREETZ_TYPE_FIRMWARE_05_2X
-		default "FRITZ.Box_Fon_WLAN_7270_v3.en-de-es-it-fr.74.05.53.image"                     if ((FREETZ_TYPE_7270_V3 && ! FREETZ_TYPE_ALIEN_HARDWARE) || FREETZ_TYPE_7240_7270 || FREETZ_TYPE_7570_7270 ) && FREETZ_TYPE_LANG_EN && FREETZ_TYPE_FIRMWARE_05_5X
+		default "FRITZ.Box_7270v3.Beta.74.05.23-27582.image"                                   if ((FREETZ_TYPE_7270_V3 && ! FREETZ_TYPE_ALIEN_HARDWARE) || FREETZ_TYPE_7240_7270 || FREETZ_TYPE_3270_V3_7270_V3 ) && FREETZ_TYPE_LANG_DE && FREETZ_TYPE_FIRMWARE_05_2X
+		default "FRITZ.Box_Fon_WLAN_7270_v3.74.05.54.image"                                    if ((FREETZ_TYPE_7270_V3 && ! FREETZ_TYPE_ALIEN_HARDWARE) || FREETZ_TYPE_7240_7270 || FREETZ_TYPE_3270_V3_7270_V3 ) && FREETZ_TYPE_LANG_DE && FREETZ_TYPE_FIRMWARE_05_5X
+		default "FRITZ.Box_Fon_WLAN_7270_v3.74.06.06.image"                                    if ((FREETZ_TYPE_7270_V3 && ! FREETZ_TYPE_ALIEN_HARDWARE) || FREETZ_TYPE_7240_7270 || FREETZ_TYPE_3270_V3_7270_V3) && FREETZ_TYPE_LANG_DE && FREETZ_TYPE_FIRMWARE_06_0X
+		default "FRITZ.Box_7270_v3.Int.74.05.24.image"                                         if ((FREETZ_TYPE_7270_V3 && ! FREETZ_TYPE_ALIEN_HARDWARE) || FREETZ_TYPE_7240_7270 || FREETZ_TYPE_7570_7270 || FREETZ_TYPE_3270_V3_7270_V3 ) && FREETZ_TYPE_LANG_EN && FREETZ_TYPE_FIRMWARE_05_2X
+		default "FRITZ.Box_Fon_WLAN_7270_v3.en-de-es-it-fr.74.05.53.image"                     if ((FREETZ_TYPE_7270_V3 && ! FREETZ_TYPE_ALIEN_HARDWARE) || FREETZ_TYPE_7240_7270 || FREETZ_TYPE_7570_7270 || FREETZ_TYPE_3270_V3_7270_V3 ) && FREETZ_TYPE_LANG_EN && FREETZ_TYPE_FIRMWARE_05_5X
 		#
 		default "FRITZ.Box_7272.120.06.30.image"                                               if FREETZ_TYPE_7272 && FREETZ_TYPE_LANG_DE && FREETZ_TYPE_FIRMWARE_06_2X
 		default "FRITZ.Box_7272.120.06.50.image"                                               if FREETZ_TYPE_7272 && FREETZ_TYPE_LANG_DE && FREETZ_TYPE_FIRMWARE_06_5X

--- a/config/mod/prefix.in
+++ b/config/mod/prefix.in
@@ -139,4 +139,5 @@ config FREETZ_TYPE_PREFIX_ALIEN_HARDWARE
 	default "5491_"             if FREETZ_TYPE_5491_7490
 	default "7520_"             if FREETZ_TYPE_7520_7530
 	default "7570_"             if FREETZ_TYPE_7570_7270
+	default "3270v3_"	    if FREETZ_TYPE_3270_V3_7270_V3
 

--- a/config/ui/firmware.in
+++ b/config/ui/firmware.in
@@ -947,6 +947,17 @@ choice
 			Enable this to compile a mod image for FritzFON 7150 based
 			on a 7170 image.
 
+	config FREETZ_TYPE_3270_V3_7270_V3
+                bool "3270 v3"
+                depends on FREETZ_TYPE_7270_V3
+                select FREETZ_REMOVE_DECT
+                select FREETZ_REMOVE_VOIPD
+                select FREETZ_REMOVE_TELEPHONY
+                select FREETZ_REMOVE_CAPIOVERTCP
+                help
+                        Enable this to compile an alien image for FritzBox WLAN 3270 v3 based
+                        on a 7270 v3 image.
+
 	config FREETZ_TYPE_7240_7270
 		bool "7240"
 		depends on FREETZ_TYPE_7270_V3

--- a/docs/FIRMWARES.md
+++ b/docs/FIRMWARES.md
@@ -52,6 +52,7 @@ Currently supported devices and firmwares
   - 96.05.54 rev27373 {GER}
   - 96.05.52 rev27362 {INT}
   - 125.05.52 rev27361 {ITA}
+  - Alien 7270 v3
 * __Fritz!Box Fon WLAN 3272__
   - 126.06.30 rev30889 {GER}
   - 126.06.50 rev33089 {GER}

--- a/patches/scripts/100-3270v3_7270v3.sh
+++ b/patches/scripts/100-3270v3_7270v3.sh
@@ -1,0 +1,21 @@
+# 7270_v3 firmware on 7270 v3 hardware
+isFreetzType 3270_V3_7270_V3 || return 0
+
+echo "adapt firmware for 3270"
+
+echo2 "moving default config dir"
+mv ${FILESYSTEM_MOD_DIR}/etc/default.Fritz_Box_72* ${FILESYSTEM_MOD_DIR}/etc/default.Fritz_Box_3270v3
+
+echo2 "patching rc.S and rc.conf"
+modsed "s/CONFIG_PRODUKT_NAME=.*$/CONFIG_PRODUKT_NAME=\"FRITZ!Box WLAN 3270 v3\"/g" "${FILESYSTEM_MOD_DIR}/etc/init.d/rc.conf"
+modsed "s/CONFIG_CAPI_POTS=.*$/CONFIG_CAPI_POTS=\"n\"/g" "${FILESYSTEM_MOD_DIR}/etc/init.d/rc.conf"
+modsed "s/CONFIG_CAPI_TE=.*$/CONFIG_CAPI_TE=\"n\"/g" "${FILESYSTEM_MOD_DIR}/etc/init.d/rc.conf"
+modsed "s/CONFIG_PRODUKT=.*$/CONFIG_PRODUKT=\"Fritz_Box_3270v3\"/g" "${FILESYSTEM_MOD_DIR}/etc/init.d/rc.conf"
+modsed "s/CONFIG_CAPI_NT=.*$/CONFIG_CAPI_NT=\"n\"/g" "${FILESYSTEM_MOD_DIR}/etc/init.d/rc.conf"
+modsed "s/CONFIG_VERSION_MAJOR=.*$/CONFIG_VERSION_MAJOR=\"96\"/g" "${FILESYSTEM_MOD_DIR}/etc/init.d/rc.conf"
+modsed "s/CONFIG_INSTALL_TYPE=.*$/CONFIG_INSTALL_TYPE=\"ur8_16MB_xilinx_4eth_isdn_nt_te_pots_wlan_usb_host_plus_21364\"/g" "${FILESYSTEM_MOD_DIR}/etc/init.d/rc.conf"
+
+# patch install script to accept firmware from 7270
+echo2 "applying install patch"
+
+modsed "s/ur8_16MB_xilinx_4eth_2ab_isdn_nt_te_pots_wlan_usb_host_dect_plus_55266/ur8_16MB_xilinx_4eth_isdn_nt_te_pots_wlan_usb_host_plus_21364/g" "${FIRMWARE_MOD_DIR}/var/install"


### PR DESCRIPTION
Ermöglicht die Nutzung der 7270v3 Firmware auf 3270v3 und damit die Nutzung der Firmware-Version 6.06.