### PR TITLE
v4 support for nfsd

### DIFF
--- a/make/nfs-utils/Config.in
+++ b/make/nfs-utils/Config.in
@@ -14,3 +14,25 @@ config FREETZ_PACKAGE_NFS_UTILS
 		Select nfsd-cgi if you want a configuration web interface.
 		If this does not work, enable replace-kernel!
 
+config FREETZ_PACKAGE_NFSD_V4
+	bool "v4 support for NFS server (EXPERIMENTAL)"
+	depends on FREETZ_PACKAGE_NFS_UTILS && !FREETZ_AVM_HAS_NFSD_BUILTIN
+	select FREETZ_MODULE_NFSD_V4
+	select FREETZ_LIB_libblkid
+	select FREETZ_LIB_libdevmapper
+	select FREETZ_LIB_libevent
+	select FREETZ_LIB_libsqlite3
+	select FREETZ_LIB_libnfsidmap
+	default n
+	help
+		Provides v4 support and utilities for nfsd. Kerberos support is missing.
+		Note:
+		1. NFSv4 has to be enabled with "make kernel-menuconfig".
+		2. The kernel modules auth_rpcgss and oid_registry must be selected manually (in the field
+		"Own kernel modules").
+		3. The mapper daemon idmapd is built but is disabled by default since it needs kerberos for
+		full functionality.
+		4. If you wish to use idmapd anyway then dnotify needs to be enabled using
+		"make kernel-menuconfig". If dnotify does not work (check whether
+		/proc/sys/fs/dir-notify-enabled exists) then try "replace kernel".
+		

--- a/make/nfs-utils/nfs-utils.mk
+++ b/make/nfs-utils/nfs-utils.mk
@@ -5,37 +5,38 @@ $(PKG)_SITE:=@SF/nfs
 
 $(PKG)_CONDITIONAL_PATCHES+=$(if $(or $(FREETZ_TARGET_UCLIBC_0_9_28),$(FREETZ_TARGET_UCLIBC_0_9_29)),uclibc-0.9.28)
 
-$(PKG)_DEPENDS_ON += $(if $(FREETZ_TARGET_UCLIBC_SUPPORTS_rpc),,libtirpc)
-
-$(PKG)_BINARIES            := exportfs mountd nfsd showmount
-$(PKG)_BINARIES_BUILD_DIR  := $(addprefix $($(PKG)_DIR)/utils/, $(join $($(PKG)_BINARIES),$(addprefix /,$($(PKG)_BINARIES))))
-$(PKG)_BINARIES_TARGET_DIR := $($(PKG)_BINARIES:%=$($(PKG)_DEST_DIR)/usr/sbin/%)
-
 $(PKG)_DEPENDS_ON += tcp_wrappers
+ifeq ($(FREETZ_TARGET_UCLIBC_SUPPORTS_rpc),y)
+	$(PKG)_CONFIGURE_OPTIONS += --disable-tirpc
+else
+	$(PKG)_DEPENDS_ON += libtirpc
+	$(PKG)_CFLAGS += -I$(TARGET_TOOLCHAIN_STAGING_DIR)/include/tirpc
+endif
 
-# IPv6 support requires TIRPC
-#$(PKG)_REBUILD_SUBOPTS += FREETZ_TARGET_IPV6_SUPPORT
-#ifeq ($(FREETZ_TARGET_IPV6_SUPPORT),y)
-#$(PKG)_CONFIGURE_OPTIONS += --enable-ipv6=yes
-#else
-$(PKG)_CONFIGURE_OPTIONS += --enable-ipv6=no
-$(PKG)_CONFIGURE_OPTIONS += $(if $(FREETZ_TARGET_UCLIBC_SUPPORTS_rpc),--disable-tirpc,--enable-tirpc)
-#endif
+#The server does not need mount.nfs
+$(PKG)_CONFIGURE_OPTIONS += --disable-mount
+#gss depends on kerberos:
+$(PKG)_CONFIGURE_OPTIONS += --disable-gss
+
+#the names of binary and folder may differ
+$(PKG)_BINARIES		+= exportfs mountd nfsd showmount sm-notify statd
+$(PKG)_BINARIES_PATH	+= exportfs mountd nfsd showmount statd statd
+
+ifeq ($(strip $(FREETZ_PACKAGE_NFSD_V4)),y)
+	$(PKG)_BINARIES		+=  idmapd  nfsdcltrack nfsstat blkmapd
+	$(PKG)_BINARIES_PATH	+=  idmapd  nfsdcltrack nfsstat blkmapd
+else
+	$(PKG)_CONFIGURE_OPTIONS += --disable-nfsv4 --disable-uuid --disable-ipv6
+endif
+
+$(PKG)_BINARIES_BUILD_DIR  := $(addprefix $($(PKG)_DIR)/utils/, $(join $($(PKG)_BINARIES_PATH),$(addprefix /,$($(PKG)_BINARIES))))
+$(PKG)_BINARIES_TARGET_DIR := $($(PKG)_BINARIES:%=$($(PKG)_DEST_DIR)/usr/sbin/%)
 
 $(PKG)_CONFIGURE_ENV += ac_cv_type_getgroups=gid_t
 $(PKG)_CONFIGURE_ENV += ac_cv_func_getgroups_works=yes
 $(PKG)_CONFIGURE_ENV += ac_cv_func_stat_empty_string_bug=no
 $(PKG)_CONFIGURE_ENV += ac_cv_func_lstat_empty_string_bug=no
 $(PKG)_CONFIGURE_ENV += ac_cv_func_lstat_dereferences_slashed_symlink=no
-
-$(PKG)_CONFIGURE_OPTIONS += --disable-nfsv4
-$(PKG)_CONFIGURE_OPTIONS += --disable-mount
-$(PKG)_CONFIGURE_OPTIONS += --disable-gss
-$(PKG)_CONFIGURE_OPTIONS += --disable-uuid
-
-ifneq ($(strip $(FREETZ_TARGET_UCLIBC_SUPPORTS_rpc)),y)
-$(PKG)_CFLAGS += -I$(TARGET_TOOLCHAIN_STAGING_DIR)/include/tirpc
-endif
 
 $(PKG_SOURCE_DOWNLOAD)
 $(PKG_UNPACKED)

--- a/make/nfs-utils/patches/100-spurious-slash.patch
+++ b/make/nfs-utils/patches/100-spurious-slash.patch
@@ -1,0 +1,11 @@
+--- utils/idmapd/idmapd.c
++++ utils/idmapd/idmapd.c
+@@ -71,7 +71,7 @@
+ #include "nfslib.h"
+ 
+ #ifndef PIPEFS_DIR
+-#define PIPEFS_DIR  "/var/lib/nfs/rpc_pipefs/"
++#define PIPEFS_DIR  "/var/lib/nfs/rpc_pipefs"
+ #endif
+ 
+ #ifndef NFSD_DIR


### PR DESCRIPTION
Zweiter Versuch, nfsv4-Support für nfs-utils zu bauen. Wenn nfsdv4 nicht ausgewählt wird, dann sollte das Ergebnis mehr oder weniger identisch mit dem vorherigen Zustand sein. Es werden noch zusätzlich sm-notify und statd gebaut. Vielleicht interessiert das jemanden. Bei v4 werden zusätzlich idmapd, nfsdcltrack, nfsstat und blkmapd gebaut. Nichts davon ist essentiell für die Funktionalität (zumindest, wenn kerberos nicht vorhanden ist). Nicht gebaut werden gssd (wegen fehlendem kerberos) und mount.nfs4 (wird nur vom client gebraucht und wegen Schwierigkeiten auf der 7490). Auf der 7490 läuft nfs4 stabil inklusive idmapd.