### PR TITLE
docker: switch to ubuntu 24

### DIFF
--- a/.github/docker/dl-packs/Dockerfile
+++ b/.github/docker/dl-packs/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 ARG BUILD_USER=builduser
 
 RUN \
@@ -7,8 +7,8 @@ RUN \
     bash locales libarchive-zip-perl  \
     pv cpio rsync kmod imagemagick inkscape graphicsmagick subversion git bc unar wget sudo gcc g++ binutils autoconf automake \
     autopoint libtool-bin make bzip2 libncurses5-dev libreadline-dev zlib1g-dev flex bison patch texinfo tofrodos gettext pkg-config ecj \
-    perl libstring-crc32-perl ruby ruby1.9 gawk libusb-dev unzip intltool libacl1-dev libcap-dev libc6-dev-i386 lib32ncurses5-dev \
-    gcc-multilib bsdmainutils lib32stdc++6 libglib2.0-dev ccache cmake lib32z1-dev libsqlite3-dev sqlite3 libzstd-dev netcat curl \
+    perl libstring-crc32-perl ruby ruby1.9 gawk libusb-dev unzip intltool libacl1-dev libcap-dev libc6-dev-i386 lib32ncurses-dev \
+    gcc-multilib bsdmainutils lib32stdc++6 libglib2.0-dev ccache cmake lib32z1-dev libsqlite3-dev sqlite3 libzstd-dev netcat-openbsd curl \
     uuid-dev libssl-dev libgnutls28-dev u-boot-tools device-tree-compiler openssl build-essential libelf-dev patchutils \
  && DEBIAN_FRONTEND=noninteractive apt-get -y clean \
  && rm -rf /var/lib/apt/lists/* \

--- a/.github/docker/firmware/Dockerfile
+++ b/.github/docker/firmware/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 ARG BUILD_USER=builduser
 
 RUN \
@@ -8,8 +8,8 @@ RUN \
     pv cpio rsync kmod imagemagick inkscape graphicsmagick subversion git bc unar wget sudo gcc g++ binutils autoconf automake \
     autopoint libtool-bin make bzip2 libncurses5-dev libreadline-dev zlib1g-dev flex bison patch texinfo tofrodos gettext pkg-config ecj \
     perl libstring-crc32-perl ruby gawk libusb-dev unzip intltool libacl1-dev libcap-dev libc6-dev-i386 \
-    lib32ncurses5-dev gcc-multilib bsdmainutils lib32stdc++6 libglib2.0-dev ccache cmake lib32z1-dev libsqlite3-dev sqlite3 libzstd-dev \
-    netcat curl uuid-dev libssl-dev libgnutls28-dev u-boot-tools device-tree-compiler libelf-dev patchutils \
+    lib32ncurses-dev gcc-multilib bsdmainutils lib32stdc++6 libglib2.0-dev ccache cmake lib32z1-dev libsqlite3-dev sqlite3 libzstd-dev \
+    netcat-openbsd curl uuid-dev libssl-dev libgnutls28-dev u-boot-tools device-tree-compiler libelf-dev patchutils \
  && DEBIAN_FRONTEND=noninteractive apt-get -y clean \
  && rm -rf /var/lib/apt/lists/* \
  && locale-gen en_US.utf8 && locale-gen de_DE.UTF-8 && update-locale \

--- a/.github/docker/generate/Dockerfile
+++ b/.github/docker/generate/Dockerfile
@@ -1,10 +1,10 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 ARG BUILD_USER=builduser
 
 RUN \
     apt-get -y update && apt-get -y upgrade && apt-get -y dist-upgrade \
  && DEBIAN_FRONTEND=noninteractive apt-get -y install \
-    git bash locales imagemagick netcat curl bsdmainutils xxd libarchive-zip-perl wget \
+    git bash locales imagemagick netcat-openbsd curl bsdmainutils xxd libarchive-zip-perl wget \
  && DEBIAN_FRONTEND=noninteractive apt-get -y clean \
  && rm -rf /var/lib/apt/lists/* \
  && locale-gen en_US.utf8 && locale-gen de_DE.UTF-8 && update-locale \


### PR DESCRIPTION
this upgrades the base images for the docker images to ubuntu 24.04 and fixes build errors that occur because some package names have changed since ubuntu 24.04.