### PR TITLE
fixing bird compile errors with gcc10+

### DIFF
--- a/make/pkgs/bird/patches/104-fixGCC10.patch
+++ b/make/pkgs/bird/patches/104-fixGCC10.patch
@@ -1,0 +1,10 @@
+--- sysdep/unix/krt.h
++++ sysdep/unix/krt.h
+@@ -112,7 +112,7 @@ struct kif_proto {
+   struct kif_state sys;		/* Sysdep state */
+ };
+ 
+-struct kif_proto *kif_proto;
++extern struct kif_proto *kif_proto;
+ 
+ #define KIF_CF ((struct kif_config *)p->p.cf)


### PR DESCRIPTION
fixes krt.h:115: multiple definition of `kif_proto'; compiler error with GCC10+. package compiles fine now.