### PR TITLE
classpath: depend directly on ecj and not on javac

### DIFF
--- a/.prerequisites
+++ b/.prerequisites
@@ -22,7 +22,7 @@ program     glib-genmarshal        FREETZ_LIB_libglib_2
 program     grep
 program     hexdump                FREETZ_TYPE_FIRMWARE_DETECT_LATEST
 program     inkscape           and FREETZ_TAGGING_ENABLED FREETZ_AVM_VERSION_06_5X_MIN FREETZ_AVM_VERSION_07_0X_MAX
-program     javac                  FREETZ_PACKAGE_CLASSPATH
+program     ecj                    FREETZ_PACKAGE_CLASSPATH
 program     ldconfig
 program     libtool
 program     libtoolize             FREETZ_PACKAGE_GNTPSEND

--- a/make/pkgs/classpath/classpath.mk
+++ b/make/pkgs/classpath/classpath.mk
@@ -32,7 +32,7 @@ $(PKG)_DEPENDS_ON += iconv
 endif
 
 $(PKG)_CONFIGURE_ENV += HAVE_INET6_I_KNOW_IT_BETTER=$(if $(FREETZ_TARGET_IPV6_SUPPORT),yes,no)
-$(PKG)_CONFIGURE_ENV += JAVAC=javac
+$(PKG)_CONFIGURE_ENV += JAVAC=ecj
 
 $(PKG)_CONFIGURE_OPTIONS += --disable-alsa
 $(PKG)_CONFIGURE_OPTIONS += --disable-gconf-peer


### PR DESCRIPTION
Auf Systemen wie Fedora wird bei der Installation von `ecj` kein symlink names `javac` angelegt. 
Auf diesen Systemen schägt die prerequisites fehl, da dort kein `javac` Command im PATH liegt. 

Es existieren (mindestens) zwei Möglichkeiten das Problem zu lösen: 
- Einen derartigen symlink anlegen (würde einen Eingriff in das System bedeuten)
- De Build von classpath anpassen, so dass dieser nicht `javac` verwendet sondern `ecj` (inklusive der Anpassung der [.prerequisites](https://github.com/Freetz-NG/freetz-ng/blob/master/.prerequisites), dass dort auf `ecj` und nicht `javac` geprüft wird). 

Der Patch setzt die zweite Möglichkeit um. 

Der Nachteil, dass `classpath` nun nicht mehr einen beliebigen Java-Compiler (javac) sondern explizit `ecj`  als Abhängigkeit "definiert" ist unerheblich, da `classpath` sowieso nicht mehr mit einem beliebigen Java-Compiler (javac) kompiliert, so schlägt beispielsweise der Build mit `javac` aus aktuellen openjdk Installationen fehl. 

Patch unter ubuntu22 sowieo fedora36 (jeweils mit und ohne javac Link) erfolgreich vertestet. 