### PR TITLE
iksemel migration (not just version bump)

### DIFF
--- a/make/libs/iksemel/iksemel.mk
+++ b/make/libs/iksemel/iksemel.mk
@@ -1,8 +1,8 @@
-$(call PKG_INIT_LIB, 978b733462)
-$(PKG)_LIB_VERSION:=3.1.1
-$(PKG)_SOURCE:=$(pkg)-$($(PKG)_VERSION).tar.xz
-$(PKG)_SOURCE_MD5:=61ce8d6121d5bb339fd1150624681a60
-$(PKG)_SITE:=git@https://code.google.com/p/iksemel
+$(call PKG_INIT_BIN, 3.1.1)
+$(PKG)_LIB_VERSION:=$($(PKG)_VERSION)
+$(PKG)_SOURCE:=v1.4.2.tar.gz
+$(PKG)_SOURCE_MD5:=04353ca58a5cc745fd1d4fc255a73f8d
+$(PKG)_SITE:=https://github.com/timothytylee/iksemel-1.4/archive/refs/tags/
 
 $(PKG)_BINARY:=$($(PKG)_DIR)/src/.libs/lib$(pkg).so.$($(PKG)_LIB_VERSION)
 $(PKG)_STAGING_BINARY:=$(TARGET_TOOLCHAIN_STAGING_DIR)/lib/lib$(pkg).so.$($(PKG)_LIB_VERSION)

--- a/make/libs/iksemel/patches/010-build_lib_only.iksemel.patch
+++ b/make/libs/iksemel/patches/010-build_lib_only.iksemel.patch
@@ -1,5 +1,5 @@
---- ./source/target-mips_gcc-4.8.5_uClibc-0.9.33.2-nptl/iksemel-3.1.1/Makefile.am	2016-03-05 12:11:02.000000000 +0000
-+++ /tmp/Makefile.am	2022-01-24 23:04:42.708798342 +0000
+--- Makefile.am	2016-03-05 12:11:02.000000000 +0000
++++ Makefile.am	2022-01-24 23:04:42.708798342 +0000
 @@ -2,7 +2,7 @@
  ## Process this file with automake to produce Makefile.in
  ##

--- a/make/libs/iksemel/patches/010-build_lib_only.iksemel.patch
+++ b/make/libs/iksemel/patches/010-build_lib_only.iksemel.patch
@@ -1,10 +1,10 @@
---- Makefile.am.orig	2013-06-19 00:29:28.000000000 +0200
-+++ Makefile.am	2013-06-19 00:32:18.060238855 +0200
-@@ -6,7 +6,7 @@
- python_d = python
- endif
+--- ./source/target-mips_gcc-4.8.5_uClibc-0.9.33.2-nptl/iksemel-3.1.1/Makefile.am	2016-03-05 12:11:02.000000000 +0000
++++ /tmp/Makefile.am	2022-01-24 23:04:42.708798342 +0000
+@@ -2,7 +2,7 @@
+ ## Process this file with automake to produce Makefile.in
+ ##
  
--SUBDIRS = include src tools $(python_d) test doc
+-SUBDIRS = include src tools test doc
 +SUBDIRS = include src
  
  EXTRA_DIST = HACKING iksemel.pc.in


### PR DESCRIPTION
When compiling asterisks I run into this issue
```
libtool: compile:  /tmp/workspace.1XL7yKca3F/toolchain/build/mips_gcc-4.8.5_uClibc-0.9.33.2-nptl/mips-linux-uclibc/bin/mips-linux-uclibc-gcc -DHAVE_CONFIG_H -I. -I../include -I../include -march=24kc -mtune=24kc -msoft-float -Os -pipe -Wa,--trap -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 --std=gnu99 -Wall -I/tmp/workspace.1XL7yKca3F/toolchain/build/mips_gcc-4.8.5_uClibc-0.9.33.2-nptl/mips-linux-uclibc/usr/include -march=24kc -mtune=24kc -msoft-float -Os -pipe -Wa,--trap -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 --std=gnu99 -Wall -MT libiksemel_la-tls-gnutls.lo -MD -MP -MF .deps/libiksemel_la-tls-gnutls.Tpo -c tls-gnutls.c -o libiksemel_la-tls-gnutls.o >/dev/null 2>&1
mv -f .deps/libiksemel_la-tls-gnutls.Tpo .deps/libiksemel_la-tls-gnutls.Plo
/bin/bash ../libtool  --tag=CC   --mode=compile /tmp/workspace.1XL7yKca3F/toolchain/build/mips_gcc-4.8.5_uClibc-0.9.33.2-nptl/mips-linux-uclibc/bin/mips-linux-uclibc-gcc -DHAVE_CONFIG_H -I. -I../include -I../include   -march=24kc -mtune=24kc -msoft-float -Os -pipe -Wa,--trap -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 --std=gnu99 -Wall  -I/tmp/workspace.1XL7yKca3F/toolchain/build/mips_gcc-4.8.5_uClibc-0.9.33.2-nptl/mips-linux-uclibc/usr/include -march=24kc -mtune=24kc -msoft-float -Os -pipe -Wa,--trap -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 --std=gnu99 -Wall -MT libiksemel_la-tls-openssl.lo -MD -MP -MF .deps/libiksemel_la-tls-openssl.Tpo -c -o libiksemel_la-tls-openssl.lo `test -f 'tls-openssl.c' || echo './'`tls-openssl.c
libtool: compile:  /tmp/workspace.1XL7yKca3F/toolchain/build/mips_gcc-4.8.5_uClibc-0.9.33.2-nptl/mips-linux-uclibc/bin/mips-linux-uclibc-gcc -DHAVE_CONFIG_H -I. -I../include -I../include -march=24kc -mtune=24kc -msoft-float -Os -pipe -Wa,--trap -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 --std=gnu99 -Wall -I/tmp/workspace.1XL7yKca3F/toolchain/build/mips_gcc-4.8.5_uClibc-0.9.33.2-nptl/mips-linux-uclibc/usr/include -march=24kc -mtune=24kc -msoft-float -Os -pipe -Wa,--trap -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 --std=gnu99 -Wall -MT libiksemel_la-tls-openssl.lo -MD -MP -MF .deps/libiksemel_la-tls-openssl.Tpo -c tls-openssl.c  -fPIC -DPIC -o .libs/libiksemel_la-tls-openssl.o
tls-openssl.c: In function 'my_bio_create':
tls-openssl.c:27:3: error: dereferencing pointer to incomplete type
  b->init = 1;
   ^
tls-openssl.c:28:3: error: dereferencing pointer to incomplete type
  b->num = 0;
   ^
tls-openssl.c:29:3: error: dereferencing pointer to incomplete type
  b->ptr = NULL;
   ^
tls-openssl.c:30:3: error: dereferencing pointer to incomplete type
  b->flags = 0 ;
   ^
tls-openssl.c: In function 'my_bio_destroy':
tls-openssl.c:39:3: error: dereferencing pointer to incomplete type
  b->ptr = NULL;
   ^
tls-openssl.c:40:3: error: dereferencing pointer to incomplete type
  b->init = 0;
   ^
tls-openssl.c:41:3: error: dereferencing pointer to incomplete type
  b->flags = 0;
   ^
tls-openssl.c: In function 'my_bio_read':
tls-openssl.c:48:53: error: dereferencing pointer to incomplete type
  struct ikstls_data *data = (struct ikstls_data *) b->ptr;
                                                     ^
tls-openssl.c: In function 'my_bio_write':
tls-openssl.c:61:53: error: dereferencing pointer to incomplete type
  struct ikstls_data *data = (struct ikstls_data *) b->ptr;
                                                     ^
tls-openssl.c: At top level:
tls-openssl.c:92:1: error: variable 'my_bio_method' has initializer but incomplete type
 static BIO_METHOD my_bio_method = {
 ^
tls-openssl.c:93:2: warning: excess elements in struct initializer [enabled by default]
  ( 100 | 0x400 ),
  ^
tls-openssl.c:93:2: warning: (near initialization for 'my_bio_method') [enabled by default]
tls-openssl.c:94:2: warning: excess elements in struct initializer [enabled by default]
  "iksemel transport",
  ^
tls-openssl.c:94:2: warning: (near initialization for 'my_bio_method') [enabled by default]
tls-openssl.c:95:2: warning: excess elements in struct initializer [enabled by default]
  my_bio_write,
  ^
tls-openssl.c:95:2: warning: (near initialization for 'my_bio_method') [enabled by default]
tls-openssl.c:96:2: warning: excess elements in struct initializer [enabled by default]
  my_bio_read,
  ^
tls-openssl.c:96:2: warning: (near initialization for 'my_bio_method') [enabled by default]
tls-openssl.c:97:2: warning: excess elements in struct initializer [enabled by default]
  my_bio_puts,
  ^
tls-openssl.c:97:2: warning: (near initialization for 'my_bio_method') [enabled by default]
tls-openssl.c:98:2: warning: excess elements in struct initializer [enabled by default]
  my_bio_gets,
  ^
tls-openssl.c:98:2: warning: (near initialization for 'my_bio_method') [enabled by default]
tls-openssl.c:99:2: warning: excess elements in struct initializer [enabled by default]
  my_bio_ctrl,
  ^
tls-openssl.c:99:2: warning: (near initialization for 'my_bio_method') [enabled by default]
tls-openssl.c:100:2: warning: excess elements in struct initializer [enabled by default]
  my_bio_create,
  ^
tls-openssl.c:100:2: warning: (near initialization for 'my_bio_method') [enabled by default]
tls-openssl.c:102:1: warning: excess elements in struct initializer [enabled by default]
 };
 ^
tls-openssl.c:102:1: warning: (near initialization for 'my_bio_method') [enabled by default]
tls-openssl.c: In function 'tls_handshake':
tls-openssl.c:138:5: error: dereferencing pointer to incomplete type
  bio->ptr = (void *) data;
     ^
make[2]: *** [Makefile:564: libiksemel_la-tls-openssl.lo] Error 1
make[2]: *** Waiting for unfinished jobs....
libtool: compile:  /tmp/workspace.1XL7yKca3F/toolchain/build/mips_gcc-4.8.5_uClibc-0.9.33.2-nptl/mips-linux-uclibc/bin/mips-linux-uclibc-gcc -DHAVE_CONFIG_H -I. -I../include -I../include -march=24kc -mtune=24kc -msoft-float -Os -pipe -Wa,--trap -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 --std=gnu99 -Wall -I/tmp/workspace.1XL7yKca3F/toolchain/build/mips_gcc-4.8.5_uClibc-0.9.33.2-nptl/mips-linux-uclibc/usr/include -march=24kc -mtune=24kc -msoft-float -Os -pipe -Wa,--trap -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 --std=gnu99 -Wall -MT libiksemel_la-stream.lo -MD -MP -MF .deps/libiksemel_la-stream.Tpo -c stream.c -o libiksemel_la-stream.o >/dev/null 2>&1
mv -f .deps/libiksemel_la-stream.Tpo .deps/libiksemel_la-stream.Plo
make[2]: Leaving directory '/tmp/workspace.1XL7yKca3F/source/target-mips_gcc-4.8.5_uClibc-0.9.33.2-nptl/iksemel-978b733462/src'
make[1]: *** [Makefile:452: all-recursive] Error 1
make[1]: Leaving directory '/tmp/workspace.1XL7yKca3F/source/target-mips_gcc-4.8.5_uClibc-0.9.33.2-nptl/iksemel-978b733462'
```

There's an issue in the project which is still open https://github.com/meduketto/iksemel/issues/52

Since the last commit in the project was in 2011-10 (yes no typo: 2011 not 2021) I started looking for forks and got it working using https://github.com/timothytylee/iksemel-1.4

I have no clue if this is a good nor the best choice (and even I can't get asterisk compiling but got over this issue)

