### PR TITLE
Patch 2

### DIFF
--- a/patches/scripts/800-yf_bootmanager.sh
+++ b/patches/scripts/800-yf_bootmanager.sh
@@ -7,8 +7,8 @@ pushd "${TOOLS_DIR}/yf/bootmanager" >/dev/null
 TMP="$TEMPDIR" \
   TARGET_SYSTEM_VERSION="${AVM_FW_MAJOR}.${AVM_FW_VERSION}" \
   TARGET_DIR="${ABS_BASE_DIR}/${FILESYSTEM_MOD_DIR}" \
-  sh "./add_to_system_reboot.sh" 2>&1 | sed 's/^/    /g'
+  TARGET_BRANDING="all" \
+sh "./add_to_system_reboot.sh" 2>&1 | sed 's/^/    /g'
 popd >/dev/null
 rmdir "$TEMPDIR"
 [ "$FREETZ_VERBOSITY_LEVEL" -lt "2" 2>/dev/null ] && exec >$(tty)
-

--- a/patches/scripts/800-yf_bootmanager.sh
+++ b/patches/scripts/800-yf_bootmanager.sh
@@ -8,7 +8,7 @@ TMP="$TEMPDIR" \
   TARGET_SYSTEM_VERSION="${AVM_FW_MAJOR}.${AVM_FW_VERSION}" \
   TARGET_DIR="${ABS_BASE_DIR}/${FILESYSTEM_MOD_DIR}" \
   TARGET_BRANDING="all" \
-sh "./add_to_system_reboot.sh" 2>&1 | sed 's/^/    /g'
+  sh "./add_to_system_reboot.sh" 2>&1 | sed 's/^/    /g'
 popd >/dev/null
 rmdir "$TEMPDIR"
 [ "$FREETZ_VERBOSITY_LEVEL" -lt "2" 2>/dev/null ] && exec >$(tty)


### PR DESCRIPTION
YourFritz-Bootmanager funktionierte in FW 7.50 nicht mehr
Dank an PeterPawn https://www.ip-phone-forum.de/threads/yf-bootmanger-mit-freetz-ng-und-fw-7-50-nicht-nutzbar.314478/post-2502442