### PR TITLE
Fix firmware update on 6591, 6660, 6690

### DIFF
--- a/make/mod/files/root/etc/services
+++ b/make/mod/files/root/etc/services
@@ -29,8 +29,8 @@ kerberos	88/tcp		kerberos5 krb5 kerberos-sec
 kerberos	88/udp		kerberos5 krb5 kerberos-sec
 pop3		110/tcp
 pop3		110/udp
-sunrpc		111/tcp
-sunrpc		111/udp
+sunrpc		111/tcp		portmapper # RPC 4.0 portmapper TCP
+sunrpc		111/udp		portmapper # RPC 4.0 portmapper UDP
 auth		113/tcp		ident
 sftp		115/tcp
 nntp		119/tcp


### PR DESCRIPTION
rpcbind will not listen on port 111 if there is no portmapper alias in  the services file.
This in turn causes 6591/6660/6690 firmware update to fail, as the arm core needs an RPC service on the atom core.