### PR TITLE
Update PREREQUISITES.md

### DIFF
--- a/.prerequisites
+++ b/.prerequisites
@@ -33,6 +33,7 @@ program     pkg-config
 program     python
 program     readlink
 program     realpath
+program     rpcgen                 FREETZ_PACKAGE_NFS_UTILS FREETZ_PACKAGE_AUTOFS
 program     rsync                  FREETZ_AVM_VERSION_07_25_MIN
 program     sed
 program     sha256sum

--- a/docs/PREREQUISITES.md
+++ b/docs/PREREQUISITES.md
@@ -33,7 +33,7 @@ sudo dnf -y update && sudo systemctl daemon-reload
  - Fedora 33/34 64-Bit:
 ```
 sudo dnf -y groupinstall 'Development Tools' 'Development Libraries'
-sudo dnf -y install pv rsync kmod execstack sqlite.i686 sqlite-devel libzstd-devel.i686 cmake zlib-devel.i686 libstdc++-devel.i686 openssl xz bc unar inkscape ImageMagick subversion ccache gcc gcc-c++ binutils autoconf automake libtool make bzip2 ncurses-devel ncurses-term zlib-devel flex bison patch texinfo gettext pkgconfig ecj perl perl-String-CRC32 wget glib2-devel git libacl-devel libattr-devel libcap-devel ncurses-devel.i686 glibc-devel.i686 libgcc.i686
+sudo dnf -y install pv rsync kmod execstack sqlite.i686 sqlite-devel libzstd-devel.i686 cmake zlib-devel.i686 libstdc++-devel.x86_64 libstdc++-devel.i686 openssl xz bc unar inkscape ImageMagick subversion ccache gcc gcc-c++ binutils autoconf automake libtool make bzip2 ncurses-devel ncurses-term zlib-devel flex bison patch texinfo gettext pkgconfig ecj perl perl-String-CRC32 wget glib2-devel git libacl-devel libattr-devel libcap-devel ncurses-devel.i686 glibc-devel.i686 libgcc.i686
 ```
 
  - Falls auf dem folgenden System ein 64-Bit Linux installiert ist wird zusätzlich benötigt:


### PR DESCRIPTION
`libstdc++-devel.x86_64` ist auf frisch installiertem fedora 35 (workstation) nicht vorhanden. `libstdc++-devel`  allein expandiert merkwürdigerweise in `libstdc++-devel.i686`