### PR TITLE
haproxy bump version to 2.2.13

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -52,7 +52,7 @@ Latest changes
  - Updated packages and libs:
    * curl 7.76.0
    * expat 2.3.0
-   * haproxy 2.2.11
+   * haproxy 2.2.13
    * libgd 2.3.2
    * mbed TLS 2.7.19/2.26.0
    * minidlna 1.3.0

--- a/docs/make/README.md
+++ b/docs/make/README.md
@@ -248,7 +248,7 @@ Index:
 
 ### H
 
-  * **[HAProxy 2.2.11](haproxy.md)<a id='haproxy'></a>**<br>
+  * **[HAProxy 2.2.13](haproxy.md)<a id='haproxy'></a>**<br>
     HAProxy is a free, very fast and reliable solution offering high availability, load balancing, and proxying for TCP and HTTP-based applications.
 
   * **[haserl 0.9.35 (binary only)](haserl.md)<a id='haserl'></a>**<br>

--- a/docs/make/haproxy.md
+++ b/docs/make/haproxy.md
@@ -1,4 +1,4 @@
-# HAProxy 2.2.11
+# HAProxy 2.2.13
  - Homepage: [https://www.haproxy.org/](https://www.haproxy.org/)
  - Manpage: [https://linux.die.net/man/1/haproxy](https://linux.die.net/man/1/haproxy)
  - Changelog: [https://www.haproxy.org/download/2.2/src/CHANGELOG](https://www.haproxy.org/download/2.2/src/CHANGELOG)

--- a/make/README.md
+++ b/make/README.md
@@ -335,7 +335,7 @@ Index:
 
 ### H
 
-  * **[HAProxy 2.2.11](../docs/make/haproxy.md)<a id='haproxy'></a>**<br>
+  * **[HAProxy 2.2.13](../docs/make/haproxy.md)<a id='haproxy'></a>**<br>
     HAProxy is a free, very fast and reliable solution offering high availability, load balancing, and proxying for TCP and HTTP-based applications.
 
   * **[haserl 0.9.35 (binary only)](../docs/make/haserl.md)<a id='haserl'></a>**<br>

--- a/make/haproxy/Config.in
+++ b/make/haproxy/Config.in
@@ -1,5 +1,5 @@
 config FREETZ_PACKAGE_HAPROXY
-	bool "HAProxy 2.2.11"
+	bool "HAProxy 2.2.13"
 	select FREETZ_LIB_libcrypt if FREETZ_TARGET_UCLIBC_HAS_multiple_libs
 	select FREETZ_BUSYBOX_START_STOP_DAEMON
 	default n

--- a/make/haproxy/haproxy.mk
+++ b/make/haproxy/haproxy.mk
@@ -1,6 +1,6 @@
-$(call PKG_INIT_BIN, 2.2.11)
+$(call PKG_INIT_BIN, 2.2.13)
 $(PKG)_SOURCE:=$(pkg)-$($(PKG)_VERSION).tar.gz
-$(PKG)_SOURCE_SHA256:=173a98506472bb1ba5a4a7f3a281125163f78bab5793bf6ba1f1d50853eb5f23
+$(PKG)_SOURCE_SHA256:=9e3e51441c70bedfb494fc9d4b4d3389a71be9a3c915ba3d6f7e8fd9a57ce160
 $(PKG)_SITE:=http://www.haproxy.org/download/2.2/src
 ### WEBSITE:=https://www.haproxy.org/
 ### MANPAGE:=https://linux.die.net/man/1/haproxy


### PR DESCRIPTION
Changelog: http://www.haproxy.org/download/2.2/src/CHANGELOG