### PR TITLE
kconfig 6.2 fix patches

### DIFF
--- a/make/host-tools/kconfig-host/patches/630-fail_on_unmet_direct_dependency.patch
+++ b/make/host-tools/kconfig-host/patches/630-fail_on_unmet_direct_dependency.patch
@@ -1,6 +1,6 @@
 --- scripts/kconfig/symbol.c
 +++ scripts/kconfig/symbol.c
-@@ -301,7 +301,7 @@
+@@ -305,7 +305,7 @@
  	struct gstr gs = str_new();
  
  	str_printf(&gs,
@@ -9,11 +9,11 @@
  		   sym->name);
  	str_printf(&gs,
  		   "  Depends on [%c]: ",
-@@ -316,6 +316,7 @@
+@@ -319,6 +319,7 @@
+ 			       "  Selected by [m]:\n");
  
  	fputs(str_get(&gs), stderr);
- 	sym_warnings++;
 +	exit(1);
  }
  
- bool sym_dep_errors(void)
+ void sym_calc_value(struct symbol *sym)

--- a/make/host-tools/kconfig-host/patches/640-max_item_count_for_choice_dialog.patch
+++ b/make/host-tools/kconfig-host/patches/640-max_item_count_for_choice_dialog.patch
@@ -1,14 +1,14 @@
 --- scripts/kconfig/mconf.c
 +++ scripts/kconfig/mconf.c
-@@ -659,9 +659,9 @@
+@@ -826,9 +826,9 @@
  		dialog_clear();
  		res = dialog_checklist(prompt ? prompt : "Main Menu",
  					radiolist_instructions,
--					MENUBOX_HEIGHT_MIN,
-+					getmaxy(stdscr) - CHECKLIST_HEIGHT_MIN,
+-					MENUBOX_HEIGTH_MIN,
++					getmaxy(stdscr) - CHECKLIST_HEIGTH_MIN,
  					MENUBOX_WIDTH_MIN,
--					CHECKLIST_HEIGHT_MIN);
-+					getmaxy(stdscr) - MENUBOX_HEIGHT_MIN);
+-					CHECKLIST_HEIGTH_MIN);
++					getmaxy(stdscr) - MENUBOX_HEIGTH_MIN);
  		selected = item_activate_selected();
  		switch (res) {
  		case 0:


### PR DESCRIPTION
had to fix these patches to fix my custom build...

no idea why these patches work in the default build
does it ignore patch errors?

[scripts/kconfig/symbol.c](https://github.com/torvalds/linux/raw/v6.2/scripts/kconfig/symbol.c)

```c
	expr_gstr_print_revdep(sym->rev_dep.expr, &gs, mod,
			       "  Selected by [m]:\n");

	fputs(str_get(&gs), stderr);
}

void sym_calc_value(struct symbol *sym)
```

[scripts/kconfig/mconf.c](https://github.com/torvalds/linux/raw/v6.2/scripts/kconfig/mconf.c)

```c
		res = dialog_checklist(prompt ? prompt : "Main Menu",
					radiolist_instructions,
					MENUBOX_HEIGTH_MIN,
					MENUBOX_WIDTH_MIN,
					CHECKLIST_HEIGTH_MIN);
```

i also compared my sources to [kconfig-v6.2.tar.xz](https://github.com/Freetz-NG/dl-mirror/raw/master/kconfig-v6.2.tar.xz)
these are exactly the same files
