### PR TITLE
Der Slash wurde immer angehängt, auch wenn EXTRA-VERSION ungesetzt war

### DIFF
--- a/fwmod
+++ b/fwmod
@@ -1798,8 +1798,7 @@ if [ "$action_names" ]; then
 			modstring+="_${modmakedate}"
 		fi
 		#EXTRA
-		if [ -n "$FREETZ_IMAGE_NAME_EXTRA" ] \
-		  || [ -z "$FREETZ_IMAGE_NAME_CUSTOM" ]; then
+		if [ ! -z ${FREETZ_IMAGE_NAME_EXTRA+x} ]; then
 			modstring+="-${FREETZ_IMAGE_NAME_EXTRA}"
 		fi
 		#done


### PR DESCRIPTION
- Extra Version Prüfung gefixt
- Die zweite Prüfung ist eigentlich unnötig