### PR TITLE
haproxy: bump to version 2.5.3

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -72,7 +72,7 @@ Latest changes
    * davfs2 1.5.2/1.6.1
    * expat 2.4.6
    * git 2.34.1
-   * HAProxy 2.5.2
+   * HAProxy 2.5.3
    * iksemel 3.1.1
    * libexif 0.6.24
    * libgcrypt 1.9.4

--- a/docs/make/README.md
+++ b/docs/make/README.md
@@ -248,7 +248,7 @@ Index:
 
 ### H
 
-  * **[HAProxy 2.5.2](haproxy.md)<a id='haproxy'></a>**<br>
+  * **[HAProxy 2.5.3](haproxy.md)<a id='haproxy'></a>**<br>
     HAProxy is a free, very fast and reliable solution offering high availability, load balancing, and proxying for TCP and HTTP-based applications.
 
   * **[haserl 0.9.35 (binary only)](haserl.md)<a id='haserl'></a>**<br>

--- a/docs/make/haproxy.md
+++ b/docs/make/haproxy.md
@@ -1,4 +1,4 @@
-# HAProxy 2.5.2
+# HAProxy 2.5.3
  - Homepage: [https://www.haproxy.org/](https://www.haproxy.org/)
  - Manpage: [https://linux.die.net/man/1/haproxy](https://linux.die.net/man/1/haproxy)
  - Changelog: [https://www.haproxy.org/download/2.5/src/CHANGELOG](https://www.haproxy.org/download/2.5/src/CHANGELOG)

--- a/make/README.md
+++ b/make/README.md
@@ -336,7 +336,7 @@ Index:
 
 ### H
 
-  * **[HAProxy 2.5.2](../docs/make/haproxy.md)<a id='haproxy'></a>**<br>
+  * **[HAProxy 2.5.3](../docs/make/haproxy.md)<a id='haproxy'></a>**<br>
     HAProxy is a free, very fast and reliable solution offering high availability, load balancing, and proxying for TCP and HTTP-based applications.
 
   * **[haserl 0.9.35 (binary only)](../docs/make/haserl.md)<a id='haserl'></a>**<br>

--- a/make/haproxy/Config.in
+++ b/make/haproxy/Config.in
@@ -1,5 +1,5 @@
 config FREETZ_PACKAGE_HAPROXY
-	bool "HAProxy 2.5.2"
+	bool "HAProxy 2.5.3"
 	select FREETZ_LIB_libcrypt if FREETZ_TARGET_UCLIBC_HAS_multiple_libs
 	select FREETZ_BUSYBOX_START_STOP_DAEMON
 	default n

--- a/make/haproxy/haproxy.mk
+++ b/make/haproxy/haproxy.mk
@@ -1,6 +1,6 @@
-$(call PKG_INIT_BIN, 2.5.2)
+$(call PKG_INIT_BIN, 2.5.3)
 $(PKG)_SOURCE:=$(pkg)-$($(PKG)_VERSION).tar.gz
-$(PKG)_SOURCE_SHA256:=2de3424fd7452be1c1c13d5e0994061285055c57046b1cb3c220d67611d0da7e
+$(PKG)_SOURCE_SHA256:=d6fa3c66f707ff93b5bd27ce69e70a8964d7b7078548b51868d47d7df3943fe4
 $(PKG)_SITE:=https://www.haproxy.org/download/2.5/src
 ### WEBSITE:=https://www.haproxy.org/
 ### MANPAGE:=https://linux.die.net/man/1/haproxy


### PR DESCRIPTION
Changelog: http://www.haproxy.org/download/2.5/src/CHANGELOG