### PR TITLE
Fix to enable IPv6 support for wireguard

### DIFF
--- a/make/wireguard/files/root/etc/init.d/rc.wireguard
+++ b/make/wireguard/files/root/etc/init.d/rc.wireguard
@@ -12,6 +12,7 @@ start() {
 	ip link add dev wg0 type wireguard
 	ip address add $WIREGUARD_IP dev wg0
 	if [ ! -z "$WIREGUARD_IP6" ]; then
+		sysctl -w net.ipv6.conf.wg0.disable_ipv6=0
 		ip -6 address add $WIREGUARD_IP6 dev wg0
 	fi
 	wg setconf wg0 /tmp/flash/wireguard/wireguard.conf


### PR DESCRIPTION
Hope this fixes

https://github.com/Freetz-NG/freetz-ng/issues/337

Final tests (deployed image) will need some more time - first test runs (copied rc.wireguard to /tmp/, modified it, restarted wireguard) look promising.