### PR TITLE
haproxy: bump to version 2.4.0 (LTS)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -64,7 +64,7 @@ Latest changes
    * curl 7.76.1
    * dnsmasq 2.80/2.85
    * expat 2.3.0
-   * haproxy 2.2.14
+   * haproxy 2.4.0
    * iperf 3.9
    * libgd 2.3.2
    * mbed TLS 2.7.19/2.26.0

--- a/docs/make/README.md
+++ b/docs/make/README.md
@@ -248,7 +248,7 @@ Index:
 
 ### H
 
-  * **[HAProxy 2.2.14](haproxy.md)<a id='haproxy'></a>**<br>
+  * **[HAProxy 2.4.0](haproxy.md)<a id='haproxy'></a>**<br>
     HAProxy is a free, very fast and reliable solution offering high availability, load balancing, and proxying for TCP and HTTP-based applications.
 
   * **[haserl 0.9.35 (binary only)](haserl.md)<a id='haserl'></a>**<br>

--- a/docs/make/haproxy.md
+++ b/docs/make/haproxy.md
@@ -1,6 +1,6 @@
-# HAProxy 2.2.14
+# HAProxy 2.4.0
  - Homepage: [https://www.haproxy.org/](https://www.haproxy.org/)
  - Manpage: [https://linux.die.net/man/1/haproxy](https://linux.die.net/man/1/haproxy)
- - Changelog: [https://www.haproxy.org/download/2.2/src/CHANGELOG](https://www.haproxy.org/download/2.2/src/CHANGELOG)
+ - Changelog: [https://www.haproxy.org/download/2.4/src/CHANGELOG](https://www.haproxy.org/download/2.4/src/CHANGELOG)
  - Repository: [https://git.haproxy.org/](https://git.haproxy.org/)
 

--- a/make/README.md
+++ b/make/README.md
@@ -336,7 +336,7 @@ Index:
 
 ### H
 
-  * **[HAProxy 2.2.14](../docs/make/haproxy.md)<a id='haproxy'></a>**<br>
+  * **[HAProxy 2.4.0](../docs/make/haproxy.md)<a id='haproxy'></a>**<br>
     HAProxy is a free, very fast and reliable solution offering high availability, load balancing, and proxying for TCP and HTTP-based applications.
 
   * **[haserl 0.9.35 (binary only)](../docs/make/haserl.md)<a id='haserl'></a>**<br>

--- a/make/haproxy/Config.in
+++ b/make/haproxy/Config.in
@@ -1,5 +1,5 @@
 config FREETZ_PACKAGE_HAPROXY
-	bool "HAProxy 2.2.14"
+	bool "HAProxy 2.4.0"
 	select FREETZ_LIB_libcrypt if FREETZ_TARGET_UCLIBC_HAS_multiple_libs
 	select FREETZ_BUSYBOX_START_STOP_DAEMON
 	default n

--- a/make/haproxy/haproxy.mk
+++ b/make/haproxy/haproxy.mk
@@ -1,10 +1,10 @@
-$(call PKG_INIT_BIN, 2.2.14)
+$(call PKG_INIT_BIN, 2.4.0)
 $(PKG)_SOURCE:=$(pkg)-$($(PKG)_VERSION).tar.gz
-$(PKG)_SOURCE_SHA256:=6a9b702f04b07786f3e5878de8172a727acfdfdbc1cefe1c7a438df372f2fb61
-$(PKG)_SITE:=http://www.haproxy.org/download/2.2/src
+$(PKG)_SOURCE_SHA256:=0a6962adaf5a1291db87e3eb4ddf906a72fed535dbd2255b164b7d8394a53640
+$(PKG)_SITE:=http://www.haproxy.org/download/2.4/src
 ### WEBSITE:=https://www.haproxy.org/
 ### MANPAGE:=https://linux.die.net/man/1/haproxy
-### CHANGES:=https://www.haproxy.org/download/2.2/src/CHANGELOG
+### CHANGES:=https://www.haproxy.org/download/2.4/src/CHANGELOG
 ### CVSREPO:=https://git.haproxy.org/
 
 $(PKG)_BINARY:=$($(PKG)_DIR)/haproxy

--- a/make/haproxy/patches/100-patch-wo-libpcreposix.patch
+++ b/make/haproxy/patches/100-patch-wo-libpcreposix.patch
@@ -1,6 +1,6 @@
 --- Makefile
 +++ Makefile
-@@ -667,11 +667,11 @@
+@@ -722,11 +722,11 @@
  ifeq ($(USE_STATIC_PCRE),)
  # dynamic PCRE
  OPTIONS_CFLAGS  += -DUSE_PCRE $(if $(PCRE_INC),-I$(PCRE_INC))
@@ -13,4 +13,4 @@
 +OPTIONS_LDFLAGS += $(if $(PCRE_LIB),-L$(PCRE_LIB)) -Wl,-Bstatic -lpcre -Wl,-Bdynamic
  endif
  endif
-
+ 


### PR DESCRIPTION
Changelog: http://www.haproxy.org/download/2.4/src/CHANGELOG