### PR TITLE
tor: bump version to 0.4.5.7

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -59,6 +59,7 @@ Latest changes
    * OpenSSH 8.5p1
    * OpenSSL 0.9.8zh/1.0.2u/1.1.1k/3.0.0-alpha13
    * stunnel 5.58
+   * Tor 0.4.5.7
 
  - Web interface:
    * Settings backup:

--- a/docs/make/README.md
+++ b/docs/make/README.md
@@ -708,7 +708,7 @@ Index:
   * **<u>tmux 2.5 (binary only)</u><a id='tmux'></a>**<br>
     tmux, a BSD-licensed alternative to GNU screen. Uses ncurses.
 
-  * **[Tor 0.4.4.6](tor.md)<a id='tor'></a>**<br>
+  * **[Tor 0.4.5.7](tor.md)<a id='tor'></a>**<br>
     The Onion Router Anonymous Internet communication system.
 
   * **[Transmission 3.00 (binary only)](transmission.md)<a id='transmission'></a>**<br>

--- a/docs/make/tor.md
+++ b/docs/make/tor.md
@@ -1,4 +1,4 @@
-# Tor 0.4.4.6
+# Tor 0.4.5.7
  - Homepage: [https://www.torproject.org/download/tor/](https://www.torproject.org/download/tor/)
  - Manpage: [https://trac.torproject.org/projects/tor/wiki/](https://trac.torproject.org/projects/tor/wiki/)
  - Changelog: [https://gitweb.torproject.org/tor.git/tree/ChangeLog](https://gitweb.torproject.org/tor.git/tree/ChangeLog)

--- a/make/README.md
+++ b/make/README.md
@@ -944,7 +944,7 @@ Index:
   * **<u>tmux 2.5 (binary only)</u><a id='tmux'></a>**<br>
     tmux, a BSD-licensed alternative to GNU screen. Uses ncurses.
 
-  * **[Tor 0.4.4.6](../docs/make/tor.md)<a id='tor'></a>**<br>
+  * **[Tor 0.4.5.7](../docs/make/tor.md)<a id='tor'></a>**<br>
     The Onion Router Anonymous Internet communication system.
      - [Tor als Proxy benutzen](../docs/make/tor.md#tor-als-proxy-benutzen)
      - [Tor und Privoxy](../docs/make/tor.md#tor-und-privoxy)

--- a/make/tor/Config.in
+++ b/make/tor/Config.in
@@ -2,7 +2,7 @@ comment "Tor (not available, needs OpenSSL 1.0 or newer)"
 	depends on !FREETZ_OPENSSL_VERSION_1_MIN
 
 config FREETZ_PACKAGE_TOR
-	bool "Tor 0.4.4.6"
+	bool "Tor 0.4.5.7"
 	depends on FREETZ_OPENSSL_VERSION_1_MIN
 	select FREETZ_LIB_libm               if !FREETZ_PACKAGE_TOR_STATIC && FREETZ_TARGET_UCLIBC_HAS_multiple_libs
 	select FREETZ_LIB_libevent           if !FREETZ_PACKAGE_TOR_STATIC

--- a/make/tor/patches/010-drop_backtrace_support.patch
+++ b/make/tor/patches/010-drop_backtrace_support.patch
@@ -1,6 +1,6 @@
 --- configure.ac
 +++ configure.ac
-@@ -666,8 +666,6 @@
+@@ -743,8 +743,6 @@
  	RtlSecureZeroMemory \
  	SecureZeroMemory \
  	accept4 \
@@ -9,7 +9,7 @@
  	eventfd \
  	explicit_bzero \
  	timingsafe_memcmp \
-@@ -1559,7 +1557,6 @@
+@@ -1681,7 +1679,6 @@
  		  unistd.h \
  		  arpa/inet.h \
  		  crt_externs.h \
@@ -19,7 +19,7 @@
  		  ifaddrs.h \
 --- configure
 +++ configure
-@@ -8785,8 +8785,6 @@
+@@ -8871,8 +8871,6 @@
  	RtlSecureZeroMemory \
  	SecureZeroMemory \
  	accept4 \
@@ -28,7 +28,7 @@
  	eventfd \
  	explicit_bzero \
  	timingsafe_memcmp \
-@@ -12858,7 +12856,6 @@
+@@ -13040,7 +13038,6 @@
  		  unistd.h \
  		  arpa/inet.h \
  		  crt_externs.h \

--- a/make/tor/tor.mk
+++ b/make/tor/tor.mk
@@ -1,6 +1,6 @@
-$(call PKG_INIT_BIN, 0.4.4.6)
+$(call PKG_INIT_BIN, 0.4.5.7)
 $(PKG)_SOURCE:=$(pkg)-$($(PKG)_VERSION).tar.gz
-$(PKG)_SOURCE_SHA256:=5f154c155803adf5c89e87cab53017b6908c5ebe50c65839e8cf4fbd2abe1fdc
+$(PKG)_SOURCE_SHA256:=447fcaaa133e2ef22427e98098a60a9c495edf9ff3e0dd13f484b9ad0185f074
 $(PKG)_SITE:=https://www.torproject.org/dist
 ### WEBSITE:=https://www.torproject.org/download/tor/
 ### MANPAGE:=https://trac.torproject.org/projects/tor/wiki/
@@ -48,7 +48,7 @@ $(PKG)_PATCH_POST_CMDS += touch -t 200001010000.00 ./configure.ac;
 # add EXTRA_(C|LD)FLAGS
 $(PKG)_PATCH_POST_CMDS += $(call PKG_ADD_EXTRA_FLAGS,(C|LD)FLAGS)
 
-$(PKG)_EXTRA_CFLAGS  += -ffunction-sections -fdata-sections
+$(PKG)_EXTRA_CFLAGS  += -ffunction-sections -fdata-sections -DDISABLE_ENGINES
 $(PKG)_EXTRA_LDFLAGS += -Wl,--gc-sections
 
 ifeq ($(strip $(FREETZ_PACKAGE_TOR_STATIC)),y)


### PR DESCRIPTION
* tor: bump version to 0.4.5.7
Changelog: https://gitweb.torproject.org/tor.git/plain/ChangeLog?h=tor-0.4.5.7

* Disable engine in CFLAGS
OpenSSL is build with no-engine