### PR TITLE
iperf: fix build, docs

### DIFF
--- a/make/toolchain/target/uclibc/0.9.28/953-add-endian-conversions-be64toh-htobe64.patch
+++ b/make/toolchain/target/uclibc/0.9.28/953-add-endian-conversions-be64toh-htobe64.patch
@@ -1,0 +1,62 @@
+From c6d6237819037168a6923ac080e348e54615422c Mon Sep 17 00:00:00 2001
+From: Vladimir Zapolskiy <vzapolskiy@gmail.com>
+Date: Tue, 1 Jun 2010 23:22:57 +0400
+Subject: [PATCH] endian.h: add BSD convertions between big/little-endian byte
+ order
+
+This patch adds support for convertion of values between host and
+big-/little-endian byte order.
+
+Signed-off-by: Vladimir Zapolskiy <vzapolskiy@gmail.com>
+Signed-off-by: Bernhard Reutner-Fischer <rep.dot.nop@gmail.com>
+---
+ include/endian.h | 38 ++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 38 insertions(+)
+
+diff --git a/include/endian.h b/include/endian.h
+index 2f7bce100..0ba738463 100644
+--- a/include/endian.h
++++ b/include/endian.h
+@@ -55,4 +55,42 @@
+ # define __LONG_LONG_PAIR(HI, LO) HI, LO
+ #endif
+ 
++
++#ifdef __USE_BSD
++/* Conversion interfaces.  */
++# include <byteswap.h>
++
++# if __BYTE_ORDER == __LITTLE_ENDIAN
++#  define htobe16(x) __bswap_16 (x)
++#  define htole16(x) (x)
++#  define be16toh(x) __bswap_16 (x)
++#  define le16toh(x) (x)
++
++#  define htobe32(x) __bswap_32 (x)
++#  define htole32(x) (x)
++#  define be32toh(x) __bswap_32 (x)
++#  define le32toh(x) (x)
++
++#  define htobe64(x) __bswap_64 (x)
++#  define htole64(x) (x)
++#  define be64toh(x) __bswap_64 (x)
++#  define le64toh(x) (x)
++# else
++#  define htobe16(x) (x)
++#  define htole16(x) __bswap_16 (x)
++#  define be16toh(x) (x)
++#  define le16toh(x) __bswap_16 (x)
++
++#  define htobe32(x) (x)
++#  define htole32(x) __bswap_32 (x)
++#  define be32toh(x) (x)
++#  define le32toh(x) __bswap_32 (x)
++
++#  define htobe64(x) (x)
++#  define htole64(x) __bswap_64 (x)
++#  define be64toh(x) (x)
++#  define le64toh(x) __bswap_64 (x)
++# endif
++#endif
++
+ #endif	/* endian.h */

--- a/make/toolchain/target/uclibc/0.9.29/953-add-endian-conversions-be64toh-htobe64.patch
+++ b/make/toolchain/target/uclibc/0.9.29/953-add-endian-conversions-be64toh-htobe64.patch
@@ -1,0 +1,62 @@
+From c6d6237819037168a6923ac080e348e54615422c Mon Sep 17 00:00:00 2001
+From: Vladimir Zapolskiy <vzapolskiy@gmail.com>
+Date: Tue, 1 Jun 2010 23:22:57 +0400
+Subject: [PATCH] endian.h: add BSD convertions between big/little-endian byte
+ order
+
+This patch adds support for convertion of values between host and
+big-/little-endian byte order.
+
+Signed-off-by: Vladimir Zapolskiy <vzapolskiy@gmail.com>
+Signed-off-by: Bernhard Reutner-Fischer <rep.dot.nop@gmail.com>
+---
+ include/endian.h | 38 ++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 38 insertions(+)
+
+diff --git a/include/endian.h b/include/endian.h
+index 2f7bce100..0ba738463 100644
+--- a/include/endian.h
++++ b/include/endian.h
+@@ -55,4 +55,42 @@
+ # define __LONG_LONG_PAIR(HI, LO) HI, LO
+ #endif
+ 
++
++#ifdef __USE_BSD
++/* Conversion interfaces.  */
++# include <byteswap.h>
++
++# if __BYTE_ORDER == __LITTLE_ENDIAN
++#  define htobe16(x) __bswap_16 (x)
++#  define htole16(x) (x)
++#  define be16toh(x) __bswap_16 (x)
++#  define le16toh(x) (x)
++
++#  define htobe32(x) __bswap_32 (x)
++#  define htole32(x) (x)
++#  define be32toh(x) __bswap_32 (x)
++#  define le32toh(x) (x)
++
++#  define htobe64(x) __bswap_64 (x)
++#  define htole64(x) (x)
++#  define be64toh(x) __bswap_64 (x)
++#  define le64toh(x) (x)
++# else
++#  define htobe16(x) (x)
++#  define htole16(x) __bswap_16 (x)
++#  define be16toh(x) (x)
++#  define le16toh(x) __bswap_16 (x)
++
++#  define htobe32(x) (x)
++#  define htole32(x) __bswap_32 (x)
++#  define be32toh(x) (x)
++#  define le32toh(x) __bswap_32 (x)
++
++#  define htobe64(x) (x)
++#  define htole64(x) __bswap_64 (x)
++#  define be64toh(x) (x)
++#  define le64toh(x) __bswap_64 (x)
++# endif
++#endif
++
+ #endif	/* endian.h */


### PR DESCRIPTION
fix #779

error was

```
  CC       iperf_time.lo
iperf_udp.c: In function 'iperf_udp_recv':
iperf_udp.c:110:6: warning: implicit declaration of function 'be64toh' [-Wimplicit-function-declaration]
iperf_udp.c: In function 'iperf_udp_send':
iperf_udp.c:230:2: warning: implicit declaration of function 'htobe64' [-Wimplicit-function-declaration]
```

actual bug: uclibc is outdated (last release 10 years ago)
and should be replaced with musl, but that is non-trivial

(should i remove the `pragma message` debug prints?)