### PR TITLE
juis action: bump labor+inhaus fos version

### DIFF
--- a/docs/juis/generate.sh
+++ b/docs/juis/generate.sh
@@ -25,11 +25,11 @@ cat fos-dwn fos-rel | sort -u > fos-xxx
 
 #lab
 echo -e '\n### FOS-Labor ##################################################'
-for x in $(seq 150 300); do  [ "$x" -lt 248 ] 2>/dev/null && m="$(( $x - 72 ))" || m=$x; m="$m.07.50-100000"
+for x in $(seq 150 300); do  [ "$x" -lt 248 ] 2>/dev/null && m="$(( $x - 72 ))" || m=$x; m="$m.07.90-100000"
                              env - $TOOLS/juis_check        HW=$x         Buildtype=1001  Version=$m  -a; done | tee fos-lab
 #inh
 echo -e '\n### FOS-Inhaus #################################################'
-for x in $(seq 150 300); do  [ "$x" -lt 248 ] 2>/dev/null && m="$(( $x - 72 ))" || m=$x; m="$m.07.50-100000"
+for x in $(seq 150 300); do  [ "$x" -lt 248 ] 2>/dev/null && m="$(( $x - 72 ))" || m=$x; m="$m.07.90-100000"
                              env - $TOOLS/juis_check        HW=$x         Buildtype=1000  Version=$m  -a; done | tee fos-inh
 #sub
 cat fos-xxx | while read -s x; do sed "/^${x//\//\\\/}$/d" -i fos-lab fos-inh; done


### PR DESCRIPTION
This fixes the detection of, among other things, laboratory firmware for fritzboxes over 07.90-100000

```diff
 ### FOS-Labor
  - HWR 185: [FRITZ.Box_7490-07.59.image](http://download.avm.de/fritzbox/fritzbox-7490/deutschland/fritz.os/FRITZ.Box_7490-07.59.image)
  - HWR 190: [FRITZ.Powerline_546E.118.07.15.image](http://download.avm.de/fritzpowerline/fritzpowerline-546e/deutschland/fritz.os/FRITZ.Powerline_546E.118.07.15.image)
+ - HWR 226: [FRITZ.Box_7590-07.90-114019-LabBETA.image](http://download.avm.de/labor/Smart24P1/7590/FRITZ.Box_7590-07.90-114019-LabBETA.image)
+ - HWR 233: [FRITZ.Box_6591_Cable-07.90-114051-LabBETA.image](http://download.avm.de/labor/Smart24P1/6591Cable/FRITZ.Box_6591_Cable-07.90-114051-LabBETA.image)
  - HWR 239: [FRITZ.Box_7583-07.39-103075-LabBETA.image](http://download.avm.de/labor/MOVE21/7583/FRITZ.Box_7583-07.39-103075-LabBETA.image)
  - HWR 260: [FRITZ.Box_7583_VDSL-07.39-103078-LabBETA.image](http://download.avm.de/labor/MOVE21/7583VDSL/FRITZ.Box_7583_VDSL-07.39-103078-LabBETA.image)
```
