### PR TITLE
Fix typos

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -318,8 +318,8 @@ Latest changes
     * Most files are move to docs/ directory.
     * Just point your brwoser to: https://freetz-ng.github.io/
     * Could also be opened by the [README.md](../README.md) in the main directory
-       + on Gitlab: https://gitlab.com/Freetz-NG/freetz-ng/blob/master/README.md
-       + on Github: https://github.com/Freetz-NG/freetz-ng/blob/master/README.md
+       + on GitLab: https://gitlab.com/Freetz-NG/freetz-ng/blob/master/README.md
+       + on GitHub: https://github.com/Freetz-NG/freetz-ng/blob/master/README.md
     * This works also offline with a checkout. You need a markdown (.md) viewer or browser with markdown-addon
     * Now the documentation is always in sync with the source code, for releases and tags
 

--- a/docs/NEWS.md
+++ b/docs/NEWS.md
@@ -81,7 +81,7 @@
    Siehe [ng21010](https://github.com/Freetz-NG/freetz-ng/releases/tag/ng21010)<br>
 
  * __[2021-01-01](#2021-01-01)__<a id='2021-01-01'></a><br>
-   Auf Github gibt es einen neuen [Discussions](https://github.com/Freetz-NG/freetz-ng/discussions)-Bereich für
+   Auf GitHub gibt es einen neuen [Discussions](https://github.com/Freetz-NG/freetz-ng/discussions)-Bereich für
    jedes Projekt. Im Gegensatz zu den [Issues](https://github.com/Freetz-NG/freetz-ng/issues) stellt dies keinen<br>
    Bugtrack sondern mehr etwas in Richtung eines Forums dar. Wohin es sich entwickelt wird sich mit der Zeit zeigen.<br>
    Hoffentlich wird es mehr als 1 Person geben die dort Fragen beantwortet!<br>
@@ -296,7 +296,7 @@
 
  * __[2019-11-06](#2019-11-06)__<a id='2019-11-06'></a><br>
    Das Trac auf boxmatrix funktioniert aktuell nicht richtig.<br>
-   Bitte stattdessen [Github](https://github.com/Freetz-NG/freetz-ng/issues) verwenden.<br>
+   Bitte stattdessen [GitHub](https://github.com/Freetz-NG/freetz-ng/issues) verwenden.<br>
 
  * __[2019-11-03](#2019-11-03)__<a id='2019-11-03'></a><br>
    In [./docs](./) liegt nun die gesammte Dokumentation und das alte Wiki.<br>

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,8 +10,8 @@ Things you could do to [SUPPORT](SUPPORT.md) Freetz-NG.<br>
 Why the [ADDONS](ADDONS.md) of the "Digitale Elite" are not supported here.
 
 ### Timeline
-[Github](https://github.com/Freetz-NG/freetz-ng/commits/master)<br>
-[Gitlab](https://gitlab.com/Freetz-NG/freetz-ng/commits/master) (Mirror)<br>
+[GitHub](https://github.com/Freetz-NG/freetz-ng/commits/master)<br>
+[GitLab](https://gitlab.com/Freetz-NG/freetz-ng/commits/master) (Mirror)<br>
 [Bitbucket](https://bitbucket.org/Freetz-NG/freetz-ng/commits/branch/master) (Mirror)<br>
 [Boxmatrix](https://trac.boxmatrix.info/freetz-ng/timeline) (Mirror)<br>
 

--- a/docs/make/knock.md
+++ b/docs/make/knock.md
@@ -18,5 +18,5 @@ braucht - der Portscan eines Hackers läuft also damit meist ins Leere.
 -   [Artikel zu
     "Portknocking"](http://blog.roothell.org/archives/146-Portknocking-Tools-Teil-1-knockd.html)
 -   [Knockd Demo auf
-    Youtube](http://www.youtube.com/watch?v=EbzrLPf6D7Y)
+    YouTube](http://www.youtube.com/watch?v=EbzrLPf6D7Y)
 

--- a/docs/make/lynx.md
+++ b/docs/make/lynx.md
@@ -13,7 +13,7 @@ und
 werden ebenfalls unterstützt - Tabellen hingegen nur eingeschränkt,
 [Java](http://de.wikipedia.org/wiki/Java_(Programmiersprache))
 sowie
-[JavaScript](http://de.wikipedia.org/wiki/Javascript)
+[JavaScript](http://de.wikipedia.org/wiki/JavaScript)
 überhaupt nicht.
 
 ### Weiterführende Links

--- a/docs/wiki/00_FAQ/FAQ.de.md
+++ b/docs/wiki/00_FAQ/FAQ.de.md
@@ -190,7 +190,7 @@ nicht so hoch, wie bei Branches und Tags.
 
 > Hier gibt es einmal die Möglichkeit dem Entwicklerteam eine Geldspende
 > zukommen zu lassen. Dazu ist in der rechten untern Ecke ein
-> Paypal-Spendenbutton angebracht. Weiterhin kann eine Box natürlich
+> PayPal-Spendenbutton angebracht. Weiterhin kann eine Box natürlich
 > besser unterstützt werden, wenn das Entwicklerteam "Testboxen"
 > besitzt. Im
 > [IPPF](http://www.ip-phone-forum.de/showpost.php?p=959253&postcount=1)

--- a/docs/wiki/00_FAQ/FAQ.en.md
+++ b/docs/wiki/00_FAQ/FAQ.en.md
@@ -179,7 +179,7 @@ German.
 ### I like Freetz and I want to support the development.
 
 > It is possible to donate money to the development team using the
-> Paypal donation button at the bottom right-hand corner. Further, a
+> PayPal donation button at the bottom right-hand corner. Further, a
 > specific hardware variation will of course be better supported when
 > the development team has some test hardware. Currently we would very
 > much benefit from some 7270s (who wouldn't?!). There is a thread on

--- a/docs/wiki/30_Expert/rudi_shell.md
+++ b/docs/wiki/30_Expert/rudi_shell.md
@@ -57,9 +57,9 @@ ausreichen (*ohne* DS-Mod/Freetz):
 ### Client
 
 -   Web-Browser mit eingeschaltetem
-    [Javascript](http://de.wikipedia.org/wiki/JavaScript);
+    [JavaScript](http://de.wikipedia.org/wiki/JavaScript);
     getestetet mit IE7, Opera 9.10, Firefox 2.0.0.2. Es wird ein wenig
-    Javascript benutzt, um im
+    JavaScript benutzt, um im
     [DOM](http://de.wikipedia.org/wiki/Document_Object_Model)
     zu navigieren, die Historie zu steuern und
     [CGI](http://de.wikipedia.org/wiki/Common_Gateway_Interface)-Unterprozesse

--- a/docs/wiki/70_Various/origin_and_history.md
+++ b/docs/wiki/70_Various/origin_and_history.md
@@ -150,7 +150,7 @@
 
 > Hier gibt es einmal die Möglichkeit dem Entwicklerteam eine Geldspende
 > zukommen zu lassen. Dazu ist in der rechten untern Ecke ein
-> Paypal-Spendenbutton angebracht. Weiterhin kann eine Box natürlich
+> PayPal-Spendenbutton angebracht. Weiterhin kann eine Box natürlich
 > besser unterstützt werden, wenn das Entwicklerteam "Testboxen"
 > besitzt. Im
 > [IPPF](http://www.ip-phone-forum.de/showpost.php?p=959253&postcount=1)


### PR DESCRIPTION
Just a bunch of minor typo fixes, e.g. `Github` -> `GitHub`.