### PR TITLE
mosquitto: extra was not available

### DIFF
--- a/make/pkgs/mosquitto/files/root/etc/init.d/rc.mosquitto
+++ b/make/pkgs/mosquitto/files/root/etc/init.d/rc.mosquitto
@@ -25,7 +25,7 @@ case "$1" in
 
 		modreg cgi $DAEMON "$DAEMON_LONG_NAME"
 		modreg daemon $DAEMON
-		modreg file $DAEMON extra 'extra' 0 $DAEMON_extra
+		modreg file $DAEMON extra 'extra' 0 mosquitto_extra
 
 		modlib_start $MOSQUITTO_ENABLED
 		;;


### PR DESCRIPTION
`$DAEMON_extra` was not expanded/resolved, so we have to use
- `${DAEMON}_extra` or
- `mosquitto_extra`

I chose the last one (`mosquitto_extra`) since more common in freetz-ng