### PR TITLE
collectd: fix bug when there are outcommented DataDir entries

### DIFF
--- a/make/collectd/files/root/usr/lib/cgi-bin/collectd/view.cgi
+++ b/make/collectd/files/root/usr/lib/cgi-bin/collectd/view.cgi
@@ -11,7 +11,7 @@
 
 [ -n "$COLLECTD_GRAPH_SCRIPT" ] && . $COLLECTD_GRAPH_SCRIPT
 
-HOSTS_DIR=$(cat /tmp/flash/collectd/collectd.conf | sed -e 's/^[ \t]*//' -n -e 's/DataDir *\"\(.*\)\"/\1/p')
+HOSTS_DIR=$(cat /tmp/flash/collectd/collectd.conf | sed -e 's/^[ \t]*//' -n -e 's/^DataDir *\"\(.*\)\"/\1/p')
 RRDTOOL=$(which rrdtool)
 
 #Error message will be printed later


### PR DESCRIPTION
Ich hatte in der collectd.conf einen DataDir Eintrag auskommentiert
```
	# DataDir "/some/old/dir"
	DataDir "/var/media/newdir"
```
Das sed Kommando in view.cgi berücksichtigt auch Zeilen, denen "DataDir" ein Hashtag vorangestellt ist, was dann dazu führt, dass das cgi mit der Fehlermeldung "RRD Data directory is not valid" abbricht. 
Wird dem sed regex vor "DataDir" noch ein Zirkumflex vorangestellt werden auskommentierte Zeilen ignoriert, da nur noch Zeilen berücksichtigt werden, die mit "DataDir" beginnen. Dies funktioniert auch, wenn "DataDir" Leerzeichen und/oder Tabs vorangestellt sind, da diese vorab vom sed Kommando selbst entfernt wurden. 

