### PR TITLE
nfs-util fails to build because versionsort not available in uClibc versions prior to 0.9.32

### DIFF
--- a/make/nfs-utils/nfs-utils.mk
+++ b/make/nfs-utils/nfs-utils.mk
@@ -3,6 +3,8 @@ $(PKG)_SOURCE:=$(pkg)-$($(PKG)_VERSION).tar.bz2
 $(PKG)_SOURCE_MD5:=2fabdadb8ff415a1eafcfb12ab1bf781
 $(PKG)_SITE:=@SF/nfs
 
+$(PKG)_CONDITIONAL_PATCHES+=$(if $(or $(FREETZ_TARGET_UCLIBC_0_9_28),$(FREETZ_TARGET_UCLIBC_0_9_29)),uclibc-0.9.28)
+
 $(PKG)_DEPENDS_ON += $(if $(FREETZ_TARGET_UCLIBC_SUPPORTS_rpc),,libtirpc)
 
 $(PKG)_BINARIES            := exportfs mountd nfsd showmount

--- a/make/nfs-utils/patches/910-add-nfs_utils_uclibc-versionsort.patch
+++ b/make/nfs-utils/patches/910-add-nfs_utils_uclibc-versionsort.patch
@@ -1,0 +1,93 @@
+--- utils/exportfs/exportfs.c	2016-08-03 20:25:15.000000000 +0200
++++ utils/exportfs/exportfs.c	2021-12-31 17:15:10.006395547 +0100
+@@ -54,6 +54,90 @@
+ static const char *lockfile = EXP_LOCKFILE;
+ static int _lockfd = -1;
+ 
++
++#if defined(__UCLIBC__) && __UCLIBC_MAJOR__ == 0 && __UCLIBC_MINOR__ == 9 && __UCLIBC_SUBLEVEL__ <= 29
++#define  S_N    0x0
++#define  S_I    0x3
++#define  S_F    0x6
++#define  S_Z    0x9
++
++/* result_type: CMP: return diff; LEN: compare using len_diff/diff */
++#define  CMP    2
++#define  LEN    3
++
++int strverscmp (const char *s1, const char *s2)
++{
++  const unsigned char *p1 = (const unsigned char *) s1;
++  const unsigned char *p2 = (const unsigned char *) s2;
++
++  /* Symbol(s)    0       [1-9]   others
++     Transition   (10) 0  (01) d  (00) x   */
++  static const uint8_t next_state[] =
++  {
++      /* state    x    d    0  */
++      /* S_N */  S_N, S_I, S_Z,
++      /* S_I */  S_N, S_I, S_I,
++      /* S_F */  S_N, S_F, S_F,
++      /* S_Z */  S_N, S_F, S_Z
++  };
++
++  static const int8_t result_type[] =
++  {
++      /* state   x/x  x/d  x/0  d/x  d/d  d/0  0/x  0/d  0/0  */
++
++      /* S_N */  CMP, CMP, CMP, CMP, LEN, CMP, CMP, CMP, CMP,
++      /* S_I */  CMP, -1,  -1,  +1,  LEN, LEN, +1,  LEN, LEN,
++      /* S_F */  CMP, CMP, CMP, CMP, CMP, CMP, CMP, CMP, CMP,
++      /* S_Z */  CMP, +1,  +1,  -1,  CMP, CMP, -1,  CMP, CMP
++  };
++  unsigned char c1, c2;
++  int state, diff;
++
++  if (p1 == p2)
++    return 0;
++
++  c1 = *p1++;
++  c2 = *p2++;
++  /* Hint: '0' is a digit too.  */
++  state = S_N + ((c1 == '0') + (isdigit (c1) != 0));
++
++  while ((diff = c1 - c2) == 0)
++    {
++      if (c1 == '\0')
++        return diff;
++
++      state = next_state[state];
++      c1 = *p1++;
++      c2 = *p2++;
++      state += (c1 == '0') + (isdigit (c1) != 0);
++    }
++
++  state = result_type[state * 3 + (((c2 == '0') + (isdigit (c2) != 0)))];
++
++  switch (state)
++  {
++    case CMP:
++      return diff;
++
++    case LEN:
++      while (isdigit (*p1++))
++        if (!isdigit (*p2++))
++          return 1;
++
++      return isdigit (*p2) ? -1 : diff;
++
++    default:
++      return state;
++  }
++}
++
++int versionsort(const struct dirent **a, const struct dirent **b)
++{
++        return strverscmp((*a)->d_name, (*b)->d_name);
++}
++#endif
++
++
+ /*
+  * If we aren't careful, changes made by exportfs can be lost
+  * when multiple exports process run at once:

--- a/make/nfs-utils/patches/uclibc-0.9.28/910-add-nfs_utils_uclibc-versionsort.patch
+++ b/make/nfs-utils/patches/uclibc-0.9.28/910-add-nfs_utils_uclibc-versionsort.patch
@@ -1,11 +1,10 @@
 --- utils/exportfs/exportfs.c	2016-08-03 20:25:15.000000000 +0200
 +++ utils/exportfs/exportfs.c	2021-12-31 17:15:10.006395547 +0100
-@@ -54,6 +54,90 @@
+@@ -54,6 +54,88 @@
  static const char *lockfile = EXP_LOCKFILE;
  static int _lockfd = -1;
  
 +
-+#if defined(__UCLIBC__) && __UCLIBC_MAJOR__ == 0 && __UCLIBC_MINOR__ == 9 && __UCLIBC_SUBLEVEL__ <= 29
 +#define  S_N    0x0
 +#define  S_I    0x3
 +#define  S_F    0x6
@@ -85,7 +84,6 @@
 +{
 +        return strverscmp((*a)->d_name, (*b)->d_name);
 +}
-+#endif
 +
 +
  /*


### PR DESCRIPTION
At least in uClibc 0.9.29 (compiling for W920V/7570) there is no versionsort in uClibc (which is refered by utils/exportfs/exportfs.c)
So I added it from the uClib sources to utils/exportfs/exportfs.c
