### PR TITLE
haproxy: bump version to 2.4.3

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -79,7 +79,7 @@ Latest changes
    * expat 2.4.1
    * git 2.33.0
    * gnutls 3.6.16
-   * haproxy 2.4.2
+   * haproxy 2.4.3
    * iperf 3.9
    * libgcrypt 1.9.3
    * libgd 2.3.2

--- a/docs/make/README.md
+++ b/docs/make/README.md
@@ -248,7 +248,7 @@ Index:
 
 ### H
 
-  * **[HAProxy 2.4.2](haproxy.md)<a id='haproxy'></a>**<br>
+  * **[HAProxy 2.4.3](haproxy.md)<a id='haproxy'></a>**<br>
     HAProxy is a free, very fast and reliable solution offering high availability, load balancing, and proxying for TCP and HTTP-based applications.
 
   * **[haserl 0.9.35 (binary only)](haserl.md)<a id='haserl'></a>**<br>

--- a/docs/make/haproxy.md
+++ b/docs/make/haproxy.md
@@ -1,4 +1,4 @@
-# HAProxy 2.4.2
+# HAProxy 2.4.3
  - Homepage: [https://www.haproxy.org/](https://www.haproxy.org/)
  - Manpage: [https://linux.die.net/man/1/haproxy](https://linux.die.net/man/1/haproxy)
  - Changelog: [https://www.haproxy.org/download/2.4/src/CHANGELOG](https://www.haproxy.org/download/2.4/src/CHANGELOG)

--- a/make/README.md
+++ b/make/README.md
@@ -336,7 +336,7 @@ Index:
 
 ### H
 
-  * **[HAProxy 2.4.2](../docs/make/haproxy.md)<a id='haproxy'></a>**<br>
+  * **[HAProxy 2.4.3](../docs/make/haproxy.md)<a id='haproxy'></a>**<br>
     HAProxy is a free, very fast and reliable solution offering high availability, load balancing, and proxying for TCP and HTTP-based applications.
 
   * **[haserl 0.9.35 (binary only)](../docs/make/haserl.md)<a id='haserl'></a>**<br>

--- a/make/haproxy/Config.in
+++ b/make/haproxy/Config.in
@@ -1,5 +1,5 @@
 config FREETZ_PACKAGE_HAPROXY
-	bool "HAProxy 2.4.2"
+	bool "HAProxy 2.4.3"
 	select FREETZ_LIB_libcrypt if FREETZ_TARGET_UCLIBC_HAS_multiple_libs
 	select FREETZ_BUSYBOX_START_STOP_DAEMON
 	default n

--- a/make/haproxy/haproxy.mk
+++ b/make/haproxy/haproxy.mk
@@ -1,6 +1,6 @@
-$(call PKG_INIT_BIN, 2.4.2)
+$(call PKG_INIT_BIN, 2.4.3)
 $(PKG)_SOURCE:=$(pkg)-$($(PKG)_VERSION).tar.gz
-$(PKG)_SOURCE_SHA256:=edf9788f7f3411498e3d7b21777036b4dc14183e95c8e2ce7577baa0ea4ea2aa
+$(PKG)_SOURCE_SHA256:=ce479380be5464faa881dcd829618931b60130ffeb01c88bc2bf95e230046405
 $(PKG)_SITE:=http://www.haproxy.org/download/2.4/src
 ### WEBSITE:=https://www.haproxy.org/
 ### MANPAGE:=https://linux.die.net/man/1/haproxy


### PR DESCRIPTION
Changelog: http://www.haproxy.org/download/2.4/src/CHANGELOG