### PR TITLE
prerequisites: Correct zlib-devel package name

### DIFF
--- a/tools/.prerequisites/Fedora40
+++ b/tools/.prerequisites/Fedora40
@@ -57,4 +57,4 @@ unar
 util-linux
 wget
 xz
-zlib-devel
+zlib-ng-devel


### PR DESCRIPTION
Fedora 40 replaced the package "zlilb-devel" with "zlib-ng-devel"