### PR TITLE
3270 v3 alien: Select Remove AHA

### DIFF
--- a/config/ui/firmware.in
+++ b/config/ui/firmware.in
@@ -954,6 +954,7 @@ choice
                 select FREETZ_REMOVE_VOIPD
                 select FREETZ_REMOVE_TELEPHONY
                 select FREETZ_REMOVE_CAPIOVERTCP
+		select FREETZ_REMOVE_AHA if FREETZ_AVM_HAS_AHA
                 help
                         Enable this to compile an alien image for FritzBox WLAN 3270 v3 based
                         on a 7270 v3 image.


### PR DESCRIPTION
Entfernt Smart Home in 3270v3 alien. Funktioniert wegen fehlenden DECT-Modul in 3270 ohnehin nicht.