### PR TITLE
read_env return code management in push_firmware

### DIFF
--- a/tools/push_firmware
+++ b/tools/push_firmware
@@ -78,7 +78,9 @@ quit" | ftp -v -n -p 2>/dev/null 1>&2 &
 	done
 	kill $bg_pid >/dev/null 2>&1  # this is needed as the FTP client freezes at the end of the file transfer
 	wait $bg_pid
+	[ $count -lt 10 -a -s "$tmpenv" ] || return 1
 	grep -qs ^wlan_ssid "$tmpenv" && dos2unix -q "$tmpenv" || rm -f "$tmpenv"
+	return 0
 }
 
 function read_enval() {
@@ -102,13 +104,17 @@ function push_fw() {
 	echo
 
 	wait_loader
-	read_env
+	if ! read_env; then
+		echo -e "\nIt appears that you are not actually connected to the device at boot time."
+		echo -e "Besides, the device shall be connected via Ethernet card (not Wi-Fi).\n"
+		exit 1
+	fi
 	for x in ProductID SerialNumber HWRevision HWSubRevision memsize linux_fs_start; do
 		eval env_$x="\$(read_enval '$x')"
 		eval echo -e "\ \ \ $x:\ \ \ \ \ \\\t   \$env_$x"
 	done
 	echo
-	[ "${PRODUCT% (*}" != "$env_ProductID" ] && echo "Error, ProductID of image does not match device"&& exit 1
+	[ "${PRODUCT% (*}" != "$env_ProductID" ] && echo "Error, ProductID of image does not match device" && exit 1
 
 	if [ -n "$ISRAM$ISFIT" ]; then
 		if [ "${FULLSIZE//0/}" == "x" ]; then


### PR DESCRIPTION
__read_env return code management in push_firmware__

This patch improves the management of some usage error cases.

A failure in reading the 'env' file produces the following error message:

    It appears that you are not actually connected to the device at boot time.
    Besides, the device shall be connected via Ethernet card (not Wi-Fi).

Without this patch, any read_env error (no variable valued) is caught by

```
	[ "${PRODUCT% (*}" != "$env_ProductID" ] && echo "Error, ProductID of image does not match device" && exit 1
```

which produces the improper message "Error, ProductID of image does not match device".