### PR TITLE
bump mbedtls to 3.0.0 Release

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -77,7 +77,7 @@ Latest changes
    * libgd 2.3.2
    * libgpg-error 1.42
    * libtirpc 1.3.2
-   * mbed TLS 2.7.19/2.27.0
+   * mbed TLS 2.7.19/3.0.0
    * minidlna 1.3.0
    * OpenSSH 8.6p1
    * OpenSSL 0.9.8zh/1.0.2u/1.1.1k/3.0.0-beta1

--- a/make/libs/mbedtls/external.files
+++ b/make/libs/mbedtls/external.files
@@ -1,4 +1,4 @@
-[ "FREETZ_AVM_GCC_4_MAX" == "y" ] && ELIBVER="2.7.19" || ELIBVER="2.27.0"
+[ "FREETZ_AVM_GCC_4_MAX" == "y" ] && ELIBVER="2.7.19" || ELIBVER="3.0.0"
 
 [ "$EXTERNAL_FREETZ_LIB_libmbedcrypto" == "y" ] && EXTERNAL_FILES+=" ${FREETZ_LIBRARY_DIR}/libmbedcrypto.so.$ELIBVER"
 [ "$EXTERNAL_FREETZ_LIB_libmbedtls"    == "y" ] && EXTERNAL_FILES+=" ${FREETZ_LIBRARY_DIR}/libmbedtls.so.$ELIBVER"

--- a/make/libs/mbedtls/mbedtls.mk
+++ b/make/libs/mbedtls/mbedtls.mk
@@ -1,7 +1,7 @@
-$(call PKG_INIT_LIB, $(if $(FREETZ_AVM_GCC_4_MAX),2.7.19,2.27.0))
+$(call PKG_INIT_LIB, $(if $(FREETZ_AVM_GCC_4_MAX),2.7.19,3.0.0))
 $(PKG)_SOURCE:=mbedtls-$($(PKG)_VERSION).tar.gz
 $(PKG)_SOURCE_SHA1_ABANDON:=fbeffb7cb5a2e8cb881024b2f99a794a704f37ae
-$(PKG)_SOURCE_SHA1_CURRENT:=035843f9d4c9ce06bd10d55d8c31a328bfb8ef5d
+$(PKG)_SOURCE_SHA1_CURRENT:=a3117a605c86ec9837783ff571e9cbc4f6a6a06b
 $(PKG)_SOURCE_SHA1:=$(MBEDTLS_SOURCE_SHA1_$(if $(FREETZ_AVM_GCC_4_MAX),ABANDON,CURRENT))
 $(PKG)_SITE:=https://github.com/ARMmbed/mbedtls/archive,https://tls.mbed.org/download
 
@@ -33,7 +33,7 @@ $(PKG)_FEATURES_TO_DISABLE += $(if $(FREETZ_LIB_libmbedcrypto_WITH_BLOWFISH),,MB
 $(PKG)_FEATURES_TO_DISABLE += $(if $(FREETZ_LIB_libmbedcrypto_WITH_GENRSA),,MBEDTLS_GENPRIME)
 
 # Don't use -D/-U to define/undefine required symbols, patch config.h instead. The installed headers must contain properly defined symbols.
-$(PKG)_PATCH_POST_CMDS += $(SED) -ri $(foreach f,$(MBEDTLS_FEATURES_TO_DISABLE),-e 's|^([ \t]*$(_hash)define[ \t]+$(f)[ \t]*)$$$$|/* \1 */|') include/mbedtls/config.h;
+$(PKG)_PATCH_POST_CMDS += $(SED) -ri $(foreach f,$(MBEDTLS_FEATURES_TO_DISABLE),-e 's|^([ \t]*$(_hash)define[ \t]+$(f)[ \t]*)$$$$|/* \1 */|') include/mbedtls/config_psa.h;
 
 $(PKG_SOURCE_DOWNLOAD)
 $(PKG_UNPACKED)

--- a/make/libs/mbedtls/patches/current/010-versioned_so.patch
+++ b/make/libs/mbedtls/patches/current/010-versioned_so.patch
@@ -1,12 +1,12 @@
 --- library/Makefile
 +++ library/Makefile
-@@ -39,9 +39,17 @@
+@@ -41,9 +41,17 @@
  endif
  endif
  
--SOEXT_TLS=so.13
--SOEXT_X509=so.1
--SOEXT_CRYPTO=so.7
+-SOEXT_TLS=so.16
+-SOEXT_X509=so.4
+-SOEXT_CRYPTO=so.10
 +VERSION=0.0.0
 +VERSION_MAJOR=$(word 1,$(subst ., ,$(VERSION)))
 +VERSION_MINOR=$(word 2,$(subst ., ,$(VERSION)))
@@ -21,7 +21,7 @@
  
  # Set AR_DASH= (empty string) to use an ar implementation that does not accept
  # the - prefix for command line options (e.g. llvm-ar)
-@@ -202,9 +210,10 @@
+@@ -196,9 +204,10 @@
  
  libmbedtls.$(SOEXT_TLS): $(OBJS_TLS) libmbedx509.so
  	echo "  LD    $@"
@@ -34,7 +34,7 @@
  	echo "  LN    $@ -> $<"
  	ln -sf $< $@
  
-@@ -229,9 +238,10 @@
+@@ -223,9 +232,10 @@
  
  libmbedx509.$(SOEXT_X509): $(OBJS_X509) libmbedcrypto.so
  	echo "  LD    $@"
@@ -47,7 +47,7 @@
  	echo "  LN    $@ -> $<"
  	ln -sf $< $@
  
-@@ -256,9 +266,10 @@
+@@ -250,9 +260,10 @@
  
  libmbedcrypto.$(SOEXT_CRYPTO): $(OBJS_CRYPTO)
  	echo "  LD    $@"


### PR DESCRIPTION
BLOWFISH wurde nun endgültig entfernt und sollte auch für ältere mbedtls Versionen ersatzlos aus der Config.in als Auswahlmöglichkeit gestrichen werden... -> deprecated and security risk