### PR TITLE
use 'command -v' instead of 'which'

### DIFF
--- a/make/include/600-macros.mk
+++ b/make/include/600-macros.mk
@@ -12,7 +12,7 @@ ifneq ($($(PKG)_BUILD_PREREQ),)
 	for fv in $($(PKG)_BUILD_PREREQ); do \
 		f=$$$$(echo $$$$fv | cut -d ':' -f 1); \
 		v=$$$$(echo $$$$fv | cut -d ':' -sf 2 | sed -e 's,[.],[.],g'); \
-		if ! which $$$$f >/dev/null 2>&1; then \
+		if ! command -v $$$$f >/dev/null 2>&1; then \
 			MISSING_PREREQ="$$$$MISSING_PREREQ $$$$f"; \
 		elif [ -n "$$$$v" ] && ! $$$$f --version 2>&1 | grep -q "$$$$v"; then \
 			MISSING_PREREQ="$$$$MISSING_PREREQ $$$$fv"; \


### PR DESCRIPTION
command is a shell builtin,
which is not installed on all systems.

a missing which command gives the false error:

> ERROR: The following command(s)
> required for building 'kconfig-host'
> are missing on your system: bison, flex

alternative: before calling `which`, use `command -v` to check the `which` command
