### PR TITLE
haproxy: bump version to 2.4.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -69,7 +69,7 @@ Latest changes
    * dnsmasq 2.80/2.85
    * expat 2.4.1
    * gnutls 3.6.16
-   * haproxy 2.4.0
+   * haproxy 2.4.1
    * iperf 3.9
    * libgcrypt 1.9.3
    * libgd 2.3.2

--- a/docs/make/README.md
+++ b/docs/make/README.md
@@ -248,7 +248,7 @@ Index:
 
 ### H
 
-  * **[HAProxy 2.4.0](haproxy.md)<a id='haproxy'></a>**<br>
+  * **[HAProxy 2.4.1](haproxy.md)<a id='haproxy'></a>**<br>
     HAProxy is a free, very fast and reliable solution offering high availability, load balancing, and proxying for TCP and HTTP-based applications.
 
   * **[haserl 0.9.35 (binary only)](haserl.md)<a id='haserl'></a>**<br>

--- a/docs/make/haproxy.md
+++ b/docs/make/haproxy.md
@@ -1,4 +1,4 @@
-# HAProxy 2.4.0
+# HAProxy 2.4.1
  - Homepage: [https://www.haproxy.org/](https://www.haproxy.org/)
  - Manpage: [https://linux.die.net/man/1/haproxy](https://linux.die.net/man/1/haproxy)
  - Changelog: [https://www.haproxy.org/download/2.4/src/CHANGELOG](https://www.haproxy.org/download/2.4/src/CHANGELOG)

--- a/make/README.md
+++ b/make/README.md
@@ -336,7 +336,7 @@ Index:
 
 ### H
 
-  * **[HAProxy 2.4.0](../docs/make/haproxy.md)<a id='haproxy'></a>**<br>
+  * **[HAProxy 2.4.1](../docs/make/haproxy.md)<a id='haproxy'></a>**<br>
     HAProxy is a free, very fast and reliable solution offering high availability, load balancing, and proxying for TCP and HTTP-based applications.
 
   * **[haserl 0.9.35 (binary only)](../docs/make/haserl.md)<a id='haserl'></a>**<br>

--- a/make/haproxy/Config.in
+++ b/make/haproxy/Config.in
@@ -1,5 +1,5 @@
 config FREETZ_PACKAGE_HAPROXY
-	bool "HAProxy 2.4.0"
+	bool "HAProxy 2.4.1"
 	select FREETZ_LIB_libcrypt if FREETZ_TARGET_UCLIBC_HAS_multiple_libs
 	select FREETZ_BUSYBOX_START_STOP_DAEMON
 	default n

--- a/make/haproxy/haproxy.mk
+++ b/make/haproxy/haproxy.mk
@@ -1,6 +1,6 @@
-$(call PKG_INIT_BIN, 2.4.0)
+$(call PKG_INIT_BIN, 2.4.1)
 $(PKG)_SOURCE:=$(pkg)-$($(PKG)_VERSION).tar.gz
-$(PKG)_SOURCE_SHA256:=0a6962adaf5a1291db87e3eb4ddf906a72fed535dbd2255b164b7d8394a53640
+$(PKG)_SOURCE_SHA256:=1b2458b05e923d70cdc00a2c8e5579c2fcde9df16bbed8955f3f3030df14e62e
 $(PKG)_SITE:=http://www.haproxy.org/download/2.4/src
 ### WEBSITE:=https://www.haproxy.org/
 ### MANPAGE:=https://linux.die.net/man/1/haproxy


### PR DESCRIPTION
Changelog: http://www.haproxy.org/download/2.4/src/CHANGELOG