### PR TITLE
fakeroot: add patch to include header

### DIFF
--- a/tools/make/fakeroot-host/patches/304-wrapdef-h.patch
+++ b/tools/make/fakeroot-host/patches/304-wrapdef-h.patch
@@ -1,0 +1,10 @@
+--- wrapdef.horig
++++ wrapdef.h
+@@ -2,6 +2,7 @@
+ #ifndef WRAPDEF_H
+ #define WRAPDEF_H
+ 
++#include <sys/capability.h>
+ 
+ int (*NEXT_LSTAT_NOARG)LSTAT_ARG(int ver, const char *file_name, struct stat *buf)=TMP_LSTAT;
+ int (*NEXT_STAT_NOARG)STAT_ARG(int ver, const char *file_name, struct stat *buf)=TMP_STAT;


### PR DESCRIPTION
I'm still on Ubuntu 18.04 LTS and compiling fakeroot failed with
error message cap_user_header_t not found, resulting in syntax errors.

Add this patch resolved this issue, but I did not digged deeper
into this - especially, I don't have newer system ready at hand
to cross-check.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>