### PR TITLE
haproxy: version bump -> 2.5.5

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -77,7 +77,7 @@ Latest changes
    * davfs2 1.5.2/1.6.1
    * expat 2.4.8
    * git 2.34.1
-   * HAProxy 2.5.4
+   * HAProxy 2.5.5
    * iksemel 3.1.1
    * libexif 0.6.24
    * libgsasl 1.10.0

--- a/docs/make/README.md
+++ b/docs/make/README.md
@@ -248,7 +248,7 @@ Index:
 
 ### H
 
-  * **[HAProxy 2.5.4](haproxy.md)<a id='haproxy'></a>**<br>
+  * **[HAProxy 2.5.5](haproxy.md)<a id='haproxy'></a>**<br>
     HAProxy is a free, very fast and reliable solution offering high availability, load balancing, and proxying for TCP and HTTP-based applications.
 
   * **[haserl 0.9.35 (binary only)](haserl.md)<a id='haserl'></a>**<br>

--- a/docs/make/haproxy.md
+++ b/docs/make/haproxy.md
@@ -1,4 +1,4 @@
-# HAProxy 2.5.4
+# HAProxy 2.5.5
  - Homepage: [https://www.haproxy.org/](https://www.haproxy.org/)
  - Manpage: [https://linux.die.net/man/1/haproxy](https://linux.die.net/man/1/haproxy)
  - Changelog: [https://www.haproxy.org/download/2.5/src/CHANGELOG](https://www.haproxy.org/download/2.5/src/CHANGELOG)

--- a/make/README.md
+++ b/make/README.md
@@ -337,7 +337,7 @@ Index:
 
 ### H
 
-  * **[HAProxy 2.5.4](../docs/make/haproxy.md)<a id='haproxy'></a>**<br>
+  * **[HAProxy 2.5.5](../docs/make/haproxy.md)<a id='haproxy'></a>**<br>
     HAProxy is a free, very fast and reliable solution offering high availability, load balancing, and proxying for TCP and HTTP-based applications.
 
   * **[haserl 0.9.35 (binary only)](../docs/make/haserl.md)<a id='haserl'></a>**<br>

--- a/make/haproxy/Config.in
+++ b/make/haproxy/Config.in
@@ -1,5 +1,5 @@
 config FREETZ_PACKAGE_HAPROXY
-	bool "HAProxy 2.5.4"
+	bool "HAProxy 2.5.5"
 	select FREETZ_LIB_libcrypt if FREETZ_TARGET_UCLIBC_HAS_multiple_libs
 	select FREETZ_BUSYBOX_START_STOP_DAEMON
 	default n

--- a/make/haproxy/haproxy.mk
+++ b/make/haproxy/haproxy.mk
@@ -1,6 +1,6 @@
-$(call PKG_INIT_BIN, 2.5.4)
+$(call PKG_INIT_BIN, 2.5.5)
 $(PKG)_SOURCE:=$(pkg)-$($(PKG)_VERSION).tar.gz
-$(PKG)_SOURCE_SHA256:=dc4015d85c7fef811b459803b763001d809b07a9251dc1864fedb9a07b44aefb
+$(PKG)_SOURCE_SHA256:=063c4845cdb2d76f292ef44d9c0117a853d8d10ae5d9615b406b14a4d74fe4b9
 $(PKG)_SITE:=https://www.haproxy.org/download/2.5/src
 ### WEBSITE:=https://www.haproxy.org/
 ### MANPAGE:=https://linux.die.net/man/1/haproxy

--- a/make/haproxy/patches/100-patch-wo-libpcreposix.patch
+++ b/make/haproxy/patches/100-patch-wo-libpcreposix.patch
@@ -1,6 +1,6 @@
 --- Makefile
 +++ Makefile
-@@ -721,11 +721,11 @@
+@@ -728,11 +728,11 @@
  ifeq ($(USE_STATIC_PCRE),)
  # dynamic PCRE
  OPTIONS_CFLAGS  += -DUSE_PCRE $(if $(PCRE_INC),-I$(PCRE_INC))


### PR DESCRIPTION
Changelog: http://www.haproxy.org/download/2.5/src/CHANGELOG