### PR TITLE
vlmcsd added

### DIFF
--- a/.github/workflows/Build_7490.yml
+++ b/.github/workflows/Build_7490.yml
@@ -1,0 +1,91 @@
+name: Build 7490 image
+
+on: workflow_dispatch
+#  push:
+#    branches: [ "master" ]
+#    tags:
+#      - "v*"
+#  pull_request:
+#    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Cache dependencies
+      id: cache-deps
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/tools-prerequisites
+        key: ${{ runner.os }}-tools-prerequisites-${{ hashFiles('path/to/dependencies') }}
+        restore-keys: |
+          ${{ runner.os }}-tools-prerequisites-
+    - name: Install dependencies
+      run: tools/prerequisites install -y
+      if: steps.cache-deps.outputs.cache-hit != 'true'
+
+    - name: Copy addons
+      run:  tar xvfz addon/addons.tar.gz -C $HOME/
+      id: copy-addons
+      
+    - name: Configure
+      run: |
+        cat config7490 > .config
+        make oldconfig
+    - name: Cache build output
+      id: cache-build
+      uses: actions/cache@v3
+      with:
+        path: build
+        key: ${{ runner.os }}-build-${{ hashFiles('.config', 'Makefile') }}
+        restore-keys: |
+          ${{ runner.os }}-build-
+    - name: Build
+      run: make
+
+    - name: Create/Update TAG Name
+      id: update_tag
+      run: |
+        firmware_number=$(cat ${{ github.workspace }}/build/original/firmware/var/version | cut -d= -f2 | cut -d, -f1)
+        export FIRMWARE_NUMBER=$firmware_number
+        echo FIRMWARE_NUMBER=$firmware_number >> $GITHUB_ENV
+        current_date=$(date +'%d%m%Y_%H%M%S')
+        firmware_number_with_date="7490_${firmware_number}.${current_date}"
+        export TAG_NAME=$firmware_number_with_date
+        echo TAG_NAME=$firmware_number_with_date >> $GITHUB_ENV
+      shell: bash
+    
+    - name: Find IMAGE_PATH
+      id: find_image_path
+      run: |
+        image_path=`find ${{ github.workspace }}/images -name "*.image" -type f | grep 7490`
+        image_path=$(printf '%q' "$image_path")
+        export IMG_PATH=$image_path
+        echo "IMG_PATH=$image_path" >> $GITHUB_ENV
+        asset_path=$(basename "$image_path")
+        echo "ASSET_PATH=$asset_path" >> $GITHUB_ENV
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ env.TAG_NAME }}
+        release_name: Release 7490-${{ env.FIRMWARE_NUMBER }}
+        allowUpdates: true
+        draft: false
+        prerelease: false
+
+    - name: Upload Release Asset
+      id: upload-release-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ${{ env.IMG_PATH }}
+        asset_name: ${{ env.ASSET_PATH }}
+        asset_content_type: application/zip

--- a/.github/workflows/Build_7490.yml
+++ b/.github/workflows/Build_7490.yml
@@ -27,10 +27,6 @@ jobs:
       run: tools/prerequisites install -y
       if: steps.cache-deps.outputs.cache-hit != 'true'
 
-    - name: Copy addons
-      run:  tar xvfz addon/addons.tar.gz -C $HOME/
-      id: copy-addons
-      
     - name: Configure
       run: |
         cat config7490 > .config

--- a/.github/workflows/Build_7590.yml
+++ b/.github/workflows/Build_7590.yml
@@ -28,7 +28,7 @@ jobs:
       if: steps.cache-deps.outputs.cache-hit != 'true'
 
     - name: Get firmware
-      run: wget https://download.avm.de/fritzbox/fritzbox-7590/deutschland/fritz.os/FRITZ.Box_7590-08.00.image -P ${{ runner.home }}/.freetz-dl/fw
+      run: wget https://download.avm.de/fritzbox/fritzbox-7590/deutschland/fritz.os/FRITZ.Box_7590-08.00.image -P $HOME/.freetz-dl/fw
       
     - name: Configure
       run: |

--- a/.github/workflows/Build_7590.yml
+++ b/.github/workflows/Build_7590.yml
@@ -27,10 +27,6 @@ jobs:
       run: tools/prerequisites install -y
       if: steps.cache-deps.outputs.cache-hit != 'true'
 
-    - name: Copy addons
-      run:  tar xvfz addon/addons.tar.gz -C $HOME/
-      id: copy-addons
-      
     - name: Configure
       run: |
         cat config7590 > .config

--- a/.github/workflows/Build_7590.yml
+++ b/.github/workflows/Build_7590.yml
@@ -1,0 +1,91 @@
+name: Build 7590 image
+
+on: workflow_dispatch
+#  push:
+#    branches: [ "master" ]
+#    tags:
+#      - "v*"
+#  pull_request:
+#    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Cache dependencies
+      id: cache-deps
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/tools-prerequisites
+        key: ${{ runner.os }}-tools-prerequisites-${{ hashFiles('path/to/dependencies') }}
+        restore-keys: |
+          ${{ runner.os }}-tools-prerequisites-
+    - name: Install dependencies
+      run: tools/prerequisites install -y
+      if: steps.cache-deps.outputs.cache-hit != 'true'
+
+    - name: Copy addons
+      run:  tar xvfz addon/addons.tar.gz -C $HOME/
+      id: copy-addons
+      
+    - name: Configure
+      run: |
+        cat config7590 > .config
+        make oldconfig
+    - name: Cache build output
+      id: cache-build
+      uses: actions/cache@v3
+      with:
+        path: build
+        key: ${{ runner.os }}-build-${{ hashFiles('.config', 'Makefile') }}
+        restore-keys: |
+          ${{ runner.os }}-build-
+    - name: Build
+      run: make
+
+    - name: Create/Update TAG Name
+      id: update_tag
+      run: |
+        firmware_number=$(cat ${{ github.workspace }}/build/original/firmware/var/version | cut -d= -f2 | cut -d, -f1)
+        export FIRMWARE_NUMBER=$firmware_number
+        echo FIRMWARE_NUMBER=$firmware_number >> $GITHUB_ENV
+        current_date=$(date +'%d%m%Y_%H%M%S')
+        firmware_number_with_date="7590_${firmware_number}.${current_date}"
+        export TAG_NAME=$firmware_number_with_date
+        echo TAG_NAME=$firmware_number_with_date >> $GITHUB_ENV
+      shell: bash
+    
+    - name: Find IMAGE_PATH
+      id: find_image_path
+      run: |
+        image_path=`find ${{ github.workspace }}/images -name "*.image" -type f | grep 7590`
+        image_path=$(printf '%q' "$image_path")
+        export IMG_PATH=$image_path
+        echo "IMG_PATH=$image_path" >> $GITHUB_ENV
+        asset_path=$(basename "$image_path")
+        echo "ASSET_PATH=$asset_path" >> $GITHUB_ENV
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ env.TAG_NAME }}
+        release_name: Release 7590-${{ env.FIRMWARE_NUMBER }}
+        allowUpdates: true
+        draft: false
+        prerelease: false
+
+    - name: Upload Release Asset
+      id: upload-release-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ${{ env.IMG_PATH }}
+        asset_name: ${{ env.ASSET_PATH }}
+        asset_content_type: application/zip

--- a/.github/workflows/Build_7590.yml
+++ b/.github/workflows/Build_7590.yml
@@ -27,6 +27,9 @@ jobs:
       run: tools/prerequisites install -y
       if: steps.cache-deps.outputs.cache-hit != 'true'
 
+    - name: Get firmware
+      run: wget https://download.avm.de/fritzbox/fritzbox-7590/deutschland/fritz.os/FRITZ.Box_7590-08.00.image -P ${{ runner.home }}//.freetz-dl/fw
+      
     - name: Configure
       run: |
         cat config7590 > .config

--- a/.github/workflows/Build_7590.yml
+++ b/.github/workflows/Build_7590.yml
@@ -28,7 +28,7 @@ jobs:
       if: steps.cache-deps.outputs.cache-hit != 'true'
 
     - name: Get firmware
-      run: wget https://download.avm.de/fritzbox/fritzbox-7590/deutschland/fritz.os/FRITZ.Box_7590-08.00.image -P ${{ runner.home }}//.freetz-dl/fw
+      run: wget https://download.avm.de/fritzbox/fritzbox-7590/deutschland/fritz.os/FRITZ.Box_7590-08.00.image -P ${{ runner.home }}/.freetz-dl/fw
       
     - name: Configure
       run: |

--- a/config7490
+++ b/config7490
@@ -1,0 +1,3208 @@
+#
+# Automatically generated file; DO NOT EDIT.
+# Freetz Configuration
+#
+FREETZ_HAVE_DOT_CONFIG=y
+
+#
+# Freetz revision  -----------------------------------------
+#
+
+#
+#  freetz-ng 23876M-59831cbff master 2024-06-15
+#
+
+#
+# User competence ------------------------------------------
+#
+# FREETZ_USER_LEVEL_BEGINNER is not set
+FREETZ_USER_LEVEL_EXPERT=y
+# FREETZ_USER_LEVEL_DEVELOPER is not set
+FREETZ_SHOW_EXPERT=y
+
+#
+# Hardware/Firmware ----------------------------------------
+#
+
+#
+# Hardware series
+#
+# FREETZ_SERIES_X is not set
+FREETZ_SERIES_6=y
+FREETZ_SERIES_5=y
+FREETZ_SERIES_4=y
+# FREETZ_SERIES_3 is not set
+# FREETZ_SERIES_2 is not set
+# FREETZ_SERIES_1 is not set
+# FREETZ_SERIES_0 is not set
+
+#
+# 
+#
+# FREETZ_SERIES_ALL is not set
+# end of Hardware series
+
+#
+# WLAN
+#
+# FREETZ_TYPE_3490 is not set
+
+#
+# WAN
+#
+# FREETZ_TYPE_4020 is not set
+# FREETZ_TYPE_4040 is not set
+# FREETZ_TYPE_4050 is not set
+# FREETZ_TYPE_4060 is not set
+
+#
+# Fiber
+#
+# FREETZ_TYPE_5490 is not set
+# FREETZ_TYPE_5491 is not set
+# FREETZ_TYPE_5590 is not set
+# FREETZ_TYPE_5690 is not set
+
+#
+# Cable
+#
+# FREETZ_TYPE_6430 is not set
+# FREETZ_TYPE_6490 is not set
+# FREETZ_TYPE_6590 is not set
+# FREETZ_TYPE_6591 is not set
+# FREETZ_TYPE_6660 is not set
+# FREETZ_TYPE_6670 is not set
+# FREETZ_TYPE_6690 is not set
+
+#
+# LTE
+#
+# FREETZ_TYPE_6820_V1 is not set
+# FREETZ_TYPE_6820_V2 is not set
+# FREETZ_TYPE_6820_V3 is not set
+# FREETZ_TYPE_6850_4G is not set
+# FREETZ_TYPE_6850_5G is not set
+# FREETZ_TYPE_6890 is not set
+
+#
+# Fon WLAN
+#
+# FREETZ_TYPE_7412 is not set
+# FREETZ_TYPE_7430 is not set
+FREETZ_TYPE_7490=y
+# FREETZ_TYPE_7510 is not set
+# FREETZ_TYPE_7520 is not set
+# FREETZ_TYPE_7521 is not set
+# FREETZ_TYPE_7530 is not set
+# FREETZ_TYPE_7539 is not set
+# FREETZ_TYPE_7560 is not set
+# FREETZ_TYPE_7580 is not set
+# FREETZ_TYPE_7581 is not set
+# FREETZ_TYPE_7582 is not set
+# FREETZ_TYPE_7583 is not set
+# FREETZ_TYPE_7584 is not set
+# FREETZ_TYPE_7590 is not set
+# FREETZ_TYPE_7599 is not set
+# FREETZ_TYPE_7690 is not set
+FREETZ_TYPE_LANG_DE=y
+# FREETZ_TYPE_LANG_EN is not set
+FREETZ_TYPE_LANGUAGE="xx"
+# FREETZ_TYPE_FIRMWARE_06_2X is not set
+# FREETZ_TYPE_FIRMWARE_06_5X is not set
+# FREETZ_TYPE_FIRMWARE_06_8X is not set
+# FREETZ_TYPE_FIRMWARE_06_9X is not set
+# FREETZ_TYPE_FIRMWARE_07_0X is not set
+# FREETZ_TYPE_FIRMWARE_07_1X is not set
+# FREETZ_TYPE_FIRMWARE_07_2X is not set
+FREETZ_TYPE_FIRMWARE_07_5X=y
+
+#
+#  >> This firmware fits on AVM and AVME devices
+#
+FREETZ_AVM_VERSION_LATEST_MAJOR=y
+FREETZ_TYPE_FIRMWARE_DETECT_LATEST=y
+FREETZ_TYPE_FIRMWARE_FINAL=y
+
+#
+# Original components --------------------------------------
+#
+FREETZ_TARGET_IPV6_SUPPORT=y
+# FREETZ_REPLACE_KERNEL is not set
+
+#
+# Removal patches
+#
+# FREETZ_SELECT_HARDENING is not set
+
+#
+# Removal patches ------------------------------------------
+#
+FREETZ_REMOVE_LEFTOVER=y
+# FREETZ_REMOVE_MULTI_ANNEX_FIRMWARE_DIFFS is not set
+# FREETZ_REMOVE_DSLD is not set
+# FREETZ_REMOVE_SHOWDSLDSTAT is not set
+# FREETZ_REMOVE_ASSISTANT is not set
+# FREETZ_REMOVE_PCPD is not set
+# FREETZ_REMOVE_PLCD is not set
+# FREETZ_REMOVE_MESHD is not set
+# FREETZ_REMOVE_NEXUS is not set
+# FREETZ_REMOVE_AHA is not set
+# FREETZ_REMOVE_AURA_USB is not set
+# FREETZ_REMOVE_WEBDAV is not set
+# FREETZ_REMOVE_MEDIASRV is not set
+# FREETZ_REMOVE_NAS is not set
+# FREETZ_REMOVE_MYFRITZ is not set
+# FREETZ_REMOVE_DDNSD is not set
+# FREETZ_REMOVE_AVM_VPN is not set
+# FREETZ_REMOVE_AVM_WIREGUARD is not set
+# FREETZ_REMOVE_AVMCOUNTERD is not set
+# FREETZ_REMOVE_LANGUAGE is not set
+# FREETZ_REMOVE_BRANDING is not set
+# FREETZ_REMOVE_CAPIOVERTCP is not set
+FREETZ_REMOVE_CHRONYD=y
+# FREETZ_REMOVE_DECT is not set
+FREETZ_REMOVE_DTRACE=y
+# FREETZ_REMOVE_FTPD is not set
+# FREETZ_REMOVE_HELP is not set
+# FREETZ_REMOVE_LIBFUSE is not set
+# FREETZ_REMOVE_FAT is not set
+# FREETZ_REMOVE_NTFS is not set
+# FREETZ_REMOVE_NLS is not set
+# FREETZ_REMOVE_USBHOST is not set
+# FREETZ_REMOVE_PRINTSERV is not set
+# FREETZ_REMOVE_RUNCLOCK is not set
+# FREETZ_REMOVE_SAMBA is not set
+# FREETZ_REMOVE_SUPPORT is not set
+# FREETZ_REMOVE_PUBKEY is not set
+# FREETZ_REMOVE_TR069 is not set
+# FREETZ_REMOVE_UMTSD is not set
+# FREETZ_REMOVE_UPNP is not set
+# FREETZ_REMOVE_KIDS is not set
+# FREETZ_REMOVE_QOS is not set
+# end of Removal patches
+
+#
+# Other patches
+#
+
+#
+# Web menu patches -----------------------------------------
+#
+# FREETZ_PATCH_ATA is not set
+# FREETZ_PATCH_FAXPAGES is not set
+# FREETZ_PATCH_GSMVOICE is not set
+# FREETZ_PATCH_SIGNED is not set
+# FREETZ_PATCH_SECURE is not set
+# FREETZ_MODIFY_DSL_WARNING is not set
+# FREETZ_MODIFY_DSL_SPECTRUM is not set
+# FREETZ_MODIFY_DSL_SETTINGS is not set
+# FREETZ_MODIFY_COUNTER is not set
+# FREETZ_PATCH_MODFS_BOOT_MANAGER is not set
+
+#
+# USB patches ----------------------------------------------
+#
+FREETZ_PATCH_UDEVMOUNT=y
+
+#
+# Intern NTFS
+#
+
+#
+# Intern Fat
+#
+
+#
+# Intern Ext2
+#
+
+#
+# Intern Ext3
+#
+
+#
+# Intern Ext4
+#
+# FREETZ_UDEVMOUNT_HFS is not set
+# FREETZ_UDEVMOUNT_HFS_PLUS is not set
+# FREETZ_UDEVMOUNT_REISER_FS is not set
+# FREETZ_PATCH_MAXDEVCOUNT is not set
+# FREETZ_CUSTOM_UDEV_RULES is not set
+# FREETZ_DROP_NOEXEC_EXTERNAL is not set
+
+#
+# Replacement patches --------------------------------------
+#
+# FREETZ_REPLACE_DTRACE is not set
+# FREETZ_REPLACE_ONLINECHANGED is not set
+
+#
+# Additional patches ---------------------------------------
+#
+# FREETZ_ADD_SWAPOPTIONS is not set
+# FREETZ_ADD_TELNETD is not set
+# FREETZ_ADD_ETCNETCONFIG is not set
+FREETZ_CUSTOM_ETCSERVICES=y
+FREETZ_ENFORCE_TMP_PERMISSIONS=y
+FREETZ_ENFORCE_BRANDING_none=y
+# FREETZ_ENFORCE_BRANDING_1und1 is not set
+# FREETZ_ENFORCE_BRANDING_avm is not set
+# FREETZ_ENFORCE_BRANDING_avme is not set
+
+#
+# Misc patches ---------------------------------------------
+#
+# FREETZ_DISABLE_SERIAL_CONSOLE is not set
+# FREETZ_RUN_TELEFON_IN_INHAUS_MODE is not set
+
+#
+# AVM daemons ----------------------------------------------
+#
+# FREETZ_AVMDAEMON_DISABLE_IGD is not set
+# FREETZ_AVMDAEMON_DISABLE_IGM is not set
+# FREETZ_AVMDAEMON_DISABLE_TR069 is not set
+FREETZ_AVMDAEMON_DISABLE_MULTIDPORTS=y
+FREETZ_AVMDAEMON_DISABLE_DNS=y
+FREETZ_AVMDAEMON_DISABLE_DHCP=y
+FREETZ_AVMDAEMON_DISABLE_LLMNR=y
+# end of Other patches
+
+#
+# Additional components ------------------------------------
+#
+
+#
+# Packages
+#
+
+#
+# A
+#
+# FREETZ_PACKAGE_ACME is not set
+# FREETZ_PACKAGE_APACHE2 is not set
+# FREETZ_PACKAGE_ATOP is not set
+# FREETZ_PACKAGE_AUTOFS is not set
+# FREETZ_PACKAGE_AUTOSSH is not set
+# FREETZ_PACKAGE_AVAHI is not set
+# end of A
+
+#
+# B
+#
+# FREETZ_PACKAGE_BASH is not set
+# FREETZ_PACKAGE_BFTPD is not set
+# FREETZ_PACKAGE_BFUSB is not set
+# FREETZ_PACKAGE_BIND is not set
+# FREETZ_PACKAGE_BIP is not set
+# FREETZ_PACKAGE_BIRD is not set
+# FREETZ_PACKAGE_BITTWIST is not set
+# FREETZ_PACKAGE_BLUEZ_UTILS is not set
+# FREETZ_PACKAGE_BRIDGE_UTILS is not set
+# FREETZ_PACKAGE_BVI is not set
+# end of B
+
+#
+# C
+#
+FREETZ_PACKAGE_CA_BUNDLE=y
+# FREETZ_PACKAGE_CALLMONITOR is not set
+# FREETZ_PACKAGE_CCID is not set
+# FREETZ_PACKAGE_CHECKMAILD is not set
+# FREETZ_PACKAGE_CIFSMOUNT is not set
+# FREETZ_PACKAGE_CLASSPATH is not set
+# FREETZ_PACKAGE_CNTLM is not set
+# FREETZ_PACKAGE_COMGT is not set
+# FREETZ_PACKAGE_CRYPTSETUP is not set
+# FREETZ_PACKAGE_CTORRENT is not set
+# FREETZ_PACKAGE_CURL is not set
+# FREETZ_PACKAGE_CURLFTPFS is not set
+# end of C
+
+#
+# D
+#
+# FREETZ_PACKAGE_DANTE is not set
+# FREETZ_PACKAGE_DAVFS2 is not set
+# FREETZ_PACKAGE_DBUS is not set
+# FREETZ_PACKAGE_DEBOOTSTRAP is not set
+# FREETZ_PACKAGE_DECO is not set
+# FREETZ_PACKAGE_DECRYPT_FRITZOS_CFG is not set
+# FREETZ_PACKAGE_DEHYDRATED is not set
+# FREETZ_PACKAGE_DEJAVU_FONTS_TTF is not set
+# FREETZ_PACKAGE_DIGITEMP is not set
+# FREETZ_PACKAGE_DNS2TCP is not set
+# FREETZ_PACKAGE_DNSMASQ is not set
+# FREETZ_PACKAGE_DOSFSTOOLS is not set
+FREETZ_PACKAGE_DROPBEAR=y
+FREETZ_PACKAGE_DROPBEAR_SFTP_SERVER=y
+# FREETZ_PACKAGE_DROPBEAR_SERVER_ONLY is not set
+# FREETZ_PACKAGE_DROPBEAR_WITH_ZLIB is not set
+FREETZ_PACKAGE_DROPBEAR_DISABLE_HOST_LOOKUP=y
+# FREETZ_PACKAGE_DROPBEAR_ENABLE_MOTD is not set
+# FREETZ_PACKAGE_DROPBEAR_UTMP is not set
+# FREETZ_PACKAGE_DROPBEAR_WTMP is not set
+# FREETZ_PACKAGE_DROPBEAR_STATIC is not set
+FREETZ_PACKAGE_DROPBEAR_AUTHORIZED_KEYS=y
+# FREETZ_PACKAGE_DROPBEAR_NONFREETZ is not set
+# FREETZ_PACKAGE_DTACH is not set
+# FREETZ_PACKAGE_DTC is not set
+# FREETZ_PACKAGE_DVBSNOOP is not set
+# FREETZ_PACKAGE_DVBSTREAM is not set
+# FREETZ_PACKAGE_DVBTUNE is not set
+# end of D
+
+#
+# E
+#
+# FREETZ_PACKAGE_EMAILRELAY is not set
+# FREETZ_PACKAGE_EMPTY is not set
+# FREETZ_PACKAGE_ESPEAK is not set
+# end of E
+
+#
+# F
+#
+# FREETZ_PACKAGE_FFMPEG is not set
+# FREETZ_PACKAGE_FORTUNE is not set
+# FREETZ_PACKAGE_FOWSR is not set
+# FREETZ_PACKAGE_FTDI1 is not set
+# FREETZ_PACKAGE_FUSE is not set
+# end of F
+
+#
+# G
+#
+# FREETZ_PACKAGE_GETDNS is not set
+# FREETZ_PACKAGE_GHOSTSCRIPT_FONTS is not set
+# FREETZ_PACKAGE_GIT is not set
+# FREETZ_PACKAGE_GNTPSEND is not set
+# FREETZ_PACKAGE_GNU_MAKE is not set
+# FREETZ_PACKAGE_GNUTLS is not set
+# FREETZ_PACKAGE_GOCR is not set
+# FREETZ_PACKAGE_GW6 is not set
+# end of G
+
+#
+# H
+#
+# FREETZ_PACKAGE_HAPROXY is not set
+FREETZ_PACKAGE_HASERL=y
+# FREETZ_PACKAGE_HASERL_WITH_LUA is not set
+# FREETZ_PACKAGE_HD_IDLE is not set
+# FREETZ_PACKAGE_HDPARM is not set
+# FREETZ_PACKAGE_HOL is not set
+# FREETZ_PACKAGE_HTML2TEXT is not set
+# FREETZ_PACKAGE_HTOP is not set
+# FREETZ_PACKAGE_HTPDATE is not set
+# FREETZ_PACKAGE_HTTPRY is not set
+# FREETZ_PACKAGE_HTTPTUNNEL is not set
+# end of H
+
+#
+# I
+#
+# FREETZ_PACKAGE_IFSTAT is not set
+# FREETZ_PACKAGE_IFTOP is not set
+# FREETZ_PACKAGE_IGMPPROXY is not set
+# FREETZ_PACKAGE_IMAGEMAGICK is not set
+# FREETZ_PACKAGE_INADYN_MT is not set
+# FREETZ_PACKAGE_INADYN_OPENDNS is not set
+FREETZ_PACKAGE_INETD=y
+# FREETZ_PACKAGE_INETD_TIME is not set
+# FREETZ_PACKAGE_IODINE is not set
+# FREETZ_PACKAGE_IPERF is not set
+# FREETZ_PACKAGE_IPTRAF is not set
+# FREETZ_PACKAGE_IPUTILS is not set
+# FREETZ_PACKAGE_IRSSI is not set
+# FREETZ_PACKAGE_ISC_DHCP is not set
+# end of I
+
+#
+# J
+#
+# FREETZ_PACKAGE_JAMVM is not set
+# FREETZ_PACKAGE_JQ is not set
+# FREETZ_PACKAGE_JS is not set
+FREETZ_PACKAGE_JUIS_CHECK=y
+# end of J
+
+#
+# K
+#
+# FREETZ_PACKAGE_KNOCK is not set
+# end of K
+
+#
+# L
+#
+# FREETZ_PACKAGE_LCD4LINUX is not set
+# FREETZ_PACKAGE_LFTP is not set
+# FREETZ_PACKAGE_LIGHTTPD is not set
+# FREETZ_PACKAGE_LUA is not set
+# FREETZ_PACKAGE_LYNX is not set
+# end of L
+
+#
+# M
+#
+# FREETZ_PACKAGE_MADPLAY is not set
+FREETZ_PACKAGE_MC=y
+# FREETZ_PACKAGE_MC_WITH_NCURSES is not set
+FREETZ_PACKAGE_MC_WITH_NCURSESW=y
+# FREETZ_PACKAGE_MC_WITH_SLANG is not set
+# FREETZ_PACKAGE_MC_WITH_BACKGROUND is not set
+# FREETZ_PACKAGE_MC_WITH_CHARSET is not set
+FREETZ_PACKAGE_MC_WITH_INTERNAL_EDIT=y
+# FREETZ_PACKAGE_MC_WITH_DIFF_VIEWER is not set
+FREETZ_PACKAGE_MC_WITH_SUBSHELL=y
+# FREETZ_PACKAGE_MC_WITH_VFS is not set
+FREETZ_PACKAGE_MC_WITH_HELP=y
+FREETZ_PACKAGE_MC_WITH_SYNTAX=y
+# FREETZ_PACKAGE_MCABBER is not set
+# FREETZ_PACKAGE_MEDIATOMB is not set
+# FREETZ_PACKAGE_MICROPERL is not set
+# FREETZ_PACKAGE_MINI_SNMPD is not set
+# FREETZ_PACKAGE_MINICOM is not set
+# FREETZ_PACKAGE_MINIDLNA is not set
+# FREETZ_PACKAGE_MINISATIP is not set
+FREETZ_PACKAGE_MOD=y
+FREETZ_PACKAGE_MODCGI=y
+# FREETZ_PACKAGE_MODULE_INIT_TOOLS is not set
+# FREETZ_PACKAGE_MOSQUITTO is not set
+# FREETZ_PACKAGE_MTR is not set
+# end of M
+
+#
+# N
+#
+# FREETZ_PACKAGE_NAGIOS is not set
+# FREETZ_PACKAGE_NANO is not set
+# FREETZ_PACKAGE_NC6 is not set
+# FREETZ_PACKAGE_NCFTP is not set
+# FREETZ_PACKAGE_NETATALK is not set
+# FREETZ_PACKAGE_NETCAT is not set
+# FREETZ_PACKAGE_NETPBM is not set
+# FREETZ_PACKAGE_NETSNMP is not set
+# FREETZ_PACKAGE_NFS_UTILS is not set
+
+#
+# NFS-root (not available, needs replace kernel)
+#
+# FREETZ_PACKAGE_NGIRCD is not set
+# FREETZ_PACKAGE_NMAP is not set
+# FREETZ_PACKAGE_NOIP is not set
+# FREETZ_PACKAGE_NZBGET is not set
+# end of N
+
+#
+# O
+#
+# FREETZ_PACKAGE_OBEXFTP is not set
+# FREETZ_PACKAGE_OIDENTD is not set
+# FREETZ_PACKAGE_OPENCONNECT is not set
+# FREETZ_PACKAGE_OPENDD is not set
+# FREETZ_PACKAGE_OPENNTPD is not set
+FREETZ_PACKAGE_OPENSSH=y
+FREETZ_PACKAGE_OPENSSH_VERSION_CURRENT=y
+FREETZ_PACKAGE_OPENSSH_AUTHORIZED_KEYS=y
+# FREETZ_PACKAGE_OPENSSH_sshd is not set
+
+#
+# SSH client (ssh) (not available, provided by dropbear)
+#
+
+#
+# Secure copy (scp) (not available, provided by dropbear)
+#
+# FREETZ_PACKAGE_OPENSSH_CLIENTUTILS is not set
+# FREETZ_PACKAGE_OPENSSH_KEYUTILS is not set
+# FREETZ_PACKAGE_OPENSSH_sftp is not set
+FREETZ_PACKAGE_OPENSSH_sftp_server=y
+
+#
+# Configuration ---
+#
+# FREETZ_PACKAGE_OPENSSH_INTERNAL_CRYPTO is not set
+# FREETZ_PACKAGE_OPENSSH_STATIC is not set
+# FREETZ_PACKAGE_OPENSSL is not set
+# FREETZ_PACKAGE_OPENVPN is not set
+# FREETZ_PACKAGE_OWFS is not set
+# end of O
+
+#
+# P
+#
+# FREETZ_PACKAGE_P7ZIP is not set
+# FREETZ_PACKAGE_PCSC_LITE is not set
+# FREETZ_PACKAGE_PHONEBOOK_TOOLS is not set
+# FREETZ_PACKAGE_PINGTUNNEL is not set
+# FREETZ_PACKAGE_POLIPO is not set
+# FREETZ_PACKAGE_PPP is not set
+FREETZ_BOX_CERTIFICATE_SUPPORT_AVAILABLE=y
+# FREETZ_PACKAGE_PRIVATEKEYPASSWORD is not set
+# FREETZ_PACKAGE_PRIVOXY is not set
+# FREETZ_PACKAGE_PROXYCHAINS_NG is not set
+# FREETZ_PACKAGE_PSL is not set
+# FREETZ_PACKAGE_PYLOAD is not set
+# FREETZ_PACKAGE_PYTHON is not set
+# end of P
+
+#
+# Q
+#
+# FREETZ_PACKAGE_QUAGGA is not set
+# end of Q
+
+#
+# R
+#
+# FREETZ_PACKAGE_RADVD is not set
+# FREETZ_PACKAGE_RCAPID is not set
+# FREETZ_PACKAGE_RIPMIME is not set
+# FREETZ_PACKAGE_RPCBIND is not set
+# FREETZ_PACKAGE_RRDTOOL is not set
+# FREETZ_PACKAGE_RSYNC is not set
+# FREETZ_PACKAGE_RTMPDUMP is not set
+# FREETZ_PACKAGE_RUSH is not set
+# end of R
+
+#
+# S
+#
+# FREETZ_PACKAGE_SABLEVM_SDK is not set
+# FREETZ_PACKAGE_SAMBA is not set
+# FREETZ_PACKAGE_SCREEN is not set
+# FREETZ_PACKAGE_SER2NET is not set
+# FREETZ_PACKAGE_SFK is not set
+# FREETZ_PACKAGE_SHELLINABOX is not set
+# FREETZ_PACKAGE_SIPROXD is not set
+# FREETZ_PACKAGE_SISPMCTL is not set
+# FREETZ_PACKAGE_SLANG is not set
+# FREETZ_PACKAGE_SLURM is not set
+# FREETZ_PACKAGE_SMARTMONTOOLS is not set
+# FREETZ_PACKAGE_SMSTOOLS3 is not set
+# FREETZ_PACKAGE_SMUSBUTIL is not set
+# FREETZ_PACKAGE_SOCAT is not set
+# FREETZ_PACKAGE_SPAWN_FCGI is not set
+# FREETZ_PACKAGE_SQLITE is not set
+# FREETZ_PACKAGE_SQUASHFS3 is not set
+# FREETZ_PACKAGE_SQUASHFS4_BE is not set
+# FREETZ_PACKAGE_SQUASHFS4_LE is not set
+# FREETZ_PACKAGE_SSHFS_FUSE is not set
+# FREETZ_PACKAGE_SSLH is not set
+# FREETZ_PACKAGE_STREAMRIPPER is not set
+# FREETZ_PACKAGE_STUNNEL is not set
+# FREETZ_PACKAGE_SUBVERSION is not set
+# FREETZ_PACKAGE_SUDO is not set
+# FREETZ_PACKAGE_SYNCE_DCCM is not set
+
+#
+# SynCE serial (not available, needs replace kernel)
+#
+# end of S
+
+#
+# T
+#
+# FREETZ_PACKAGE_TCP_WRAPPERS is not set
+# FREETZ_PACKAGE_TCPDUMP is not set
+# FREETZ_PACKAGE_TCPPROXY is not set
+# FREETZ_PACKAGE_TESSERACT is not set
+# FREETZ_PACKAGE_TICHKSUM is not set
+# FREETZ_PACKAGE_TIFF is not set
+# FREETZ_PACKAGE_TINC is not set
+# FREETZ_PACKAGE_TINYPROXY is not set
+# FREETZ_PACKAGE_TMUX is not set
+# FREETZ_PACKAGE_TOR is not set
+# FREETZ_PACKAGE_TRANSMISSION is not set
+# FREETZ_PACKAGE_TREE is not set
+# FREETZ_PACKAGE_TRICKLE is not set
+# end of T
+
+#
+# U
+#
+# FREETZ_PACKAGE_UDPXY is not set
+# FREETZ_PACKAGE_UMURMUR is not set
+# FREETZ_PACKAGE_UNBOUND is not set
+# FREETZ_PACKAGE_UNRAR is not set
+# FREETZ_PACKAGE_USBIDS is not set
+# end of U
+
+#
+# V
+#
+# FREETZ_PACKAGE_VIM is not set
+FREETZ_PACKAGE_VLMCSD=y
+FREETZ_PACKAGE_VLMCSDSETUP=y
+# FREETZ_PACKAGE_VNSTAT is not set
+# FREETZ_PACKAGE_VPNC is not set
+# FREETZ_PACKAGE_VSFTPD is not set
+# FREETZ_PACKAGE_VTUN is not set
+# end of V
+
+#
+# W
+#
+FREETZ_PACKAGE_WGET=y
+FREETZ_PACKAGE_WGET_WITH_SSL=y
+FREETZ_PACKAGE_WGET_OPENSSL=y
+# FREETZ_PACKAGE_WGET_GNUTLS is not set
+FREETZ_PACKAGE_WGET_CA_BUNDLE=y
+# FREETZ_PACKAGE_WGET_STATIC is not set
+FREETZ_WGET=y
+# FREETZ_PACKAGE_WHOIS is not set
+
+#
+# wireguard-tools (not available, needs replace kernel)
+#
+# FREETZ_PACKAGE_WOL is not set
+# FREETZ_PACKAGE_WPUT is not set
+# end of W
+
+#
+# X
+#
+# FREETZ_PACKAGE_XMAIL is not set
+# FREETZ_PACKAGE_XPDF is not set
+# FREETZ_PACKAGE_XRELAYD is not set
+# FREETZ_PACKAGE_XSLTPROC is not set
+# FREETZ_PACKAGE_XZ is not set
+# end of X
+
+#
+# ----------------------------------------
+#
+
+#
+# Debug helpers
+#
+# FREETZ_PACKAGE_GDB is not set
+# FREETZ_PACKAGE_INOTIFY_TOOLS is not set
+# FREETZ_PACKAGE_LDD is not set
+# FREETZ_PACKAGE_LSOF is not set
+# FREETZ_PACKAGE_LTRACE is not set
+# FREETZ_PACKAGE_NANO_SHELL is not set
+# FREETZ_PACKAGE_PCIUTILS is not set
+# FREETZ_PACKAGE_STRACE is not set
+# FREETZ_PACKAGE_USBUTILS is not set
+# FREETZ_PACKAGE_VERMAGIC is not set
+# end of Debug helpers
+
+#
+# Unstable
+#
+# FREETZ_PACKAGE_ASTERISK is not set
+# FREETZ_PACKAGE_COLLECTD is not set
+# FREETZ_PACKAGE_GPTFDISK is not set
+# FREETZ_PACKAGE_HP_UTILS is not set
+# FREETZ_PACKAGE_HPLIP is not set
+# FREETZ_PACKAGE_MINI_FO is not set
+# FREETZ_PACKAGE_MYSQL is not set
+# FREETZ_PACKAGE_PHP is not set
+# FREETZ_PACKAGE_SANE_BACKENDS is not set
+# FREETZ_PACKAGE_SCANBUTTOND is not set
+# FREETZ_PACKAGE_USBROOT is not set
+# FREETZ_PACKAGE_VIRTUALIP_CGI is not set
+# FREETZ_PACKAGE_ZABBIX is not set
+# end of Unstable
+
+#
+# Web interfaces
+#
+
+#
+# Addhole (needs dnsmasq)
+#
+FREETZ_PACKAGE_AUTHORIZED_KEYS=y
+# FREETZ_PACKAGE_AVM_PORTFW is not set
+# FREETZ_PACKAGE_DNSD_CGI is not set
+# FREETZ_PACKAGE_DOWNLOADER is not set
+# FREETZ_PACKAGE_NFSD_CGI is not set
+# FREETZ_PACKAGE_ONLINECHANGED_CGI is not set
+# FREETZ_PACKAGE_PHPXMAIL is not set
+# FREETZ_PACKAGE_PPP_CGI is not set
+# FREETZ_PACKAGE_RRDSTATS is not set
+# FREETZ_PACKAGE_SPINDOWN_CGI is not set
+FREETZ_PACKAGE_SYSLOGD_CGI=y
+# FREETZ_PACKAGE_VNSTAT_CGI is not set
+# FREETZ_PACKAGE_WOL_CGI is not set
+# end of Web interfaces
+# end of Packages
+
+#
+# Shared libraries
+#
+
+#
+# Apache Portable Runtime libs
+#
+# FREETZ_LIB_libapr is not set
+# FREETZ_LIB_libaprutil is not set
+# end of Apache Portable Runtime libs
+
+#
+# Avahi libraries
+#
+# FREETZ_LIB_libavahi_common is not set
+# FREETZ_LIB_libavahi_core is not set
+# FREETZ_LIB_libavahi_client is not set
+# end of Avahi libraries
+
+#
+# Charsets & Internationalization
+#
+FREETZ_LIB_libintl=y
+# FREETZ_LIB_libfribidi is not set
+# FREETZ_LIB_libutf8proc is not set
+# end of Charsets & Internationalization
+
+#
+# Crypto & SSL
+#
+
+#
+# GnuPG ----------------------------------
+#
+# FREETZ_LIB_libgpg_error is not set
+# FREETZ_LIB_libgcrypt is not set
+
+#
+# GnuTLS ---------------------------------
+#
+# FREETZ_LIB_libgnutls is not set
+# FREETZ_LIB_libtasn1 is not set
+
+#
+# mbed TLS -------------------------------
+#
+# FREETZ_LIB_libmbedcrypto is not set
+# FREETZ_LIB_libmbedtls is not set
+# FREETZ_LIB_libmbedx509 is not set
+FREETZ_MBEDTLS_VERSION_CURRENT=y
+
+#
+# Nettle ---------------------------------
+#
+# FREETZ_LIB_libnettle is not set
+# FREETZ_LIB_libhogweed is not set
+
+#
+# OpenSSL --------------------------------
+#
+FREETZ_LIB_libcrypto=y
+FREETZ_LIB_libssl=y
+# FREETZ_OPENSSL_VERSION_2 is not set
+FREETZ_OPENSSL_VERSION_3=y
+
+#
+# OpenSSL configuration
+#
+FREETZ_OPENSSL_SHLIB_VERSION="3"
+FREETZ_OPENSSL_LIBCRYPTO_EXTRA_LIBS="-ldl -pthread -latomic"
+FREETZ_LIB_libcrypto_WITH_EC=y
+# FREETZ_LIB_libcrypto_WITH_RC4 is not set
+# FREETZ_LIB_libcrypto_WITH_ZLIB is not set
+FREETZ_OPENSSL_SMALL_FOOTPRINT=y
+FREETZ_OPENSSL_CONFIG_DIR="/mod/etc/ssl"
+# end of OpenSSL configuration
+
+FREETZ_OPENSSL_VERSION_1_MIN=y
+FREETZ_OPENSSL_VERSION_2_MIN=y
+FREETZ_OPENSSL_VERSION_3_MIN=y
+
+#
+# PolarSSL -------------------------------
+#
+# FREETZ_LIB_libpolarssl12 is not set
+# FREETZ_LIB_libpolarssl13 is not set
+
+#
+# Misc -----------------------------------
+#
+# FREETZ_LIB_libgsasl is not set
+# FREETZ_LIB_libssh2 is not set
+# end of Crypto & SSL
+
+#
+# Data compression
+#
+# FREETZ_LIB_libdeflate is not set
+# FREETZ_LIB_liblz4 is not set
+# FREETZ_LIB_liblzo2 is not set
+# FREETZ_LIB_liblzma is not set
+FREETZ_LIB_libz=y
+# end of Data compression
+
+#
+# Database
+#
+# FREETZ_LIB_libdb is not set
+# FREETZ_LIB_libmaxminddb is not set
+# FREETZ_LIB_libsqlite3 is not set
+# end of Database
+
+#
+# File systems
+#
+
+#
+# e2fsprogs libraries
+#
+# FREETZ_LIB_libblkid is not set
+# FREETZ_LIB_libcom_err is not set
+# FREETZ_LIB_libe2p is not set
+# FREETZ_LIB_libext2fs is not set
+# FREETZ_LIB_libss is not set
+# FREETZ_LIB_libuuid is not set
+# end of e2fsprogs libraries
+
+# FREETZ_LIB_libfuse is not set
+# FREETZ_LIB_libntfs is not set
+# end of File systems
+
+#
+# Freetz
+#
+FREETZ_LIB_libmultid=y
+FREETZ_LIB_libmultid_WITH_ANYIP=y
+FREETZ_LIB_libmultid_WITH_DNS=y
+FREETZ_LIB_libmultid_WITH_DHCP=y
+FREETZ_LIB_libmultid_WITH_LLMNR=y
+# end of Freetz
+
+#
+# GCC
+#
+FREETZ_LIB_libatomic=y
+FREETZ_LIB_libgcc_s=y
+# FREETZ_LIB_libstdc__ is not set
+# end of GCC
+
+#
+# GLib
+#
+FREETZ_LIB_libglib_2=y
+FREETZ_LIB_libglib_2_VERSION_CURRENT=y
+# FREETZ_LIB_libgio_2 is not set
+# FREETZ_LIB_libgobject_2 is not set
+# FREETZ_LIB_libgmodule_2 is not set
+# FREETZ_LIB_libgthread_2 is not set
+# end of GLib
+
+#
+# Graphics & fonts
+#
+# FREETZ_LIB_libcairo is not set
+# FREETZ_LIB_libfontconfig is not set
+# FREETZ_LIB_libfreetype is not set
+# FREETZ_LIB_libharfbuzz is not set
+# FREETZ_LIB_libart_lgpl_2 is not set
+# FREETZ_LIB_libexif is not set
+# FREETZ_LIB_libjpeg is not set
+# FREETZ_LIB_liblept is not set
+# FREETZ_LIB_libpng16 is not set
+# FREETZ_LIB_libgd is not set
+# FREETZ_LIB_libopenjpeg is not set
+# FREETZ_LIB_libopenjp2 is not set
+# FREETZ_LIB_libpango_1 is not set
+# FREETZ_LIB_libpangoft2_1 is not set
+# FREETZ_LIB_libpangocairo_1 is not set
+# FREETZ_LIB_libpixman_1 is not set
+# FREETZ_LIB_libtesseract is not set
+# FREETZ_LIB_libtiff is not set
+# FREETZ_LIB_libtiffxx is not set
+# FREETZ_LIB_libnetpbm is not set
+# end of Graphics & fonts
+
+#
+# Multi precision arithmetic libs
+#
+FREETZ_LIB_libgmp=y
+FREETZ_LIB_libmpfr=y
+FREETZ_LIB_libmpc=y
+# end of Multi precision arithmetic libs
+
+#
+# Multimedia
+#
+# FREETZ_LIB_libdvbcsa is not set
+
+#
+# Audio and video codecs
+#
+
+#
+# Audio codecs
+#
+# FREETZ_LIB_libFLAC is not set
+# FREETZ_LIB_libmad is not set
+# FREETZ_LIB_libogg is not set
+# FREETZ_LIB_libopus is not set
+# FREETZ_LIB_libspeex is not set
+# FREETZ_LIB_libspeexdsp is not set
+# end of Audio codecs
+
+#
+# FFmpeg libraries
+#
+# FREETZ_LIB_libavcodec is not set
+# FREETZ_LIB_libavdevice is not set
+# FREETZ_LIB_libavfilter is not set
+# FREETZ_LIB_libavformat is not set
+# FREETZ_LIB_libavutil is not set
+# FREETZ_LIB_libpostproc is not set
+# FREETZ_LIB_libswresample is not set
+# FREETZ_LIB_libswscale is not set
+# end of FFmpeg libraries
+
+#
+# Video codecs
+#
+
+#
+# Vorbis video codec ---------------------
+#
+# FREETZ_LIB_libvorbis is not set
+# FREETZ_LIB_libvorbisenc is not set
+# FREETZ_LIB_libvorbisfile is not set
+# end of Video codecs
+# end of Audio and video codecs
+
+#
+# ID3 tag reading libs
+#
+# FREETZ_LIB_libid3tag is not set
+# FREETZ_LIB_libtag is not set
+# end of ID3 tag reading libs
+# end of Multimedia
+
+#
+# ncurses
+#
+FREETZ_SHARE_terminfo=y
+FREETZ_SHARE_terminfo_ansi=y
+FREETZ_SHARE_terminfo_gnome=y
+FREETZ_SHARE_terminfo_konsole=y
+FREETZ_SHARE_terminfo_linux=y
+FREETZ_SHARE_terminfo_putty=y
+FREETZ_SHARE_terminfo_rxvt=y
+FREETZ_SHARE_terminfo_screen=y
+FREETZ_SHARE_terminfo_screenMINUSw=y
+FREETZ_SHARE_terminfo_sun=y
+FREETZ_SHARE_terminfo_vt100=y
+FREETZ_SHARE_terminfo_vt102=y
+FREETZ_SHARE_terminfo_vt102MINUSnsgr=y
+FREETZ_SHARE_terminfo_vt102MINUSw=y
+FREETZ_SHARE_terminfo_vt200=y
+FREETZ_SHARE_terminfo_vt220=y
+FREETZ_SHARE_terminfo_vt52=y
+FREETZ_SHARE_terminfo_xterm=y
+FREETZ_SHARE_terminfo_xtermMINUS256color=y
+FREETZ_SHARE_terminfo_xtermMINUScolor=y
+FREETZ_SHARE_terminfo_xtermMINUSxfree86=y
+# FREETZ_SHARE_terminfo_showall is not set
+FREETZ_LIB_libncurses=y
+FREETZ_LIB_libform=y
+FREETZ_LIB_libmenu=y
+FREETZ_LIB_libpanel=y
+FREETZ_LIB_libncursesw=y
+FREETZ_LIB_libformw=y
+FREETZ_LIB_libmenuw=y
+FREETZ_LIB_libpanelw=y
+# end of ncurses
+
+#
+# Networking
+#
+
+#
+# ATM ------------------------------------
+#
+# FREETZ_LIB_libatm is not set
+
+#
+# Bluetooth ------------------------------
+#
+# FREETZ_LIB_libbluetooth is not set
+# FREETZ_LIB_libopenobex is not set
+
+#
+# ISDN & CAPI ----------------------------
+#
+# FREETZ_LIB_libcapi20 is not set
+
+#
+# Misc networking ------------------------
+#
+# FREETZ_LIB_libdnet is not set
+# FREETZ_LIB_libgsm is not set
+# FREETZ_LIB_libiksemel is not set
+# FREETZ_LIB_libldns is not set
+# FREETZ_LIB_libmnl is not set
+# FREETZ_LIB_libnet is not set
+# FREETZ_LIB_liboping is not set
+# FREETZ_LIB_libosip2 is not set
+# FREETZ_LIB_libosipparser2 is not set
+# FREETZ_LIB_libpcap is not set
+# FREETZ_LIB_libunbound is not set
+# FREETZ_LIB_libspandsp is not set
+# FREETZ_LIB_libsrtp is not set
+# FREETZ_LIB_libtirpc is not set
+# FREETZ_LIB_libudns is not set
+# end of Networking
+
+#
+# PJ Project
+#
+# FREETZ_LIB_libpj is not set
+# FREETZ_LIB_libpjlib_util is not set
+# FREETZ_LIB_libpjmedia is not set
+# FREETZ_LIB_libpjmedia_audiodev is not set
+# FREETZ_LIB_libpjmedia_codec is not set
+# FREETZ_LIB_libpjmedia_videodev is not set
+# FREETZ_LIB_libpjnath is not set
+# FREETZ_LIB_libpjsip is not set
+# FREETZ_LIB_libpjsip_simple is not set
+# FREETZ_LIB_libpjsip_ua is not set
+# FREETZ_LIB_libpjsua is not set
+
+#
+# 3rdparty libraries
+#
+# FREETZ_LIB_libg7221codec is not set
+# FREETZ_LIB_libilbccodec is not set
+# FREETZ_LIB_libmilenage is not set
+# end of PJ Project
+
+#
+# Readline
+#
+# FREETZ_LIB_libreadline is not set
+# FREETZ_LIB_libhistory is not set
+# end of Readline
+
+#
+# Regular expressions
+#
+# FREETZ_LIB_libonig is not set
+# FREETZ_LIB_libpcre is not set
+# FREETZ_LIB_libpcreposix is not set
+FREETZ_LIB_libpcre2=y
+# FREETZ_LIB_libpcre2_posix is not set
+# end of Regular expressions
+
+#
+# uClibc
+#
+FREETZ_LIB_ld_uClibc=y
+# FREETZ_LIB_libthread_db is not set
+FREETZ_LIB_libuClibc=y
+# FREETZ_LIB_libuClibc__ is not set
+# end of uClibc
+
+#
+# USB & FTDI
+#
+# FREETZ_LIB_libusb_0 is not set
+# FREETZ_LIB_libusb_1 is not set
+# FREETZ_LIB_libftdi is not set
+# FREETZ_LIB_libftdi1 is not set
+# end of USB & FTDI
+
+#
+# Web and WebDAV
+#
+# FREETZ_LIB_libcurl is not set
+# FREETZ_LIB_libidn is not set
+# FREETZ_LIB_libjansson is not set
+# FREETZ_LIB_libjs is not set
+# FREETZ_LIB_libneon is not set
+# FREETZ_LIB_libpsl is not set
+# FREETZ_LIB_libserf is not set
+# end of Web and WebDAV
+
+#
+# XML & XSLT
+#
+# FREETZ_LIB_libexpat is not set
+# FREETZ_LIB_libxml2 is not set
+# FREETZ_LIB_libxslt is not set
+# FREETZ_LIB_libexslt is not set
+# end of XML & XSLT
+
+# FREETZ_LIB_libattr is not set
+# FREETZ_LIB_libcap is not set
+# FREETZ_LIB_libcap_ng is not set
+# FREETZ_LIB_libconfig is not set
+# FREETZ_LIB_libconfuse is not set
+# FREETZ_LIB_libdaemon is not set
+# FREETZ_LIB_libdbus is not set
+# FREETZ_LIB_libdevmapper is not set
+# FREETZ_LIB_libelf is not set
+# FREETZ_LIB_libev is not set
+# FREETZ_LIB_libevent is not set
+# FREETZ_LIB_libffi is not set
+# FREETZ_LIB_liblua is not set
+# FREETZ_LIB_libnfsidmap is not set
+# FREETZ_LIB_libpcsclite is not set
+FREETZ_LIB_libpopt=y
+# FREETZ_LIB_libprivatekeypassword is not set
+# FREETZ_LIB_libprotobuf_c is not set
+# FREETZ_LIB_librrd is not set
+# FREETZ_LIB_libslang is not set
+# FREETZ_LIB_libsynce is not set
+# FREETZ_LIB_libsysfs is not set
+# FREETZ_LIB_libltdl is not set
+# FREETZ_LIB_libuv is not set
+# FREETZ_LIB_libyaml is not set
+# end of Shared libraries
+
+#
+# Kernel modules
+#
+FREETZ_MODULES_KOON=y
+FREETZ_MODULES_OWN=""
+
+#
+# crypto
+#
+# FREETZ_MODULE_aead is not set
+# FREETZ_MODULE_arc4 is not set
+# FREETZ_MODULE_cbc is not set
+# FREETZ_MODULE_crypto_blkcipher is not set
+# FREETZ_MODULE_crypto_wq is not set
+# FREETZ_MODULE_cryptomgr is not set
+# FREETZ_MODULE_pcompress is not set
+# FREETZ_MODULE_rng is not set
+# FREETZ_MODULE_sha1_generic is not set
+# FREETZ_MODULE_sha256_generic is not set
+# end of crypto
+
+#
+# drivers
+#
+# FREETZ_MODULE_bfusb is not set
+# FREETZ_MODULE_btusb is not set
+# FREETZ_MODULE_capiconn is not set
+# FREETZ_MODULE_cdrom is not set
+# FREETZ_MODULE_dummy is not set
+# FREETZ_MODULE_dm_mod is not set
+# FREETZ_MODULE_dm_crypt is not set
+# FREETZ_MODULE_musb_hdrc is not set
+# FREETZ_MODULE_scsi_mod is not set
+# FREETZ_MODULE_sd_mod is not set
+# FREETZ_MODULE_sg is not set
+# FREETZ_MODULE_slhc is not set
+# FREETZ_MODULE_sr_mod is not set
+# FREETZ_MODULE_usb_storage is not set
+# FREETZ_MODULE_usbcore is not set
+# FREETZ_MODULE_usblp is not set
+# FREETZ_MODULE_usbmon is not set
+
+#
+#  ppp
+#
+# FREETZ_MODULE_ppp_async is not set
+# FREETZ_MODULE_ppp_deflate is not set
+# FREETZ_MODULE_ppp_generic is not set
+# FREETZ_MODULE_ppp_mppe is not set
+# FREETZ_MODULE_pppoe is not set
+
+#
+#  serial
+#
+# FREETZ_MODULE_ch341 is not set
+# FREETZ_MODULE_cp2101 is not set
+# FREETZ_MODULE_cp210x is not set
+# FREETZ_MODULE_ftdi_sio is not set
+# FREETZ_MODULE_ipaq is not set
+# FREETZ_MODULE_option is not set
+# FREETZ_MODULE_pl2303 is not set
+# FREETZ_MODULE_usbserial is not set
+# end of drivers
+
+#
+# fs
+#
+# FREETZ_MODULE_fat is not set
+# FREETZ_MODULE_hfs is not set
+# FREETZ_MODULE_hfsplus is not set
+# FREETZ_MODULE_iso9660 is not set
+# FREETZ_MODULE_jffs2 is not set
+# FREETZ_MODULE_mini_fo is not set
+# FREETZ_MODULE_minix is not set
+# FREETZ_MODULE_msdos is not set
+# FREETZ_MODULE_reiserfs is not set
+# FREETZ_MODULE_udf is not set
+# FREETZ_MODULE_unionfs is not set
+
+#
+#  net
+#
+# FREETZ_MODULE_autofs4 is not set
+# FREETZ_MODULE_cifs is not set
+
+#
+#  nfs
+#
+# FREETZ_MODULE_nfs is not set
+# FREETZ_MODULE_nfsd is not set
+
+#
+#  nls
+#
+# FREETZ_MODULE_nls_cp437 is not set
+# FREETZ_MODULE_nls_cp850 is not set
+# FREETZ_MODULE_nls_iso8859_1 is not set
+# FREETZ_MODULE_nls_iso8859_15 is not set
+# end of fs
+
+#
+# lib
+#
+# FREETZ_MODULE_crc_ccitt is not set
+# end of lib
+
+#
+# net
+#
+# FREETZ_MODULE_yf_patchkernel is not set
+
+#
+#  bt
+#
+# FREETZ_MODULE_bluetooth is not set
+# FREETZ_MODULE_bnep is not set
+# FREETZ_MODULE_l2cap is not set
+# FREETZ_MODULE_rfcomm is not set
+
+#
+#  qos
+#
+# FREETZ_MODULE_sch_cbq is not set
+# FREETZ_MODULE_sch_htb is not set
+# FREETZ_MODULE_sch_llq is not set
+# FREETZ_MODULE_sch_sfq is not set
+# FREETZ_MODULE_sch_tbf is not set
+# end of net
+# end of Kernel modules
+
+#
+# Busybox applets
+#
+FREETZ_BUSYBOX__VERSION_V136=y
+FREETZ_BUSYBOX__VERSION_STRING="1.36.1"
+FREETZ_BUSYBOX__RECOMMENDED=y
+FREETZ_BUSYBOX__MANDATORY=y
+FREETZ_BUSYBOX__MANDATORY_05_2X=y
+FREETZ_BUSYBOX__MANDATORY_06_5X=y
+FREETZ_BUSYBOX__MANDATORY_07_0X=y
+FREETZ_BUSYBOX__MANDATORY_07_2X=y
+FREETZ_BUSYBOX__MANDATORY_07_5X=y
+FREETZ_BUSYBOX__BUILD_TIMESTAMP=y
+FREETZ_BUSYBOX__KEEP_BINARIES=y
+FREETZ_BUSYBOX__IPV6_UTILS=y
+# FREETZ_BUSYBOX__PACKER is not set
+# FREETZ_BUSYBOX__NETWORK is not set
+# FREETZ_BUSYBOX__TERMINAL is not set
+# FREETZ_BUSYBOX__DEVELOPER is not set
+
+#
+# 
+#
+FREETZ_BUSYBOX_ADDGROUP=y
+FREETZ_BUSYBOX_ADDUSER=y
+FREETZ_BUSYBOX_AR=y
+FREETZ_BUSYBOX_ARP=y
+FREETZ_BUSYBOX_ARPING=y
+FREETZ_BUSYBOX_ASH=y
+FREETZ_BUSYBOX_ASH_ALIAS=y
+FREETZ_BUSYBOX_ASH_BASH_COMPAT=y
+FREETZ_BUSYBOX_ASH_BASH_NOT_FOUND_HOOK=y
+FREETZ_BUSYBOX_ASH_CMDCMD=y
+FREETZ_BUSYBOX_ASH_ECHO=y
+FREETZ_BUSYBOX_ASH_EXPAND_PRMT=y
+FREETZ_BUSYBOX_ASH_GETOPTS=y
+FREETZ_BUSYBOX_ASH_INTERNAL_GLOB=y
+FREETZ_BUSYBOX_ASH_JOB_CONTROL=y
+FREETZ_BUSYBOX_ASH_OPTIMIZE_FOR_SIZE=y
+FREETZ_BUSYBOX_ASH_PRINTF=y
+FREETZ_BUSYBOX_ASH_RANDOM_SUPPORT=y
+FREETZ_BUSYBOX_ASH_TEST=y
+FREETZ_BUSYBOX_AWK=y
+FREETZ_BUSYBOX_BASE64=y
+FREETZ_BUSYBOX_BASENAME=y
+FREETZ_BUSYBOX_BBCONFIG=y
+FREETZ_BUSYBOX_BB_SYSCTL=y
+FREETZ_BUSYBOX_BC=y
+FREETZ_BUSYBOX_BEEP=y
+FREETZ_BUSYBOX_BRCTL=y
+FREETZ_BUSYBOX_BUNZIP2=y
+FREETZ_BUSYBOX_BUSYBOX=y
+FREETZ_BUSYBOX_BZCAT=y
+FREETZ_BUSYBOX_BZIP2=y
+FREETZ_BUSYBOX_CAT=y
+FREETZ_BUSYBOX_CHGRP=y
+FREETZ_BUSYBOX_CHMOD=y
+FREETZ_BUSYBOX_CHOWN=y
+FREETZ_BUSYBOX_CHROOT=y
+FREETZ_BUSYBOX_CHRT=y
+FREETZ_BUSYBOX_CMP=y
+FREETZ_BUSYBOX_CP=y
+FREETZ_BUSYBOX_CPIO=y
+FREETZ_BUSYBOX_CROND=y
+FREETZ_BUSYBOX_CRONTAB=y
+FREETZ_BUSYBOX_CRYPTPW=y
+FREETZ_BUSYBOX_CUT=y
+FREETZ_BUSYBOX_DATE=y
+FREETZ_BUSYBOX_DD=y
+FREETZ_BUSYBOX_DELGROUP=y
+FREETZ_BUSYBOX_DELUSER=y
+FREETZ_BUSYBOX_DEVMEM=y
+FREETZ_BUSYBOX_DF=y
+FREETZ_BUSYBOX_DIRNAME=y
+FREETZ_BUSYBOX_DNSDOMAINNAME=y
+FREETZ_BUSYBOX_DU=y
+FREETZ_BUSYBOX_ECHO=y
+FREETZ_BUSYBOX_EGREP=y
+FREETZ_BUSYBOX_ENV=y
+FREETZ_BUSYBOX_ETHER_WAKE=y
+FREETZ_BUSYBOX_EXPR=y
+FREETZ_BUSYBOX_EXPR_MATH_SUPPORT_64=y
+FREETZ_BUSYBOX_FACTOR=y
+FREETZ_BUSYBOX_FALSE=y
+FREETZ_BUSYBOX_FEATURE_ADDUSER_TO_GROUP=y
+FREETZ_BUSYBOX_FEATURE_ALLOW_EXEC=y
+FREETZ_BUSYBOX_FEATURE_BRCTL_FANCY=y
+FREETZ_BUSYBOX_FEATURE_BRCTL_SHOW=y
+FREETZ_BUSYBOX_FEATURE_COMPRESS_BBCONFIG=y
+FREETZ_BUSYBOX_FEATURE_COMPRESS_USAGE=y
+FREETZ_BUSYBOX_FEATURE_DATE_COMPAT=y
+FREETZ_BUSYBOX_FEATURE_DATE_ISOFMT=y
+FREETZ_BUSYBOX_FEATURE_DD_IBS_OBS=y
+FREETZ_BUSYBOX_FEATURE_DD_SIGNAL_HANDLING=y
+FREETZ_BUSYBOX_FEATURE_DD_STATUS=y
+FREETZ_BUSYBOX_FEATURE_DEL_USER_FROM_GROUP=y
+FREETZ_BUSYBOX_FEATURE_DEVPTS=y
+FREETZ_BUSYBOX_FEATURE_DF_FANCY=y
+FREETZ_BUSYBOX_FEATURE_DU_DEFAULT_BLOCKSIZE_1K=y
+FREETZ_BUSYBOX_FEATURE_EDITING=y
+FREETZ_BUSYBOX_FEATURE_EDITING_FANCY_PROMPT=y
+FREETZ_BUSYBOX_FEATURE_EDITING_WINCH=y
+FREETZ_BUSYBOX_FEATURE_ENV_LONG_OPTIONS=y
+FREETZ_BUSYBOX_FEATURE_FANCY_ECHO=y
+FREETZ_BUSYBOX_FEATURE_FANCY_HEAD=y
+FREETZ_BUSYBOX_FEATURE_FANCY_PING=y
+FREETZ_BUSYBOX_FEATURE_FANCY_SLEEP=y
+FREETZ_BUSYBOX_FEATURE_FANCY_TAIL=y
+FREETZ_BUSYBOX_FEATURE_FAST_TOP=y
+FREETZ_BUSYBOX_FEATURE_FIND_DEPTH=y
+FREETZ_BUSYBOX_FEATURE_FIND_EXEC=y
+FREETZ_BUSYBOX_FEATURE_FIND_GROUP=y
+FREETZ_BUSYBOX_FEATURE_FIND_INUM=y
+FREETZ_BUSYBOX_FEATURE_FIND_MAXDEPTH=y
+FREETZ_BUSYBOX_FEATURE_FIND_MMIN=y
+FREETZ_BUSYBOX_FEATURE_FIND_MTIME=y
+FREETZ_BUSYBOX_FEATURE_FIND_NEWER=y
+FREETZ_BUSYBOX_FEATURE_FIND_NOT=y
+FREETZ_BUSYBOX_FEATURE_FIND_PAREN=y
+FREETZ_BUSYBOX_FEATURE_FIND_PATH=y
+FREETZ_BUSYBOX_FEATURE_FIND_PERM=y
+FREETZ_BUSYBOX_FEATURE_FIND_PRINT0=y
+FREETZ_BUSYBOX_FEATURE_FIND_PRUNE=y
+FREETZ_BUSYBOX_FEATURE_FIND_REGEX=y
+FREETZ_BUSYBOX_FEATURE_FIND_SIZE=y
+FREETZ_BUSYBOX_FEATURE_FIND_TYPE=y
+FREETZ_BUSYBOX_FEATURE_FIND_USER=y
+FREETZ_BUSYBOX_FEATURE_FIND_XDEV=y
+FREETZ_BUSYBOX_FEATURE_FTPGETPUT_LONG_OPTIONS=y
+FREETZ_BUSYBOX_FEATURE_GETOPT_LONG=y
+FREETZ_BUSYBOX_FEATURE_GREP_CONTEXT=y
+FREETZ_BUSYBOX_FEATURE_HEXDUMP_REVERSE=y
+FREETZ_BUSYBOX_FEATURE_HTTPD_AUTH_MD5=y
+FREETZ_BUSYBOX_FEATURE_HTTPD_BASIC_AUTH=y
+FREETZ_BUSYBOX_FEATURE_HTTPD_CGI=y
+FREETZ_BUSYBOX_FEATURE_HTTPD_CONFIG_WITH_SCRIPT_INTERPR=y
+FREETZ_BUSYBOX_FEATURE_HTTPD_ENCODE_URL_STR=y
+FREETZ_BUSYBOX_FEATURE_HUMAN_READABLE=y
+FREETZ_BUSYBOX_FEATURE_HWIB=y
+FREETZ_BUSYBOX_FEATURE_IFCONFIG_BROADCAST_PLUS=y
+FREETZ_BUSYBOX_FEATURE_IFCONFIG_HW=y
+FREETZ_BUSYBOX_FEATURE_IFCONFIG_MEMSTART_IOADDR_IRQ=y
+FREETZ_BUSYBOX_FEATURE_IFCONFIG_SLIP=y
+FREETZ_BUSYBOX_FEATURE_IFCONFIG_STATUS=y
+FREETZ_BUSYBOX_FEATURE_IFUPDOWN_IP=y
+FREETZ_BUSYBOX_FEATURE_IFUPDOWN_IPV4=y
+FREETZ_BUSYBOX_FEATURE_IFUPDOWN_IPV6=y
+FREETZ_BUSYBOX_FEATURE_IFUPDOWN_MAPPING=y
+FREETZ_BUSYBOX_FEATURE_INETD_SUPPORT_BUILTIN_CHARGEN=y
+FREETZ_BUSYBOX_FEATURE_INETD_SUPPORT_BUILTIN_DAYTIME=y
+FREETZ_BUSYBOX_FEATURE_INETD_SUPPORT_BUILTIN_DISCARD=y
+FREETZ_BUSYBOX_FEATURE_INETD_SUPPORT_BUILTIN_ECHO=y
+FREETZ_BUSYBOX_FEATURE_INETD_SUPPORT_BUILTIN_TIME=y
+FREETZ_BUSYBOX_FEATURE_INIT_MODIFY_CMDLINE=y
+FREETZ_BUSYBOX_FEATURE_INIT_QUIET=y
+FREETZ_BUSYBOX_FEATURE_INIT_SCTTY=y
+FREETZ_BUSYBOX_FEATURE_INIT_SYSLOG=y
+FREETZ_BUSYBOX_FEATURE_IP_ADDRESS=y
+FREETZ_BUSYBOX_FEATURE_IPC_SYSLOG=y
+FREETZ_BUSYBOX_FEATURE_IP_LINK=y
+FREETZ_BUSYBOX_FEATURE_IP_NEIGH=y
+FREETZ_BUSYBOX_FEATURE_IP_ROUTE=y
+FREETZ_BUSYBOX_FEATURE_IP_RULE=y
+FREETZ_BUSYBOX_FEATURE_IP_TUNNEL=y
+FREETZ_BUSYBOX_FEATURE_IPV6=y
+FREETZ_BUSYBOX_FEATURE_KILL_REMOVED=y
+FREETZ_BUSYBOX_FEATURE_KLOGD_KLOGCTL=y
+FREETZ_BUSYBOX_FEATURE_LOGREAD_REDUCED_LOCKING=y
+FREETZ_BUSYBOX_FEATURE_LS_COLOR=y
+FREETZ_BUSYBOX_FEATURE_LS_FILETYPES=y
+FREETZ_BUSYBOX_FEATURE_LS_FOLLOWLINKS=y
+FREETZ_BUSYBOX_FEATURE_LS_RECURSIVE=y
+FREETZ_BUSYBOX_FEATURE_LS_SORTFILES=y
+FREETZ_BUSYBOX_FEATURE_LS_TIMESTAMPS=y
+FREETZ_BUSYBOX_FEATURE_LS_USERNAME=y
+FREETZ_BUSYBOX_FEATURE_MAKEDEVS_TABLE=y
+FREETZ_BUSYBOX_FEATURE_MD5_SHA1_SUM_CHECK=y
+FREETZ_BUSYBOX_FEATURE_MKDIR_LONG_OPTIONS=y
+FREETZ_BUSYBOX_FEATURE_MOUNT_CIFS=y
+FREETZ_BUSYBOX_FEATURE_MOUNT_FAKE=y
+FREETZ_BUSYBOX_FEATURE_MOUNT_FLAGS=y
+FREETZ_BUSYBOX_FEATURE_MOUNT_FSTAB=y
+FREETZ_BUSYBOX_FEATURE_MOUNT_HELPERS=y
+FREETZ_BUSYBOX_FEATURE_MOUNT_LABEL=y
+FREETZ_BUSYBOX_FEATURE_MOUNT_LOOP=y
+FREETZ_BUSYBOX_FEATURE_MOUNT_LOOP_CREATE=y
+FREETZ_BUSYBOX_FEATURE_MOUNT_OTHERTAB=y
+FREETZ_BUSYBOX_FEATURE_MOUNT_VERBOSE=y
+FREETZ_BUSYBOX_FEATURE_MTAB_SUPPORT=y
+FREETZ_BUSYBOX_FEATURE_MV_LONG_OPTIONS=y
+FREETZ_BUSYBOX_FEATURE_NETSTAT_PRG=y
+FREETZ_BUSYBOX_FEATURE_NETSTAT_WIDE=y
+FREETZ_BUSYBOX_FEATURE_NOLOGIN=y
+FREETZ_BUSYBOX_FEATURE_NON_POSIX_CP=y
+FREETZ_BUSYBOX_FEATURE_PASSWD_WEAK_CHECK=y
+FREETZ_BUSYBOX_FEATURE_PIDFILE=y
+FREETZ_BUSYBOX_FEATURE_PIDOF_OMIT=y
+FREETZ_BUSYBOX_FEATURE_PIDOF_SINGLE=y
+FREETZ_BUSYBOX_FEATURE_PREFER_IPV4_ADDRESS=y
+FREETZ_BUSYBOX_FEATURE_PRESERVE_HARDLINKS=y
+FREETZ_BUSYBOX_FEATURE_READLINK_FOLLOW=y
+FREETZ_BUSYBOX_FEATURE_REMOTE_LOG=y
+FREETZ_BUSYBOX_FEATURE_RMDIR_LONG_OPTIONS=y
+FREETZ_BUSYBOX_FEATURE_ROTATE_LOGFILE=y
+FREETZ_BUSYBOX_FEATURE_RTMINMAX=y
+FREETZ_BUSYBOX_FEATURE_SEAMLESS_BZ2=y
+FREETZ_BUSYBOX_FEATURE_SEAMLESS_GZ=y
+FREETZ_BUSYBOX_FEATURE_SEAMLESS_LZMA=y
+FREETZ_BUSYBOX_FEATURE_SEAMLESS_XZ=y
+FREETZ_BUSYBOX_FEATURE_SEAMLESS_Z=y
+FREETZ_BUSYBOX_FEATURE_SECURETTY=y
+FREETZ_BUSYBOX_FEATURE_SETCONSOLE_LONG_OPTIONS=y
+FREETZ_BUSYBOX_FEATURE_SHADOWPASSWDS=y
+FREETZ_BUSYBOX_FEATURE_SH_EMBEDDED_SCRIPTS=y
+FREETZ_BUSYBOX_FEATURE_SH_HISTFILESIZE=y
+FREETZ_BUSYBOX_FEATURE_SH_MATH=y
+FREETZ_BUSYBOX_FEATURE_SH_MATH_64=y
+FREETZ_BUSYBOX_FEATURE_SHOW_THREADS=y
+FREETZ_BUSYBOX_FEATURE_SH_READ_FRAC=y
+FREETZ_BUSYBOX_FEATURE_SKIP_ROOTFS=y
+FREETZ_BUSYBOX_FEATURE_SORT_BIG=y
+FREETZ_BUSYBOX_FEATURE_SPLIT_FANCY=y
+FREETZ_BUSYBOX_FEATURE_START_STOP_DAEMON_FANCY=y
+FREETZ_BUSYBOX_FEATURE_STAT_FILESYSTEM=y
+FREETZ_BUSYBOX_FEATURE_STAT_FORMAT=y
+FREETZ_BUSYBOX_FEATURE_SUID=y
+FREETZ_BUSYBOX_FEATURE_SWAPONOFF_LABEL=y
+FREETZ_BUSYBOX_FEATURE_SWAPON_PRI=y
+FREETZ_BUSYBOX_FEATURE_SYSLOG=y
+FREETZ_BUSYBOX_FEATURE_SYSLOGD_DUP=y
+FREETZ_BUSYBOX_FEATURE_TAB_COMPLETION=y
+FREETZ_BUSYBOX_FEATURE_TAR_CREATE=y
+FREETZ_BUSYBOX_FEATURE_TAR_FROM=y
+FREETZ_BUSYBOX_FEATURE_TAR_GNU_EXTENSIONS=y
+FREETZ_BUSYBOX_FEATURE_TAR_LONG_OPTIONS=y
+FREETZ_BUSYBOX_FEATURE_TAR_OLDGNU_COMPATIBILITY=y
+FREETZ_BUSYBOX_FEATURE_TAR_OLDSUN_COMPATIBILITY=y
+FREETZ_BUSYBOX_FEATURE_TAR_TO_COMMAND=y
+FREETZ_BUSYBOX_FEATURE_TAR_UNAME_GNAME=y
+FREETZ_BUSYBOX_FEATURE_TASKSET_FANCY=y
+FREETZ_BUSYBOX_FEATURE_TEE_USE_BLOCK_IO=y
+FREETZ_BUSYBOX_FEATURE_TEST_64=y
+FREETZ_BUSYBOX_FEATURE_TFTP_GET=y
+FREETZ_BUSYBOX_FEATURE_TFTP_PUT=y
+FREETZ_BUSYBOX_FEATURE_TOP_CPU_GLOBAL_PERCENTS=y
+FREETZ_BUSYBOX_FEATURE_TOP_CPU_USAGE_PERCENTAGE=y
+FREETZ_BUSYBOX_FEATURE_TOP_DECIMALS=y
+FREETZ_BUSYBOX_FEATURE_TOP_INTERACTIVE=y
+FREETZ_BUSYBOX_FEATURE_TOPMEM=y
+FREETZ_BUSYBOX_FEATURE_TOP_SMP_CPU=y
+FREETZ_BUSYBOX_FEATURE_TOP_SMP_PROCESS=y
+FREETZ_BUSYBOX_FEATURE_TOUCH_NODEREF=y
+FREETZ_BUSYBOX_FEATURE_TOUCH_SUSV3=y
+FREETZ_BUSYBOX_FEATURE_TRACEROUTE_USE_ICMP=y
+FREETZ_BUSYBOX_FEATURE_TRACEROUTE_VERBOSE=y
+FREETZ_BUSYBOX_FEATURE_TR_CLASSES=y
+FREETZ_BUSYBOX_FEATURE_TR_EQUIV=y
+FREETZ_BUSYBOX_FEATURE_UMOUNT_ALL=y
+FREETZ_BUSYBOX_FEATURE_UNZIP_CDF=y
+FREETZ_BUSYBOX_FEATURE_USE_INITTAB=y
+FREETZ_BUSYBOX_FEATURE_USE_SENDFILE=y
+FREETZ_BUSYBOX_FEATURE_UTMP=y
+FREETZ_BUSYBOX_FEATURE_VERBOSE=y
+FREETZ_BUSYBOX_FEATURE_VERBOSE_USAGE=y
+FREETZ_BUSYBOX_FEATURE_VI_8BIT=y
+FREETZ_BUSYBOX_FEATURE_VI_ASK_TERMINAL=y
+FREETZ_BUSYBOX_FEATURE_VI_COLON=y
+FREETZ_BUSYBOX_FEATURE_VI_DOT_CMD=y
+FREETZ_BUSYBOX_FEATURE_VI_READONLY=y
+FREETZ_BUSYBOX_FEATURE_VI_SEARCH=y
+FREETZ_BUSYBOX_FEATURE_VI_SET=y
+FREETZ_BUSYBOX_FEATURE_VI_SETOPTS=y
+FREETZ_BUSYBOX_FEATURE_VI_USE_SIGNALS=y
+FREETZ_BUSYBOX_FEATURE_VI_WIN_RESIZE=y
+FREETZ_BUSYBOX_FEATURE_VI_YANKMARK=y
+FREETZ_BUSYBOX_FEATURE_VOLUMEID_EXFAT=y
+FREETZ_BUSYBOX_FEATURE_VOLUMEID_F2FS=y
+FREETZ_BUSYBOX_FEATURE_WAIT_FOR_INIT=y
+FREETZ_BUSYBOX_FEATURE_WC_LARGE=y
+FREETZ_BUSYBOX_FEATURE_XARGS_SUPPORT_ARGS_FILE=y
+FREETZ_BUSYBOX_FEATURE_XARGS_SUPPORT_CONFIRMATION=y
+FREETZ_BUSYBOX_FEATURE_XARGS_SUPPORT_QUOTES=y
+FREETZ_BUSYBOX_FEATURE_XARGS_SUPPORT_TERMOPT=y
+FREETZ_BUSYBOX_FEATURE_XARGS_SUPPORT_ZERO_TERM=y
+FREETZ_BUSYBOX_FGCONSOLE=y
+FREETZ_BUSYBOX_FGREP=y
+FREETZ_BUSYBOX_FIND=y
+FREETZ_BUSYBOX_FLOCK=y
+FREETZ_BUSYBOX_FREE=y
+FREETZ_BUSYBOX_FSTRIM=y
+FREETZ_BUSYBOX_FTPGET=y
+FREETZ_BUSYBOX_FTPPUT=y
+FREETZ_BUSYBOX_FUSER=y
+FREETZ_BUSYBOX_GETOPT=y
+FREETZ_BUSYBOX_GREP=y
+FREETZ_BUSYBOX_GROUPS=y
+FREETZ_BUSYBOX_GUNZIP=y
+FREETZ_BUSYBOX_GZIP=y
+FREETZ_BUSYBOX_HALT=y
+FREETZ_BUSYBOX_HAVE_DOT_CONFIG=y
+FREETZ_BUSYBOX_HEAD=y
+FREETZ_BUSYBOX_HEXDUMP=y
+FREETZ_BUSYBOX_HOSTNAME=y
+FREETZ_BUSYBOX_HTTPD=y
+FREETZ_BUSYBOX_I2CTRANSFER=y
+FREETZ_BUSYBOX_ID=y
+FREETZ_BUSYBOX_IFCONFIG=y
+FREETZ_BUSYBOX_IFDOWN=y
+FREETZ_BUSYBOX_IFUP=y
+FREETZ_BUSYBOX_INCLUDE_SUSv2=y
+FREETZ_BUSYBOX_INETD=y
+FREETZ_BUSYBOX_INIT=y
+FREETZ_BUSYBOX_INOTIFYD=y
+FREETZ_BUSYBOX_INSTALL_APPLET_SYMLINKS=y
+FREETZ_BUSYBOX_IOCTL_HEX2STR_ERROR=y
+FREETZ_BUSYBOX_IOSTAT=y
+FREETZ_BUSYBOX_IP=y
+FREETZ_BUSYBOX_IPADDR=y
+FREETZ_BUSYBOX_IPLINK=y
+FREETZ_BUSYBOX_IPNEIGH=y
+FREETZ_BUSYBOX_IPROUTE=y
+FREETZ_BUSYBOX_IPRULE=y
+FREETZ_BUSYBOX_IPTUNNEL=y
+FREETZ_BUSYBOX_KILL=y
+FREETZ_BUSYBOX_KILLALL=y
+FREETZ_BUSYBOX_KILLALL5=y
+FREETZ_BUSYBOX_KLOGD=y
+FREETZ_BUSYBOX_LFS=y
+FREETZ_BUSYBOX_LN=y
+FREETZ_BUSYBOX_LOGGER=y
+FREETZ_BUSYBOX_LOGIN=y
+FREETZ_BUSYBOX_LOGNAME=y
+FREETZ_BUSYBOX_LOGREAD=y
+FREETZ_BUSYBOX_LONG_OPTS=y
+FREETZ_BUSYBOX_LS=y
+FREETZ_BUSYBOX_LSOF=y
+FREETZ_BUSYBOX_MAKEDEVS=y
+FREETZ_BUSYBOX_MD5SUM=y
+FREETZ_BUSYBOX_MKDIR=y
+FREETZ_BUSYBOX_MKFIFO=y
+FREETZ_BUSYBOX_MKNOD=y
+FREETZ_BUSYBOX_MKPASSWD=y
+FREETZ_BUSYBOX_MKSWAP=y
+FREETZ_BUSYBOX_MKTEMP=y
+FREETZ_BUSYBOX_MONOTONIC_SYSCALL=y
+FREETZ_BUSYBOX_MORE=y
+FREETZ_BUSYBOX_MOUNT=y
+FREETZ_BUSYBOX_MPSTAT=y
+FREETZ_BUSYBOX_MV=y
+FREETZ_BUSYBOX_NBDCLIENT=y
+FREETZ_BUSYBOX_NC=y
+FREETZ_BUSYBOX_NC_110_COMPAT=y
+FREETZ_BUSYBOX_NC_EXTRA=y
+FREETZ_BUSYBOX_NETCAT=y
+FREETZ_BUSYBOX_NETSTAT=y
+FREETZ_BUSYBOX_NICE=y
+FREETZ_BUSYBOX_NO_DEBUG_LIB=y
+FREETZ_BUSYBOX_NOHUP=y
+FREETZ_BUSYBOX_NOLOGIN=y
+FREETZ_BUSYBOX_NSLOOKUP=y
+FREETZ_BUSYBOX_OD=y
+FREETZ_BUSYBOX_PASSWD=y
+FREETZ_BUSYBOX_PIDOF=y
+FREETZ_BUSYBOX_PING=y
+FREETZ_BUSYBOX_PING6=y
+FREETZ_BUSYBOX_PIVOT_ROOT=y
+FREETZ_BUSYBOX_PLATFORM_LINUX=y
+FREETZ_BUSYBOX_PMAP=y
+FREETZ_BUSYBOX_POWEROFF=y
+FREETZ_BUSYBOX_PRINTENV=y
+FREETZ_BUSYBOX_PRINTF=y
+FREETZ_BUSYBOX_PS=y
+FREETZ_BUSYBOX_PSTREE=y
+FREETZ_BUSYBOX_PWD=y
+FREETZ_BUSYBOX_PWDX=y
+FREETZ_BUSYBOX_READLINK=y
+FREETZ_BUSYBOX_REALPATH=y
+FREETZ_BUSYBOX_REBOOT=y
+FREETZ_BUSYBOX_RENICE=y
+FREETZ_BUSYBOX_RESET=y
+FREETZ_BUSYBOX_RM=y
+FREETZ_BUSYBOX_RMDIR=y
+FREETZ_BUSYBOX_ROUTE=y
+FREETZ_BUSYBOX_SED=y
+FREETZ_BUSYBOX_SEQ=y
+FREETZ_BUSYBOX_SETCONSOLE=y
+FREETZ_BUSYBOX_SETSERIAL=y
+FREETZ_BUSYBOX_SHA3SUM=y
+FREETZ_BUSYBOX_SHOW_USAGE=y
+FREETZ_BUSYBOX_SHUF=y
+FREETZ_BUSYBOX_SLEEP=y
+FREETZ_BUSYBOX_SMEMCAP=y
+FREETZ_BUSYBOX_SORT=y
+FREETZ_BUSYBOX_SPLIT=y
+FREETZ_BUSYBOX_STACK_OPTIMIZATION_386=y
+FREETZ_BUSYBOX_START_STOP_DAEMON=y
+FREETZ_BUSYBOX_STAT=y
+FREETZ_BUSYBOX_STTY=y
+FREETZ_BUSYBOX_STUN_IP=y
+FREETZ_BUSYBOX_SWAPOFF=y
+FREETZ_BUSYBOX_SWAPON=y
+FREETZ_BUSYBOX_SWITCH_ROOT=y
+FREETZ_BUSYBOX_SYNC=y
+FREETZ_BUSYBOX_SYSLOGD=y
+FREETZ_BUSYBOX_TAIL=y
+FREETZ_BUSYBOX_TAR=y
+FREETZ_BUSYBOX_TASKSET=y
+FREETZ_BUSYBOX_TCPSVD=y
+FREETZ_BUSYBOX_TEE=y
+FREETZ_BUSYBOX_TEST=y
+FREETZ_BUSYBOX_TEST1=y
+FREETZ_BUSYBOX_TEST2=y
+FREETZ_BUSYBOX_TFTP=y
+FREETZ_BUSYBOX_TFTPD=y
+FREETZ_BUSYBOX_TIME=y
+FREETZ_BUSYBOX_TIMEOUT=y
+FREETZ_BUSYBOX_TOP=y
+FREETZ_BUSYBOX_TOUCH=y
+FREETZ_BUSYBOX_TR=y
+FREETZ_BUSYBOX_TRACEROUTE=y
+FREETZ_BUSYBOX_TRACEROUTE6=y
+FREETZ_BUSYBOX_TRUE=y
+FREETZ_BUSYBOX_TS=y
+FREETZ_BUSYBOX_TTY=y
+FREETZ_BUSYBOX_UDPSVD=y
+FREETZ_BUSYBOX_UMOUNT=y
+FREETZ_BUSYBOX_UNAME=y
+FREETZ_BUSYBOX_UNICODE_SUPPORT=y
+FREETZ_BUSYBOX_UNIQ=y
+FREETZ_BUSYBOX_UNXZ=y
+FREETZ_BUSYBOX_UNZIP=y
+FREETZ_BUSYBOX_UPTIME=y
+FREETZ_BUSYBOX_USE_BB_CRYPT=y
+FREETZ_BUSYBOX_USE_BB_CRYPT_SHA=y
+FREETZ_BUSYBOX_USERS=y
+FREETZ_BUSYBOX_USLEEP=y
+FREETZ_BUSYBOX_UUDECODE=y
+FREETZ_BUSYBOX_VCONFIG=y
+FREETZ_BUSYBOX_VERBOSE_RESOLUTION_ERRORS=y
+FREETZ_BUSYBOX_VI=y
+FREETZ_BUSYBOX_WC=y
+FREETZ_BUSYBOX_WHICH=y
+FREETZ_BUSYBOX_WHO=y
+FREETZ_BUSYBOX_WHOAMI=y
+FREETZ_BUSYBOX_WHOIS=y
+FREETZ_BUSYBOX_XARGS=y
+FREETZ_BUSYBOX_XXD=y
+FREETZ_BUSYBOX_XZ=y
+FREETZ_BUSYBOX_XZCAT=y
+FREETZ_BUSYBOX_YES=y
+FREETZ_BUSYBOX_ZCAT=y
+FREETZ_BUSYBOX___V136_HAVE_DOT_CONFIG=y
+
+#
+# Settings
+#
+# FREETZ_BUSYBOX___V136_DESKTOP is not set
+# FREETZ_BUSYBOX___V136_EXTRA_COMPAT is not set
+FREETZ_BUSYBOX___V136_INCLUDE_SUSv2=y
+FREETZ_BUSYBOX___V136_LONG_OPTS=y
+FREETZ_BUSYBOX___V136_SHOW_USAGE=y
+FREETZ_BUSYBOX___V136_FEATURE_VERBOSE_USAGE=y
+FREETZ_BUSYBOX___V136_FEATURE_COMPRESS_USAGE=y
+FREETZ_BUSYBOX___V136_LFS=y
+# FREETZ_BUSYBOX___V136_PAM is not set
+FREETZ_BUSYBOX___V136_FEATURE_DEVPTS=y
+FREETZ_BUSYBOX___V136_FEATURE_UTMP=y
+# FREETZ_BUSYBOX___V136_FEATURE_WTMP is not set
+FREETZ_BUSYBOX___V136_FEATURE_PIDFILE=y
+FREETZ_BUSYBOX___V136_PID_FILE_PATH="/var/run"
+FREETZ_BUSYBOX___V136_BUSYBOX=y
+# FREETZ_BUSYBOX___V136_FEATURE_SHOW_SCRIPT is not set
+# FREETZ_BUSYBOX___V136_FEATURE_INSTALLER is not set
+# FREETZ_BUSYBOX___V136_INSTALL_NO_USR is not set
+FREETZ_BUSYBOX___V136_FEATURE_SUID=y
+# FREETZ_BUSYBOX___V136_FEATURE_SUID_CONFIG is not set
+FREETZ_BUSYBOX___V136_BUSYBOX_EXEC_PATH="/proc/self/exe"
+# FREETZ_BUSYBOX___V136_SELINUX is not set
+# FREETZ_BUSYBOX___V136_FEATURE_CLEAN_UP is not set
+# FREETZ_BUSYBOX___V136_FEATURE_SYSLOG_INFO is not set
+FREETZ_BUSYBOX___V136_FEATURE_SYSLOG=y
+
+#
+# Build Options
+#
+# FREETZ_BUSYBOX___V136_STATIC is not set
+# FREETZ_BUSYBOX___V136_PIE is not set
+FREETZ_BUSYBOX___V136_CROSS_COMPILER_PREFIX=""
+FREETZ_BUSYBOX___V136_SYSROOT=""
+FREETZ_BUSYBOX___V136_EXTRA_CFLAGS=""
+FREETZ_BUSYBOX___V136_EXTRA_LDFLAGS=""
+FREETZ_BUSYBOX___V136_EXTRA_LDLIBS=""
+# FREETZ_BUSYBOX___V136_USE_PORTABLE_CODE is not set
+FREETZ_BUSYBOX___V136_STACK_OPTIMIZATION_386=y
+# FREETZ_BUSYBOX___V136_STATIC_LIBGCC is not set
+
+#
+# Installation Options ("make install" behavior)
+#
+FREETZ_BUSYBOX___V136_INSTALL_APPLET_SYMLINKS=y
+# FREETZ_BUSYBOX___V136_INSTALL_APPLET_HARDLINKS is not set
+# FREETZ_BUSYBOX___V136_INSTALL_APPLET_SCRIPT_WRAPPERS is not set
+# FREETZ_BUSYBOX___V136_INSTALL_APPLET_DONT is not set
+FREETZ_BUSYBOX___V136_PREFIX="./_install"
+
+#
+# Debugging Options
+#
+# FREETZ_BUSYBOX___V136_DEBUG is not set
+# FREETZ_BUSYBOX___V136_DEBUG_SANITIZE is not set
+# FREETZ_BUSYBOX___V136_UNIT_TEST is not set
+# FREETZ_BUSYBOX___V136_WERROR is not set
+# FREETZ_BUSYBOX___V136_WARN_SIMPLE_MSG is not set
+FREETZ_BUSYBOX___V136_NO_DEBUG_LIB=y
+# FREETZ_BUSYBOX___V136_DMALLOC is not set
+# FREETZ_BUSYBOX___V136_EFENCE is not set
+
+#
+# Library Tuning
+#
+# FREETZ_BUSYBOX___V136_FLOAT_DURATION is not set
+FREETZ_BUSYBOX___V136_FEATURE_RTMINMAX=y
+# FREETZ_BUSYBOX___V136_FEATURE_RTMINMAX_USE_LIBC_DEFINITIONS is not set
+FREETZ_BUSYBOX___V136_FEATURE_BUFFERS_USE_MALLOC=y
+# FREETZ_BUSYBOX___V136_FEATURE_BUFFERS_GO_ON_STACK is not set
+# FREETZ_BUSYBOX___V136_FEATURE_BUFFERS_GO_IN_BSS is not set
+FREETZ_BUSYBOX___V136_PASSWORD_MINLEN=6
+FREETZ_BUSYBOX___V136_MD5_SMALL=1
+FREETZ_BUSYBOX___V136_SHA1_SMALL=3
+# FREETZ_BUSYBOX___V136_SHA1_HWACCEL is not set
+# FREETZ_BUSYBOX___V136_SHA256_HWACCEL is not set
+FREETZ_BUSYBOX___V136_SHA3_SMALL=1
+FREETZ_BUSYBOX___V136_FEATURE_NON_POSIX_CP=y
+# FREETZ_BUSYBOX___V136_FEATURE_VERBOSE_CP_MESSAGE is not set
+FREETZ_BUSYBOX___V136_FEATURE_USE_SENDFILE=y
+FREETZ_BUSYBOX___V136_FEATURE_COPYBUF_KB=4
+FREETZ_BUSYBOX___V136_MONOTONIC_SYSCALL=y
+FREETZ_BUSYBOX___V136_IOCTL_HEX2STR_ERROR=y
+FREETZ_BUSYBOX___V136_FEATURE_EDITING=y
+FREETZ_BUSYBOX___V136_FEATURE_EDITING_MAX_LEN=1024
+# FREETZ_BUSYBOX___V136_FEATURE_EDITING_VI is not set
+FREETZ_BUSYBOX___V136_FEATURE_EDITING_HISTORY=255
+# FREETZ_BUSYBOX___V136_FEATURE_EDITING_SAVEHISTORY is not set
+# FREETZ_BUSYBOX___V136_FEATURE_REVERSE_SEARCH is not set
+FREETZ_BUSYBOX___V136_FEATURE_TAB_COMPLETION=y
+# FREETZ_BUSYBOX___V136_FEATURE_USERNAME_COMPLETION is not set
+FREETZ_BUSYBOX___V136_FEATURE_EDITING_FANCY_PROMPT=y
+FREETZ_BUSYBOX___V136_FEATURE_EDITING_WINCH=y
+# FREETZ_BUSYBOX___V136_FEATURE_EDITING_ASK_TERMINAL is not set
+# FREETZ_BUSYBOX___V136_LOCALE_SUPPORT is not set
+FREETZ_BUSYBOX___V136_UNICODE_SUPPORT=y
+# FREETZ_BUSYBOX___V136_FEATURE_CHECK_UNICODE_IN_ENV is not set
+FREETZ_BUSYBOX___V136_SUBST_WCHAR=63
+FREETZ_BUSYBOX___V136_LAST_SUPPORTED_WCHAR=767
+# FREETZ_BUSYBOX___V136_UNICODE_COMBINING_WCHARS is not set
+# FREETZ_BUSYBOX___V136_UNICODE_WIDE_WCHARS is not set
+# FREETZ_BUSYBOX___V136_UNICODE_BIDI_SUPPORT is not set
+# FREETZ_BUSYBOX___V136_UNICODE_PRESERVE_BROKEN is not set
+# FREETZ_BUSYBOX___V136_LOOP_CONFIGURE is not set
+# FREETZ_BUSYBOX___V136_NO_LOOP_CONFIGURE is not set
+FREETZ_BUSYBOX___V136_TRY_LOOP_CONFIGURE=y
+# end of Settings
+
+#
+# Applets
+#
+
+#
+# Archival Utilities
+#
+FREETZ_BUSYBOX___V136_FEATURE_SEAMLESS_XZ=y
+FREETZ_BUSYBOX___V136_FEATURE_SEAMLESS_LZMA=y
+FREETZ_BUSYBOX___V136_FEATURE_SEAMLESS_BZ2=y
+FREETZ_BUSYBOX___V136_FEATURE_SEAMLESS_GZ=y
+# FREETZ_BUSYBOX___V136_FEATURE_SEAMLESS_LZ is not set
+FREETZ_BUSYBOX___V136_FEATURE_SEAMLESS_Z=y
+FREETZ_BUSYBOX___V136_AR=y
+# FREETZ_BUSYBOX___V136_FEATURE_AR_LONG_FILENAMES is not set
+# FREETZ_BUSYBOX___V136_FEATURE_AR_CREATE is not set
+# FREETZ_BUSYBOX___V136_UNCOMPRESS is not set
+FREETZ_BUSYBOX___V136_GUNZIP=y
+FREETZ_BUSYBOX___V136_ZCAT=y
+# FREETZ_BUSYBOX___V136_FEATURE_GUNZIP_LONG_OPTIONS is not set
+FREETZ_BUSYBOX___V136_BUNZIP2=y
+FREETZ_BUSYBOX___V136_BZCAT=y
+# FREETZ_BUSYBOX___V136_LUNZIP is not set
+# FREETZ_BUSYBOX___V136_UNLZMA is not set
+# FREETZ_BUSYBOX___V136_LZCAT is not set
+# FREETZ_BUSYBOX___V136_LZMA is not set
+FREETZ_BUSYBOX___V136_UNXZ=y
+FREETZ_BUSYBOX___V136_XZCAT=y
+FREETZ_BUSYBOX___V136_XZ=y
+FREETZ_BUSYBOX___V136_BZIP2=y
+FREETZ_BUSYBOX___V136_BZIP2_SMALL=8
+FREETZ_BUSYBOX___V136_FEATURE_BZIP2_DECOMPRESS=y
+FREETZ_BUSYBOX___V136_CPIO=y
+# FREETZ_BUSYBOX___V136_FEATURE_CPIO_O is not set
+# FREETZ_BUSYBOX___V136_DPKG is not set
+# FREETZ_BUSYBOX___V136_DPKG_DEB is not set
+FREETZ_BUSYBOX___V136_GZIP=y
+# FREETZ_BUSYBOX___V136_FEATURE_GZIP_LONG_OPTIONS is not set
+FREETZ_BUSYBOX___V136_GZIP_FAST=0
+# FREETZ_BUSYBOX___V136_FEATURE_GZIP_LEVELS is not set
+FREETZ_BUSYBOX___V136_FEATURE_GZIP_DECOMPRESS=y
+# FREETZ_BUSYBOX___V136_LZIP is not set
+# FREETZ_BUSYBOX___V136_LZOP is not set
+# FREETZ_BUSYBOX___V136_UNLZOP is not set
+# FREETZ_BUSYBOX___V136_LZOPCAT is not set
+# FREETZ_BUSYBOX___V136_RPM is not set
+# FREETZ_BUSYBOX___V136_RPM2CPIO is not set
+FREETZ_BUSYBOX___V136_TAR=y
+FREETZ_BUSYBOX___V136_FEATURE_TAR_LONG_OPTIONS=y
+FREETZ_BUSYBOX___V136_FEATURE_TAR_CREATE=y
+# FREETZ_BUSYBOX___V136_FEATURE_TAR_AUTODETECT is not set
+FREETZ_BUSYBOX___V136_FEATURE_TAR_FROM=y
+FREETZ_BUSYBOX___V136_FEATURE_TAR_OLDGNU_COMPATIBILITY=y
+FREETZ_BUSYBOX___V136_FEATURE_TAR_OLDSUN_COMPATIBILITY=y
+FREETZ_BUSYBOX___V136_FEATURE_TAR_GNU_EXTENSIONS=y
+FREETZ_BUSYBOX___V136_FEATURE_TAR_TO_COMMAND=y
+FREETZ_BUSYBOX___V136_FEATURE_TAR_UNAME_GNAME=y
+# FREETZ_BUSYBOX___V136_FEATURE_TAR_NOPRESERVE_TIME is not set
+FREETZ_BUSYBOX___V136_UNZIP=y
+FREETZ_BUSYBOX___V136_FEATURE_UNZIP_CDF=y
+# FREETZ_BUSYBOX___V136_FEATURE_UNZIP_J_NUM is not set
+# FREETZ_BUSYBOX___V136_FEATURE_LZMA_FAST is not set
+# end of Archival Utilities
+
+#
+# Coreutils
+#
+FREETZ_BUSYBOX___V136_FEATURE_VERBOSE=y
+
+#
+# Common options for date and touch
+#
+
+#
+# Common options for cp and mv
+#
+FREETZ_BUSYBOX___V136_FEATURE_PRESERVE_HARDLINKS=y
+
+#
+# Common options for df, du, ls
+#
+FREETZ_BUSYBOX___V136_FEATURE_HUMAN_READABLE=y
+FREETZ_BUSYBOX___V136_BASENAME=y
+FREETZ_BUSYBOX___V136_CAT=y
+# FREETZ_BUSYBOX___V136_FEATURE_CATN is not set
+# FREETZ_BUSYBOX___V136_FEATURE_CATV is not set
+FREETZ_BUSYBOX___V136_CHGRP=y
+FREETZ_BUSYBOX___V136_CHMOD=y
+FREETZ_BUSYBOX___V136_CHOWN=y
+# FREETZ_BUSYBOX___V136_FEATURE_CHOWN_LONG_OPTIONS is not set
+FREETZ_BUSYBOX___V136_CHROOT=y
+# FREETZ_BUSYBOX___V136_CKSUM is not set
+# FREETZ_BUSYBOX___V136_CRC32 is not set
+# FREETZ_BUSYBOX___V136_COMM is not set
+FREETZ_BUSYBOX___V136_CP=y
+# FREETZ_BUSYBOX___V136_FEATURE_CP_LONG_OPTIONS is not set
+FREETZ_BUSYBOX___V136_CUT=y
+# FREETZ_BUSYBOX___V136_FEATURE_CUT_REGEX is not set
+FREETZ_BUSYBOX___V136_DATE=y
+FREETZ_BUSYBOX___V136_FEATURE_DATE_ISOFMT=y
+# FREETZ_BUSYBOX___V136_FEATURE_DATE_NANO is not set
+FREETZ_BUSYBOX___V136_FEATURE_DATE_COMPAT=y
+FREETZ_BUSYBOX___V136_DD=y
+FREETZ_BUSYBOX___V136_FEATURE_DD_SIGNAL_HANDLING=y
+# FREETZ_BUSYBOX___V136_FEATURE_DD_THIRD_STATUS_LINE is not set
+FREETZ_BUSYBOX___V136_FEATURE_DD_IBS_OBS=y
+FREETZ_BUSYBOX___V136_FEATURE_DD_STATUS=y
+FREETZ_BUSYBOX___V136_DF=y
+FREETZ_BUSYBOX___V136_FEATURE_DF_FANCY=y
+FREETZ_BUSYBOX___V136_FEATURE_SKIP_ROOTFS=y
+FREETZ_BUSYBOX___V136_DIRNAME=y
+FREETZ_BUSYBOX___V136_DOS2UNIX=y
+# FREETZ_BUSYBOX___V136_UNIX2DOS is not set
+FREETZ_BUSYBOX___V136_DU=y
+FREETZ_BUSYBOX___V136_FEATURE_DU_DEFAULT_BLOCKSIZE_1K=y
+FREETZ_BUSYBOX___V136_ECHO=y
+FREETZ_BUSYBOX___V136_FEATURE_FANCY_ECHO=y
+FREETZ_BUSYBOX___V136_ENV=y
+# FREETZ_BUSYBOX___V136_EXPAND is not set
+# FREETZ_BUSYBOX___V136_UNEXPAND is not set
+FREETZ_BUSYBOX___V136_EXPR=y
+FREETZ_BUSYBOX___V136_EXPR_MATH_SUPPORT_64=y
+FREETZ_BUSYBOX___V136_FACTOR=y
+FREETZ_BUSYBOX___V136_FALSE=y
+# FREETZ_BUSYBOX___V136_FOLD is not set
+FREETZ_BUSYBOX___V136_HEAD=y
+FREETZ_BUSYBOX___V136_FEATURE_FANCY_HEAD=y
+# FREETZ_BUSYBOX___V136_HOSTID is not set
+FREETZ_BUSYBOX___V136_ID=y
+FREETZ_BUSYBOX___V136_GROUPS=y
+# FREETZ_BUSYBOX___V136_INSTALL is not set
+# FREETZ_BUSYBOX___V136_LINK is not set
+FREETZ_BUSYBOX___V136_LN=y
+FREETZ_BUSYBOX___V136_LOGNAME=y
+FREETZ_BUSYBOX___V136_LS=y
+FREETZ_BUSYBOX___V136_FEATURE_LS_FILETYPES=y
+FREETZ_BUSYBOX___V136_FEATURE_LS_FOLLOWLINKS=y
+FREETZ_BUSYBOX___V136_FEATURE_LS_RECURSIVE=y
+# FREETZ_BUSYBOX___V136_FEATURE_LS_WIDTH is not set
+FREETZ_BUSYBOX___V136_FEATURE_LS_SORTFILES=y
+FREETZ_BUSYBOX___V136_FEATURE_LS_TIMESTAMPS=y
+FREETZ_BUSYBOX___V136_FEATURE_LS_USERNAME=y
+FREETZ_BUSYBOX___V136_FEATURE_LS_COLOR=y
+# FREETZ_BUSYBOX___V136_FEATURE_LS_COLOR_IS_DEFAULT is not set
+FREETZ_BUSYBOX___V136_MD5SUM=y
+# FREETZ_BUSYBOX___V136_SHA1SUM is not set
+# FREETZ_BUSYBOX___V136_SHA256SUM is not set
+# FREETZ_BUSYBOX___V136_SHA512SUM is not set
+FREETZ_BUSYBOX___V136_SHA3SUM=y
+
+#
+# Common options for md5sum, sha1sum, sha256sum, sha512sum, sha3sum
+#
+FREETZ_BUSYBOX___V136_FEATURE_MD5_SHA1_SUM_CHECK=y
+FREETZ_BUSYBOX___V136_MKDIR=y
+FREETZ_BUSYBOX___V136_MKFIFO=y
+FREETZ_BUSYBOX___V136_MKNOD=y
+FREETZ_BUSYBOX___V136_MKTEMP=y
+FREETZ_BUSYBOX___V136_MV=y
+FREETZ_BUSYBOX___V136_NICE=y
+# FREETZ_BUSYBOX___V136_NL is not set
+FREETZ_BUSYBOX___V136_NOHUP=y
+# FREETZ_BUSYBOX___V136_NPROC is not set
+FREETZ_BUSYBOX___V136_OD=y
+# FREETZ_BUSYBOX___V136_PASTE is not set
+FREETZ_BUSYBOX___V136_PRINTENV=y
+FREETZ_BUSYBOX___V136_PRINTF=y
+FREETZ_BUSYBOX___V136_PWD=y
+FREETZ_BUSYBOX___V136_READLINK=y
+FREETZ_BUSYBOX___V136_FEATURE_READLINK_FOLLOW=y
+FREETZ_BUSYBOX___V136_REALPATH=y
+FREETZ_BUSYBOX___V136_RM=y
+FREETZ_BUSYBOX___V136_RMDIR=y
+FREETZ_BUSYBOX___V136_SEQ=y
+# FREETZ_BUSYBOX___V136_SHRED is not set
+FREETZ_BUSYBOX___V136_SHUF=y
+FREETZ_BUSYBOX___V136_SLEEP=y
+FREETZ_BUSYBOX___V136_FEATURE_FANCY_SLEEP=y
+FREETZ_BUSYBOX___V136_SORT=y
+FREETZ_BUSYBOX___V136_FEATURE_SORT_BIG=y
+# FREETZ_BUSYBOX___V136_FEATURE_SORT_OPTIMIZE_MEMORY is not set
+FREETZ_BUSYBOX___V136_SPLIT=y
+FREETZ_BUSYBOX___V136_FEATURE_SPLIT_FANCY=y
+FREETZ_BUSYBOX___V136_STAT=y
+FREETZ_BUSYBOX___V136_FEATURE_STAT_FORMAT=y
+FREETZ_BUSYBOX___V136_FEATURE_STAT_FILESYSTEM=y
+FREETZ_BUSYBOX___V136_STTY=y
+# FREETZ_BUSYBOX___V136_SUM is not set
+FREETZ_BUSYBOX___V136_SYNC=y
+# FREETZ_BUSYBOX___V136_FEATURE_SYNC_FANCY is not set
+# FREETZ_BUSYBOX___V136_FSYNC is not set
+# FREETZ_BUSYBOX___V136_TAC is not set
+FREETZ_BUSYBOX___V136_TAIL=y
+FREETZ_BUSYBOX___V136_FEATURE_FANCY_TAIL=y
+FREETZ_BUSYBOX___V136_TEE=y
+FREETZ_BUSYBOX___V136_FEATURE_TEE_USE_BLOCK_IO=y
+FREETZ_BUSYBOX___V136_TEST=y
+FREETZ_BUSYBOX___V136_TEST1=y
+FREETZ_BUSYBOX___V136_TEST2=y
+FREETZ_BUSYBOX___V136_FEATURE_TEST_64=y
+FREETZ_BUSYBOX___V136_TIMEOUT=y
+FREETZ_BUSYBOX___V136_TOUCH=y
+FREETZ_BUSYBOX___V136_FEATURE_TOUCH_SUSV3=y
+FREETZ_BUSYBOX___V136_TR=y
+FREETZ_BUSYBOX___V136_FEATURE_TR_CLASSES=y
+FREETZ_BUSYBOX___V136_FEATURE_TR_EQUIV=y
+FREETZ_BUSYBOX___V136_TRUE=y
+# FREETZ_BUSYBOX___V136_TRUNCATE is not set
+# FREETZ_BUSYBOX___V136_TSORT is not set
+FREETZ_BUSYBOX___V136_TTY=y
+FREETZ_BUSYBOX___V136_UNAME=y
+FREETZ_BUSYBOX___V136_UNAME_OSNAME="GNU/Linux"
+# FREETZ_BUSYBOX___V136_BB_ARCH is not set
+FREETZ_BUSYBOX___V136_UNIQ=y
+# FREETZ_BUSYBOX___V136_UNLINK is not set
+FREETZ_BUSYBOX___V136_USLEEP=y
+FREETZ_BUSYBOX___V136_UUDECODE=y
+# FREETZ_BUSYBOX___V136_BASE32 is not set
+FREETZ_BUSYBOX___V136_BASE64=y
+# FREETZ_BUSYBOX___V136_UUENCODE is not set
+FREETZ_BUSYBOX___V136_WC=y
+FREETZ_BUSYBOX___V136_FEATURE_WC_LARGE=y
+FREETZ_BUSYBOX___V136_WHO=y
+# FREETZ_BUSYBOX___V136_W is not set
+FREETZ_BUSYBOX___V136_USERS=y
+FREETZ_BUSYBOX___V136_WHOAMI=y
+FREETZ_BUSYBOX___V136_YES=y
+# end of Coreutils
+
+#
+# Console Utilities
+#
+# FREETZ_BUSYBOX___V136_CHVT is not set
+# FREETZ_BUSYBOX___V136_CLEAR is not set
+# FREETZ_BUSYBOX___V136_DEALLOCVT is not set
+# FREETZ_BUSYBOX___V136_DUMPKMAP is not set
+FREETZ_BUSYBOX___V136_FGCONSOLE=y
+# FREETZ_BUSYBOX___V136_KBD_MODE is not set
+# FREETZ_BUSYBOX___V136_LOADFONT is not set
+# FREETZ_BUSYBOX___V136_SETFONT is not set
+# FREETZ_BUSYBOX___V136_LOADKMAP is not set
+# FREETZ_BUSYBOX___V136_OPENVT is not set
+FREETZ_BUSYBOX___V136_RESET=y
+# FREETZ_BUSYBOX___V136_RESIZE is not set
+FREETZ_BUSYBOX___V136_SETCONSOLE=y
+FREETZ_BUSYBOX___V136_FEATURE_SETCONSOLE_LONG_OPTIONS=y
+# FREETZ_BUSYBOX___V136_SETKEYCODES is not set
+# FREETZ_BUSYBOX___V136_SETLOGCONS is not set
+# FREETZ_BUSYBOX___V136_SHOWKEY is not set
+# end of Console Utilities
+
+#
+# Debian Utilities
+#
+# FREETZ_BUSYBOX___V136_PIPE_PROGRESS is not set
+# FREETZ_BUSYBOX___V136_RUN_PARTS is not set
+FREETZ_BUSYBOX___V136_START_STOP_DAEMON=y
+# FREETZ_BUSYBOX___V136_FEATURE_START_STOP_DAEMON_LONG_OPTIONS is not set
+FREETZ_BUSYBOX___V136_FEATURE_START_STOP_DAEMON_FANCY=y
+FREETZ_BUSYBOX___V136_WHICH=y
+# end of Debian Utilities
+
+#
+# klibc-utils
+#
+# FREETZ_BUSYBOX___V136_MINIPS is not set
+# FREETZ_BUSYBOX___V136_NUKE is not set
+# FREETZ_BUSYBOX___V136_RESUME is not set
+# FREETZ_BUSYBOX___V136_RUN_INIT is not set
+# end of klibc-utils
+
+#
+# Editors
+#
+FREETZ_BUSYBOX___V136_AWK=y
+# FREETZ_BUSYBOX___V136_FEATURE_AWK_LIBM is not set
+# FREETZ_BUSYBOX___V136_FEATURE_AWK_GNU_EXTENSIONS is not set
+FREETZ_BUSYBOX___V136_CMP=y
+# FREETZ_BUSYBOX___V136_DIFF is not set
+# FREETZ_BUSYBOX___V136_ED is not set
+# FREETZ_BUSYBOX___V136_PATCH is not set
+FREETZ_BUSYBOX___V136_SED=y
+FREETZ_BUSYBOX___V136_VI=y
+FREETZ_BUSYBOX___V136_FEATURE_VI_MAX_LEN=4096
+FREETZ_BUSYBOX___V136_FEATURE_VI_8BIT=y
+FREETZ_BUSYBOX___V136_FEATURE_VI_COLON=y
+# FREETZ_BUSYBOX___V136_FEATURE_VI_COLON_EXPAND is not set
+FREETZ_BUSYBOX___V136_FEATURE_VI_YANKMARK=y
+FREETZ_BUSYBOX___V136_FEATURE_VI_SEARCH=y
+# FREETZ_BUSYBOX___V136_FEATURE_VI_REGEX_SEARCH is not set
+FREETZ_BUSYBOX___V136_FEATURE_VI_USE_SIGNALS=y
+FREETZ_BUSYBOX___V136_FEATURE_VI_DOT_CMD=y
+FREETZ_BUSYBOX___V136_FEATURE_VI_READONLY=y
+FREETZ_BUSYBOX___V136_FEATURE_VI_SETOPTS=y
+FREETZ_BUSYBOX___V136_FEATURE_VI_SET=y
+FREETZ_BUSYBOX___V136_FEATURE_VI_WIN_RESIZE=y
+FREETZ_BUSYBOX___V136_FEATURE_VI_ASK_TERMINAL=y
+# FREETZ_BUSYBOX___V136_FEATURE_VI_UNDO is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VI_VERBOSE_STATUS is not set
+FREETZ_BUSYBOX___V136_FEATURE_ALLOW_EXEC=y
+# end of Editors
+
+#
+# Finding Utilities
+#
+FREETZ_BUSYBOX___V136_FIND=y
+FREETZ_BUSYBOX___V136_FEATURE_FIND_PRINT0=y
+FREETZ_BUSYBOX___V136_FEATURE_FIND_MTIME=y
+# FREETZ_BUSYBOX___V136_FEATURE_FIND_ATIME is not set
+# FREETZ_BUSYBOX___V136_FEATURE_FIND_CTIME is not set
+FREETZ_BUSYBOX___V136_FEATURE_FIND_MMIN=y
+# FREETZ_BUSYBOX___V136_FEATURE_FIND_AMIN is not set
+# FREETZ_BUSYBOX___V136_FEATURE_FIND_CMIN is not set
+FREETZ_BUSYBOX___V136_FEATURE_FIND_PERM=y
+FREETZ_BUSYBOX___V136_FEATURE_FIND_TYPE=y
+# FREETZ_BUSYBOX___V136_FEATURE_FIND_EXECUTABLE is not set
+FREETZ_BUSYBOX___V136_FEATURE_FIND_XDEV=y
+FREETZ_BUSYBOX___V136_FEATURE_FIND_MAXDEPTH=y
+FREETZ_BUSYBOX___V136_FEATURE_FIND_NEWER=y
+FREETZ_BUSYBOX___V136_FEATURE_FIND_INUM=y
+# FREETZ_BUSYBOX___V136_FEATURE_FIND_SAMEFILE is not set
+FREETZ_BUSYBOX___V136_FEATURE_FIND_EXEC=y
+# FREETZ_BUSYBOX___V136_FEATURE_FIND_EXEC_PLUS is not set
+FREETZ_BUSYBOX___V136_FEATURE_FIND_USER=y
+FREETZ_BUSYBOX___V136_FEATURE_FIND_GROUP=y
+FREETZ_BUSYBOX___V136_FEATURE_FIND_NOT=y
+FREETZ_BUSYBOX___V136_FEATURE_FIND_DEPTH=y
+FREETZ_BUSYBOX___V136_FEATURE_FIND_PAREN=y
+FREETZ_BUSYBOX___V136_FEATURE_FIND_SIZE=y
+FREETZ_BUSYBOX___V136_FEATURE_FIND_PRUNE=y
+# FREETZ_BUSYBOX___V136_FEATURE_FIND_QUIT is not set
+# FREETZ_BUSYBOX___V136_FEATURE_FIND_DELETE is not set
+# FREETZ_BUSYBOX___V136_FEATURE_FIND_EMPTY is not set
+FREETZ_BUSYBOX___V136_FEATURE_FIND_PATH=y
+FREETZ_BUSYBOX___V136_FEATURE_FIND_REGEX=y
+# FREETZ_BUSYBOX___V136_FEATURE_FIND_LINKS is not set
+FREETZ_BUSYBOX___V136_GREP=y
+FREETZ_BUSYBOX___V136_EGREP=y
+FREETZ_BUSYBOX___V136_FGREP=y
+FREETZ_BUSYBOX___V136_FEATURE_GREP_CONTEXT=y
+FREETZ_BUSYBOX___V136_XARGS=y
+FREETZ_BUSYBOX___V136_FEATURE_XARGS_SUPPORT_CONFIRMATION=y
+FREETZ_BUSYBOX___V136_FEATURE_XARGS_SUPPORT_QUOTES=y
+FREETZ_BUSYBOX___V136_FEATURE_XARGS_SUPPORT_TERMOPT=y
+FREETZ_BUSYBOX___V136_FEATURE_XARGS_SUPPORT_ZERO_TERM=y
+# FREETZ_BUSYBOX___V136_FEATURE_XARGS_SUPPORT_REPL_STR is not set
+# FREETZ_BUSYBOX___V136_FEATURE_XARGS_SUPPORT_PARALLEL is not set
+FREETZ_BUSYBOX___V136_FEATURE_XARGS_SUPPORT_ARGS_FILE=y
+# end of Finding Utilities
+
+#
+# Init Utilities
+#
+# FREETZ_BUSYBOX___V136_BOOTCHARTD is not set
+FREETZ_BUSYBOX___V136_HALT=y
+FREETZ_BUSYBOX___V136_POWEROFF=y
+FREETZ_BUSYBOX___V136_REBOOT=y
+FREETZ_BUSYBOX___V136_FEATURE_WAIT_FOR_INIT=y
+FREETZ_BUSYBOX___V136_INIT=y
+# FREETZ_BUSYBOX___V136_LINUXRC is not set
+FREETZ_BUSYBOX___V136_FEATURE_USE_INITTAB=y
+FREETZ_BUSYBOX___V136_FEATURE_KILL_REMOVED=y
+FREETZ_BUSYBOX___V136_FEATURE_KILL_DELAY=0
+FREETZ_BUSYBOX___V136_FEATURE_INIT_SCTTY=y
+FREETZ_BUSYBOX___V136_FEATURE_INIT_SYSLOG=y
+FREETZ_BUSYBOX___V136_FEATURE_INIT_QUIET=y
+# FREETZ_BUSYBOX___V136_FEATURE_INIT_COREDUMPS is not set
+FREETZ_BUSYBOX___V136_INIT_TERMINAL_TYPE="linux"
+FREETZ_BUSYBOX___V136_FEATURE_INIT_MODIFY_CMDLINE=y
+# end of Init Utilities
+
+#
+# Login/Password Management Utilities
+#
+FREETZ_BUSYBOX___V136_FEATURE_SHADOWPASSWDS=y
+FREETZ_BUSYBOX___V136_USE_BB_CRYPT=y
+FREETZ_BUSYBOX___V136_USE_BB_CRYPT_SHA=y
+# FREETZ_BUSYBOX___V136_ADD_SHELL is not set
+# FREETZ_BUSYBOX___V136_REMOVE_SHELL is not set
+FREETZ_BUSYBOX___V136_ADDGROUP=y
+FREETZ_BUSYBOX___V136_FEATURE_ADDUSER_TO_GROUP=y
+FREETZ_BUSYBOX___V136_ADDUSER=y
+# FREETZ_BUSYBOX___V136_FEATURE_CHECK_NAMES is not set
+FREETZ_BUSYBOX___V136_LAST_ID=60000
+FREETZ_BUSYBOX___V136_FIRST_SYSTEM_ID=100
+FREETZ_BUSYBOX___V136_LAST_SYSTEM_ID=899
+# FREETZ_BUSYBOX___V136_CHPASSWD is not set
+FREETZ_BUSYBOX___V136_FEATURE_DEFAULT_PASSWD_ALGO="sha512"
+FREETZ_BUSYBOX___V136_CRYPTPW=y
+FREETZ_BUSYBOX___V136_MKPASSWD=y
+FREETZ_BUSYBOX___V136_DELUSER=y
+FREETZ_BUSYBOX___V136_DELGROUP=y
+FREETZ_BUSYBOX___V136_FEATURE_DEL_USER_FROM_GROUP=y
+# FREETZ_BUSYBOX___V136_GETTY is not set
+FREETZ_BUSYBOX___V136_LOGIN=y
+# FREETZ_BUSYBOX___V136_LOGIN_SESSION_AS_CHILD is not set
+# FREETZ_BUSYBOX___V136_LOGIN_SCRIPTS is not set
+FREETZ_BUSYBOX___V136_FEATURE_NOLOGIN=y
+FREETZ_BUSYBOX___V136_FEATURE_SECURETTY=y
+FREETZ_BUSYBOX___V136_PASSWD=y
+FREETZ_BUSYBOX___V136_FEATURE_PASSWD_WEAK_CHECK=y
+# FREETZ_BUSYBOX___V136_SU is not set
+# FREETZ_BUSYBOX___V136_SULOGIN is not set
+# FREETZ_BUSYBOX___V136_VLOCK is not set
+# end of Login/Password Management Utilities
+
+#
+# Linux Ext2 FS Progs
+#
+# FREETZ_BUSYBOX___V136_CHATTR is not set
+# FREETZ_BUSYBOX___V136_FSCK is not set
+# FREETZ_BUSYBOX___V136_LSATTR is not set
+# FREETZ_BUSYBOX___V136_TUNE2FS is not set
+# end of Linux Ext2 FS Progs
+
+#
+# Linux Module Utilities
+#
+# FREETZ_BUSYBOX___V136_DEPMOD is not set
+# FREETZ_BUSYBOX___V136_MODINFO is not set
+
+#
+# Options common to multiple modutils
+#
+# end of Linux Module Utilities
+
+#
+# Linux System Utilities
+#
+# FREETZ_BUSYBOX___V136_ACPID is not set
+# FREETZ_BUSYBOX___V136_BLKDISCARD is not set
+# FREETZ_BUSYBOX___V136_BLOCKDEV is not set
+# FREETZ_BUSYBOX___V136_CAL is not set
+FREETZ_BUSYBOX___V136_CHRT=y
+# FREETZ_BUSYBOX___V136_EJECT is not set
+# FREETZ_BUSYBOX___V136_FATATTR is not set
+# FREETZ_BUSYBOX___V136_FBSET is not set
+# FREETZ_BUSYBOX___V136_FDFORMAT is not set
+# FREETZ_BUSYBOX___V136_FDISK is not set
+# FREETZ_BUSYBOX___V136_FINDFS is not set
+FREETZ_BUSYBOX___V136_FLOCK=y
+# FREETZ_BUSYBOX___V136_FDFLUSH is not set
+# FREETZ_BUSYBOX___V136_FREERAMDISK is not set
+# FREETZ_BUSYBOX___V136_FSCK_MINIX is not set
+# FREETZ_BUSYBOX___V136_FSFREEZE is not set
+FREETZ_BUSYBOX___V136_FSTRIM=y
+FREETZ_BUSYBOX___V136_GETOPT=y
+FREETZ_BUSYBOX___V136_FEATURE_GETOPT_LONG=y
+FREETZ_BUSYBOX___V136_HEXDUMP=y
+# FREETZ_BUSYBOX___V136_HD is not set
+FREETZ_BUSYBOX___V136_XXD=y
+# FREETZ_BUSYBOX___V136_HWCLOCK is not set
+# FREETZ_BUSYBOX___V136_IONICE is not set
+# FREETZ_BUSYBOX___V136_IPCRM is not set
+# FREETZ_BUSYBOX___V136_IPCS is not set
+# FREETZ_BUSYBOX___V136_LOSETUP is not set
+# FREETZ_BUSYBOX___V136_LSPCI is not set
+# FREETZ_BUSYBOX___V136_LSUSB is not set
+# FREETZ_BUSYBOX___V136_MDEV is not set
+# FREETZ_BUSYBOX___V136_MESG is not set
+# FREETZ_BUSYBOX___V136_MKE2FS is not set
+# FREETZ_BUSYBOX___V136_MKFS_EXT2 is not set
+# FREETZ_BUSYBOX___V136_MKFS_MINIX is not set
+# FREETZ_BUSYBOX___V136_MKFS_REISER is not set
+# FREETZ_BUSYBOX___V136_MKDOSFS is not set
+# FREETZ_BUSYBOX___V136_MKFS_VFAT is not set
+FREETZ_BUSYBOX___V136_MKSWAP=y
+# FREETZ_BUSYBOX___V136_FEATURE_MKSWAP_UUID is not set
+FREETZ_BUSYBOX___V136_MORE=y
+FREETZ_BUSYBOX___V136_MOUNT=y
+FREETZ_BUSYBOX___V136_FEATURE_MOUNT_FAKE=y
+FREETZ_BUSYBOX___V136_FEATURE_MOUNT_VERBOSE=y
+FREETZ_BUSYBOX___V136_FEATURE_MOUNT_HELPERS=y
+FREETZ_BUSYBOX___V136_FEATURE_MOUNT_LABEL=y
+FREETZ_BUSYBOX___V136_FEATURE_MOUNT_CIFS=y
+FREETZ_BUSYBOX___V136_FEATURE_MOUNT_FLAGS=y
+FREETZ_BUSYBOX___V136_FEATURE_MOUNT_FSTAB=y
+FREETZ_BUSYBOX___V136_FEATURE_MOUNT_OTHERTAB=y
+# FREETZ_BUSYBOX___V136_MOUNTPOINT is not set
+FREETZ_BUSYBOX___V136_NOLOGIN=y
+# FREETZ_BUSYBOX___V136_NOLOGIN_DEPENDENCIES is not set
+# FREETZ_BUSYBOX___V136_NSENTER is not set
+FREETZ_BUSYBOX___V136_PIVOT_ROOT=y
+# FREETZ_BUSYBOX___V136_RDATE is not set
+# FREETZ_BUSYBOX___V136_RDEV is not set
+# FREETZ_BUSYBOX___V136_READPROFILE is not set
+FREETZ_BUSYBOX___V136_RENICE=y
+# FREETZ_BUSYBOX___V136_REV is not set
+# FREETZ_BUSYBOX___V136_RTCWAKE is not set
+# FREETZ_BUSYBOX___V136_SCRIPT is not set
+# FREETZ_BUSYBOX___V136_SCRIPTREPLAY is not set
+# FREETZ_BUSYBOX___V136_SETARCH is not set
+# FREETZ_BUSYBOX___V136_LINUX32 is not set
+# FREETZ_BUSYBOX___V136_LINUX64 is not set
+# FREETZ_BUSYBOX___V136_SETPRIV is not set
+# FREETZ_BUSYBOX___V136_SETSID is not set
+FREETZ_BUSYBOX___V136_SWAPON=y
+# FREETZ_BUSYBOX___V136_FEATURE_SWAPON_DISCARD is not set
+FREETZ_BUSYBOX___V136_FEATURE_SWAPON_PRI=y
+FREETZ_BUSYBOX___V136_SWAPOFF=y
+FREETZ_BUSYBOX___V136_FEATURE_SWAPONOFF_LABEL=y
+FREETZ_BUSYBOX___V136_SWITCH_ROOT=y
+FREETZ_BUSYBOX___V136_TASKSET=y
+FREETZ_BUSYBOX___V136_FEATURE_TASKSET_FANCY=y
+# FREETZ_BUSYBOX___V136_FEATURE_TASKSET_CPULIST is not set
+# FREETZ_BUSYBOX___V136_UEVENT is not set
+FREETZ_BUSYBOX___V136_UMOUNT=y
+FREETZ_BUSYBOX___V136_FEATURE_UMOUNT_ALL=y
+# FREETZ_BUSYBOX___V136_UNSHARE is not set
+# FREETZ_BUSYBOX___V136_WALL is not set
+
+#
+# Common options for mount/umount
+#
+FREETZ_BUSYBOX___V136_FEATURE_MOUNT_LOOP=y
+FREETZ_BUSYBOX___V136_FEATURE_MOUNT_LOOP_CREATE=y
+FREETZ_BUSYBOX___V136_FEATURE_MTAB_SUPPORT=y
+FREETZ_BUSYBOX___V136_VOLUMEID=y
+
+#
+# Filesystem/Volume identification
+#
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_BCACHE is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_BTRFS is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_CRAMFS is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_EROFS is not set
+FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_EXFAT=y
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_EXT is not set
+FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_F2FS=y
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_FAT is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_HFS is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_ISO9660 is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_JFS is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_LINUXRAID is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_LINUXSWAP is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_LUKS is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_MINIX is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_NILFS is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_NTFS is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_OCFS2 is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_REISERFS is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_ROMFS is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_SYSV is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_UBIFS is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_UDF is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_XFS is not set
+# end of Filesystem/Volume identification
+# end of Linux System Utilities
+
+#
+# Miscellaneous Utilities
+#
+# FREETZ_BUSYBOX___V136_ADJTIMEX is not set
+# FREETZ_BUSYBOX___V136_ASCII is not set
+FREETZ_BUSYBOX___V136_BBCONFIG=y
+FREETZ_BUSYBOX___V136_FEATURE_COMPRESS_BBCONFIG=y
+FREETZ_BUSYBOX___V136_BC=y
+# FREETZ_BUSYBOX___V136_DC is not set
+FREETZ_BUSYBOX___V136_FEATURE_DC_BIG=y
+# FREETZ_BUSYBOX___V136_FEATURE_BC_INTERACTIVE is not set
+# FREETZ_BUSYBOX___V136_FEATURE_BC_LONG_OPTIONS is not set
+FREETZ_BUSYBOX___V136_BEEP=y
+FREETZ_BUSYBOX___V136_FEATURE_BEEP_FREQ=4000
+FREETZ_BUSYBOX___V136_FEATURE_BEEP_LENGTH_MS=30
+# FREETZ_BUSYBOX___V136_CHAT is not set
+# FREETZ_BUSYBOX___V136_CONSPY is not set
+FREETZ_BUSYBOX___V136_CROND=y
+# FREETZ_BUSYBOX___V136_FEATURE_CROND_D is not set
+# FREETZ_BUSYBOX___V136_FEATURE_CROND_CALL_SENDMAIL is not set
+# FREETZ_BUSYBOX___V136_FEATURE_CROND_ROOT_NOLOG is not set
+# FREETZ_BUSYBOX___V136_FEATURE_CROND_SPECIAL_TIMES is not set
+FREETZ_BUSYBOX___V136_FEATURE_CROND_DIR="/mod/var/spool/cron"
+FREETZ_BUSYBOX___V136_CRONTAB=y
+# FREETZ_BUSYBOX___V136_DEVFSD is not set
+# FREETZ_BUSYBOX___V136_FEATURE_DEVFS is not set
+FREETZ_BUSYBOX___V136_DEVMEM=y
+# FREETZ_BUSYBOX___V136_FBSPLASH is not set
+# FREETZ_BUSYBOX___V136_FLASH_ERASEALL is not set
+# FREETZ_BUSYBOX___V136_FLASH_LOCK is not set
+# FREETZ_BUSYBOX___V136_FLASH_UNLOCK is not set
+# FREETZ_BUSYBOX___V136_FLASHCP is not set
+# FREETZ_BUSYBOX___V136_HDPARM is not set
+# FREETZ_BUSYBOX___V136_HEXEDIT is not set
+# FREETZ_BUSYBOX___V136_I2CGET is not set
+# FREETZ_BUSYBOX___V136_I2CSET is not set
+# FREETZ_BUSYBOX___V136_I2CDUMP is not set
+# FREETZ_BUSYBOX___V136_I2CDETECT is not set
+FREETZ_BUSYBOX___V136_I2CTRANSFER=y
+FREETZ_BUSYBOX___V136_INOTIFYD=y
+# FREETZ_BUSYBOX___V136_LESS is not set
+# FREETZ_BUSYBOX___V136_LSSCSI is not set
+FREETZ_BUSYBOX___V136_MAKEDEVS=y
+# FREETZ_BUSYBOX___V136_FEATURE_MAKEDEVS_LEAF is not set
+FREETZ_BUSYBOX___V136_FEATURE_MAKEDEVS_TABLE=y
+# FREETZ_BUSYBOX___V136_MAN is not set
+# FREETZ_BUSYBOX___V136_MICROCOM is not set
+# FREETZ_BUSYBOX___V136_MIM is not set
+# FREETZ_BUSYBOX___V136_MT is not set
+# FREETZ_BUSYBOX___V136_NANDWRITE is not set
+# FREETZ_BUSYBOX___V136_PARTPROBE is not set
+# FREETZ_BUSYBOX___V136_RAIDAUTORUN is not set
+# FREETZ_BUSYBOX___V136_READAHEAD is not set
+# FREETZ_BUSYBOX___V136_RFKILL is not set
+# FREETZ_BUSYBOX___V136_RUNLEVEL is not set
+# FREETZ_BUSYBOX___V136_RX is not set
+# FREETZ_BUSYBOX___V136_SEEDRNG is not set
+# FREETZ_BUSYBOX___V136_SETFATTR is not set
+FREETZ_BUSYBOX___V136_SETSERIAL=y
+# FREETZ_BUSYBOX___V136_STRINGS is not set
+FREETZ_BUSYBOX___V136_TIME=y
+# FREETZ_BUSYBOX___V136_TREE is not set
+FREETZ_BUSYBOX___V136_TS=y
+# FREETZ_BUSYBOX___V136_TTYSIZE is not set
+# FREETZ_BUSYBOX___V136_VOLNAME is not set
+# FREETZ_BUSYBOX___V136_WATCHDOG is not set
+# end of Miscellaneous Utilities
+
+#
+# Networking Utilities
+#
+FREETZ_BUSYBOX___V136_FEATURE_IPV6=y
+# FREETZ_BUSYBOX___V136_FEATURE_UNIX_LOCAL is not set
+FREETZ_BUSYBOX___V136_FEATURE_PREFER_IPV4_ADDRESS=y
+FREETZ_BUSYBOX___V136_VERBOSE_RESOLUTION_ERRORS=y
+# FREETZ_BUSYBOX___V136_FEATURE_ETC_NETWORKS is not set
+# FREETZ_BUSYBOX___V136_FEATURE_ETC_SERVICES is not set
+FREETZ_BUSYBOX___V136_FEATURE_HWIB=y
+FREETZ_BUSYBOX___V136_ARP=y
+FREETZ_BUSYBOX___V136_ARPING=y
+FREETZ_BUSYBOX___V136_BRCTL=y
+FREETZ_BUSYBOX___V136_FEATURE_BRCTL_FANCY=y
+FREETZ_BUSYBOX___V136_FEATURE_BRCTL_SHOW=y
+# FREETZ_BUSYBOX___V136_DNSD is not set
+FREETZ_BUSYBOX___V136_ETHER_WAKE=y
+# FREETZ_BUSYBOX___V136_FTPD is not set
+FREETZ_BUSYBOX___V136_FTPGET=y
+FREETZ_BUSYBOX___V136_FTPPUT=y
+FREETZ_BUSYBOX___V136_FEATURE_FTPGETPUT_LONG_OPTIONS=y
+FREETZ_BUSYBOX___V136_HOSTNAME=y
+FREETZ_BUSYBOX___V136_DNSDOMAINNAME=y
+FREETZ_BUSYBOX___V136_HTTPD=y
+FREETZ_BUSYBOX___V136_FEATURE_HTTPD_PORT_DEFAULT=80
+# FREETZ_BUSYBOX___V136_FEATURE_HTTPD_RANGES is not set
+# FREETZ_BUSYBOX___V136_FEATURE_HTTPD_SETUID is not set
+FREETZ_BUSYBOX___V136_FEATURE_HTTPD_BASIC_AUTH=y
+FREETZ_BUSYBOX___V136_FEATURE_HTTPD_AUTH_MD5=y
+FREETZ_BUSYBOX___V136_FEATURE_HTTPD_CGI=y
+FREETZ_BUSYBOX___V136_FEATURE_HTTPD_CONFIG_WITH_SCRIPT_INTERPR=y
+# FREETZ_BUSYBOX___V136_FEATURE_HTTPD_SET_REMOTE_PORT_TO_ENV is not set
+FREETZ_BUSYBOX___V136_FEATURE_HTTPD_ENCODE_URL_STR=y
+# FREETZ_BUSYBOX___V136_FEATURE_HTTPD_ERROR_PAGES is not set
+# FREETZ_BUSYBOX___V136_FEATURE_HTTPD_PROXY is not set
+# FREETZ_BUSYBOX___V136_FEATURE_HTTPD_GZIP is not set
+# FREETZ_BUSYBOX___V136_FEATURE_HTTPD_ETAG is not set
+# FREETZ_BUSYBOX___V136_FEATURE_HTTPD_LAST_MODIFIED is not set
+# FREETZ_BUSYBOX___V136_FEATURE_HTTPD_DATE is not set
+# FREETZ_BUSYBOX___V136_FEATURE_HTTPD_ACL_IP is not set
+FREETZ_BUSYBOX___V136_IFCONFIG=y
+FREETZ_BUSYBOX___V136_FEATURE_IFCONFIG_STATUS=y
+FREETZ_BUSYBOX___V136_FEATURE_IFCONFIG_SLIP=y
+FREETZ_BUSYBOX___V136_FEATURE_IFCONFIG_MEMSTART_IOADDR_IRQ=y
+FREETZ_BUSYBOX___V136_FEATURE_IFCONFIG_HW=y
+FREETZ_BUSYBOX___V136_FEATURE_IFCONFIG_BROADCAST_PLUS=y
+# FREETZ_BUSYBOX___V136_IFENSLAVE is not set
+# FREETZ_BUSYBOX___V136_IFPLUGD is not set
+FREETZ_BUSYBOX___V136_IFUP=y
+FREETZ_BUSYBOX___V136_IFDOWN=y
+FREETZ_BUSYBOX___V136_IFUPDOWN_IFSTATE_PATH="/var/run/ifstate"
+FREETZ_BUSYBOX___V136_FEATURE_IFUPDOWN_IP=y
+FREETZ_BUSYBOX___V136_FEATURE_IFUPDOWN_IPV4=y
+FREETZ_BUSYBOX___V136_FEATURE_IFUPDOWN_IPV6=y
+FREETZ_BUSYBOX___V136_FEATURE_IFUPDOWN_MAPPING=y
+# FREETZ_BUSYBOX___V136_FEATURE_IFUPDOWN_EXTERNAL_DHCP is not set
+FREETZ_BUSYBOX___V136_INETD=y
+FREETZ_BUSYBOX___V136_FEATURE_INETD_SUPPORT_BUILTIN_ECHO=y
+FREETZ_BUSYBOX___V136_FEATURE_INETD_SUPPORT_BUILTIN_DISCARD=y
+FREETZ_BUSYBOX___V136_FEATURE_INETD_SUPPORT_BUILTIN_TIME=y
+FREETZ_BUSYBOX___V136_FEATURE_INETD_SUPPORT_BUILTIN_DAYTIME=y
+FREETZ_BUSYBOX___V136_FEATURE_INETD_SUPPORT_BUILTIN_CHARGEN=y
+FREETZ_BUSYBOX___V136_IP=y
+FREETZ_BUSYBOX___V136_IPADDR=y
+FREETZ_BUSYBOX___V136_IPLINK=y
+FREETZ_BUSYBOX___V136_IPROUTE=y
+FREETZ_BUSYBOX___V136_IPTUNNEL=y
+FREETZ_BUSYBOX___V136_IPRULE=y
+FREETZ_BUSYBOX___V136_IPNEIGH=y
+FREETZ_BUSYBOX___V136_FEATURE_IP_ADDRESS=y
+FREETZ_BUSYBOX___V136_FEATURE_IP_LINK=y
+FREETZ_BUSYBOX___V136_FEATURE_IP_ROUTE=y
+FREETZ_BUSYBOX___V136_FEATURE_IP_ROUTE_DIR="/etc/iproute2"
+FREETZ_BUSYBOX___V136_FEATURE_IP_TUNNEL=y
+FREETZ_BUSYBOX___V136_FEATURE_IP_RULE=y
+FREETZ_BUSYBOX___V136_FEATURE_IP_NEIGH=y
+# FREETZ_BUSYBOX___V136_FEATURE_IP_RARE_PROTOCOLS is not set
+# FREETZ_BUSYBOX___V136_IPCALC is not set
+# FREETZ_BUSYBOX___V136_FAKEIDENTD is not set
+# FREETZ_BUSYBOX___V136_NAMEIF is not set
+FREETZ_BUSYBOX___V136_NBDCLIENT=y
+FREETZ_BUSYBOX___V136_NC=y
+FREETZ_BUSYBOX___V136_NETCAT=y
+# FREETZ_BUSYBOX___V136_NC_SERVER is not set
+FREETZ_BUSYBOX___V136_NC_EXTRA=y
+FREETZ_BUSYBOX___V136_NC_110_COMPAT=y
+FREETZ_BUSYBOX___V136_NETSTAT=y
+FREETZ_BUSYBOX___V136_FEATURE_NETSTAT_WIDE=y
+FREETZ_BUSYBOX___V136_FEATURE_NETSTAT_PRG=y
+FREETZ_BUSYBOX___V136_NSLOOKUP=y
+# FREETZ_BUSYBOX___V136_FEATURE_NSLOOKUP_BIG is not set
+# FREETZ_BUSYBOX___V136_NTPD is not set
+FREETZ_BUSYBOX___V136_PING=y
+FREETZ_BUSYBOX___V136_PING6=y
+FREETZ_BUSYBOX___V136_FEATURE_FANCY_PING=y
+# FREETZ_BUSYBOX___V136_PSCAN is not set
+FREETZ_BUSYBOX___V136_ROUTE=y
+# FREETZ_BUSYBOX___V136_SENDARP is not set
+# FREETZ_BUSYBOX___V136_SLATTACH is not set
+# FREETZ_BUSYBOX___V136_SSL_CLIENT is not set
+FREETZ_BUSYBOX___V136_STUN_IP=y
+# FREETZ_BUSYBOX___V136_TC is not set
+FREETZ_BUSYBOX___V136_TCPSVD=y
+FREETZ_BUSYBOX___V136_UDPSVD=y
+# FREETZ_BUSYBOX___V136_TELNET is not set
+FREETZ_BUSYBOX___V136_TFTP=y
+# FREETZ_BUSYBOX___V136_FEATURE_TFTP_PROGRESS_BAR is not set
+# FREETZ_BUSYBOX___V136_FEATURE_TFTP_HPA_COMPAT is not set
+FREETZ_BUSYBOX___V136_TFTPD=y
+FREETZ_BUSYBOX___V136_FEATURE_TFTP_GET=y
+FREETZ_BUSYBOX___V136_FEATURE_TFTP_PUT=y
+# FREETZ_BUSYBOX___V136_FEATURE_TFTP_BLOCKSIZE is not set
+# FREETZ_BUSYBOX___V136_TFTP_DEBUG is not set
+FREETZ_BUSYBOX___V136_TRACEROUTE=y
+FREETZ_BUSYBOX___V136_TRACEROUTE6=y
+FREETZ_BUSYBOX___V136_FEATURE_TRACEROUTE_VERBOSE=y
+FREETZ_BUSYBOX___V136_FEATURE_TRACEROUTE_USE_ICMP=y
+# FREETZ_BUSYBOX___V136_TUNCTL is not set
+FREETZ_BUSYBOX___V136_VCONFIG=y
+FREETZ_BUSYBOX___V136_WHOIS=y
+# FREETZ_BUSYBOX___V136_ZCIP is not set
+# FREETZ_BUSYBOX___V136_UDHCPD is not set
+# FREETZ_BUSYBOX___V136_DUMPLEASES is not set
+# FREETZ_BUSYBOX___V136_DHCPRELAY is not set
+# FREETZ_BUSYBOX___V136_UDHCPC is not set
+# FREETZ_BUSYBOX___V136_UDHCPC6 is not set
+FREETZ_BUSYBOX___V136_IFUPDOWN_UDHCPC_CMD_OPTIONS="-R -n"
+# end of Networking Utilities
+
+#
+# Print Utilities
+#
+# FREETZ_BUSYBOX___V136_LPD is not set
+# FREETZ_BUSYBOX___V136_LPR is not set
+# FREETZ_BUSYBOX___V136_LPQ is not set
+# end of Print Utilities
+
+#
+# Mail Utilities
+#
+# FREETZ_BUSYBOX___V136_MAKEMIME is not set
+# FREETZ_BUSYBOX___V136_POPMAILDIR is not set
+# FREETZ_BUSYBOX___V136_REFORMIME is not set
+# FREETZ_BUSYBOX___V136_SENDMAIL is not set
+# end of Mail Utilities
+
+#
+# Process Utilities
+#
+FREETZ_BUSYBOX___V136_FEATURE_FAST_TOP=y
+FREETZ_BUSYBOX___V136_FEATURE_SHOW_THREADS=y
+FREETZ_BUSYBOX___V136_FREE=y
+FREETZ_BUSYBOX___V136_FUSER=y
+FREETZ_BUSYBOX___V136_IOSTAT=y
+FREETZ_BUSYBOX___V136_KILL=y
+FREETZ_BUSYBOX___V136_KILLALL=y
+FREETZ_BUSYBOX___V136_KILLALL5=y
+FREETZ_BUSYBOX___V136_LSOF=y
+FREETZ_BUSYBOX___V136_MPSTAT=y
+# FREETZ_BUSYBOX___V136_NMETER is not set
+# FREETZ_BUSYBOX___V136_PGREP is not set
+# FREETZ_BUSYBOX___V136_PKILL is not set
+FREETZ_BUSYBOX___V136_PIDOF=y
+FREETZ_BUSYBOX___V136_FEATURE_PIDOF_SINGLE=y
+FREETZ_BUSYBOX___V136_FEATURE_PIDOF_OMIT=y
+FREETZ_BUSYBOX___V136_PMAP=y
+# FREETZ_BUSYBOX___V136_POWERTOP is not set
+FREETZ_BUSYBOX___V136_PS=y
+FREETZ_BUSYBOX___V136_FEATURE_PS_WIDE=y
+FREETZ_BUSYBOX___V136_FEATURE_PS_LONG=y
+FREETZ_BUSYBOX___V136_PSTREE=y
+FREETZ_BUSYBOX___V136_PWDX=y
+FREETZ_BUSYBOX___V136_SMEMCAP=y
+FREETZ_BUSYBOX___V136_BB_SYSCTL=y
+FREETZ_BUSYBOX___V136_TOP=y
+FREETZ_BUSYBOX___V136_FEATURE_TOP_INTERACTIVE=y
+FREETZ_BUSYBOX___V136_FEATURE_TOP_CPU_USAGE_PERCENTAGE=y
+FREETZ_BUSYBOX___V136_FEATURE_TOP_CPU_GLOBAL_PERCENTS=y
+FREETZ_BUSYBOX___V136_FEATURE_TOP_SMP_CPU=y
+FREETZ_BUSYBOX___V136_FEATURE_TOP_DECIMALS=y
+FREETZ_BUSYBOX___V136_FEATURE_TOP_SMP_PROCESS=y
+FREETZ_BUSYBOX___V136_FEATURE_TOPMEM=y
+FREETZ_BUSYBOX___V136_UPTIME=y
+# FREETZ_BUSYBOX___V136_FEATURE_UPTIME_UTMP_SUPPORT is not set
+# FREETZ_BUSYBOX___V136_WATCH is not set
+# end of Process Utilities
+
+#
+# Runit Utilities
+#
+# FREETZ_BUSYBOX___V136_CHPST is not set
+# FREETZ_BUSYBOX___V136_SETUIDGID is not set
+# FREETZ_BUSYBOX___V136_ENVUIDGID is not set
+# FREETZ_BUSYBOX___V136_ENVDIR is not set
+# FREETZ_BUSYBOX___V136_SOFTLIMIT is not set
+# FREETZ_BUSYBOX___V136_RUNSV is not set
+# FREETZ_BUSYBOX___V136_RUNSVDIR is not set
+# FREETZ_BUSYBOX___V136_SV is not set
+# FREETZ_BUSYBOX___V136_SVC is not set
+# FREETZ_BUSYBOX___V136_SVOK is not set
+# FREETZ_BUSYBOX___V136_SVLOGD is not set
+# end of Runit Utilities
+
+#
+# Shells
+#
+FREETZ_BUSYBOX___V136_SH_IS_ASH=y
+FREETZ_BUSYBOX___V136_BASH_IS_ASH=y
+FREETZ_BUSYBOX___V136_SHELL_ASH=y
+FREETZ_BUSYBOX___V136_ASH=y
+FREETZ_BUSYBOX___V136_ASH_OPTIMIZE_FOR_SIZE=y
+FREETZ_BUSYBOX___V136_ASH_INTERNAL_GLOB=y
+FREETZ_BUSYBOX___V136_ASH_BASH_COMPAT=y
+# FREETZ_BUSYBOX___V136_ASH_BASH_SOURCE_CURDIR is not set
+FREETZ_BUSYBOX___V136_ASH_BASH_NOT_FOUND_HOOK=y
+FREETZ_BUSYBOX___V136_ASH_JOB_CONTROL=y
+FREETZ_BUSYBOX___V136_ASH_ALIAS=y
+FREETZ_BUSYBOX___V136_ASH_RANDOM_SUPPORT=y
+FREETZ_BUSYBOX___V136_ASH_EXPAND_PRMT=y
+# FREETZ_BUSYBOX___V136_ASH_IDLE_TIMEOUT is not set
+# FREETZ_BUSYBOX___V136_ASH_MAIL is not set
+FREETZ_BUSYBOX___V136_ASH_ECHO=y
+FREETZ_BUSYBOX___V136_ASH_PRINTF=y
+FREETZ_BUSYBOX___V136_ASH_TEST=y
+# FREETZ_BUSYBOX___V136_ASH_SLEEP is not set
+# FREETZ_BUSYBOX___V136_ASH_HELP is not set
+FREETZ_BUSYBOX___V136_ASH_GETOPTS=y
+FREETZ_BUSYBOX___V136_ASH_CMDCMD=y
+# FREETZ_BUSYBOX___V136_CTTYHACK is not set
+# FREETZ_BUSYBOX___V136_HUSH is not set
+# FREETZ_BUSYBOX___V136_SHELL_HUSH is not set
+
+#
+# Options common to all shells
+#
+FREETZ_BUSYBOX___V136_FEATURE_SH_MATH=y
+FREETZ_BUSYBOX___V136_FEATURE_SH_MATH_64=y
+# FREETZ_BUSYBOX___V136_FEATURE_SH_MATH_BASE is not set
+# FREETZ_BUSYBOX___V136_FEATURE_SH_EXTRA_QUIET is not set
+FREETZ_BUSYBOX___V136_FEATURE_SH_READ_FRAC=y
+FREETZ_BUSYBOX___V136_FEATURE_SH_HISTFILESIZE=y
+FREETZ_BUSYBOX___V136_FEATURE_SH_EMBEDDED_SCRIPTS=y
+# end of Shells
+
+#
+# System Logging Utilities
+#
+FREETZ_BUSYBOX___V136_KLOGD=y
+FREETZ_BUSYBOX___V136_FEATURE_KLOGD_KLOGCTL=y
+FREETZ_BUSYBOX___V136_LOGGER=y
+FREETZ_BUSYBOX___V136_LOGREAD=y
+FREETZ_BUSYBOX___V136_FEATURE_LOGREAD_REDUCED_LOCKING=y
+FREETZ_BUSYBOX___V136_SYSLOGD=y
+FREETZ_BUSYBOX___V136_FEATURE_ROTATE_LOGFILE=y
+FREETZ_BUSYBOX___V136_FEATURE_REMOTE_LOG=y
+FREETZ_BUSYBOX___V136_FEATURE_SYSLOGD_DUP=y
+# FREETZ_BUSYBOX___V136_FEATURE_SYSLOGD_CFG is not set
+# FREETZ_BUSYBOX___V136_FEATURE_SYSLOGD_PRECISE_TIMESTAMPS is not set
+FREETZ_BUSYBOX___V136_FEATURE_SYSLOGD_READ_BUFFER_SIZE=256
+FREETZ_BUSYBOX___V136_FEATURE_IPC_SYSLOG=y
+FREETZ_BUSYBOX___V136_FEATURE_IPC_SYSLOG_BUFFER_SIZE=16
+# FREETZ_BUSYBOX___V136_FEATURE_KMSG_SYSLOG is not set
+# end of System Logging Utilities
+# end of Busybox applets
+
+# EXTERNAL_ENABLED is not set
+
+#
+# Mod customizations ---------------------------------------
+#
+
+#
+# Web Interface
+#
+# FREETZ_BACKUP_ENCRYPTION is not set
+# FREETZ_BACKUP_DECODING is not set
+# FREETZ_BACKUP_EXPORT is not set
+FREETZ_LANG_DE=y
+# FREETZ_LANG_EN is not set
+FREETZ_LANG_STRING="de"
+FREETZ_SECURITY_LEVEL=0
+FREETZ_STYLE_GREY=y
+FREETZ_STYLE="grey"
+
+#
+# Freetz skins
+#
+FREETZ_SKIN_cuma=y
+FREETZ_SKIN_legacy=y
+# FREETZ_SKIN_newfreetz is not set
+# FREETZ_SKIN_phoenix is not set
+# end of Freetz skins
+
+FREETZ_FAVICON_NONE=y
+# FREETZ_FAVICON_ATOMPHIL is not set
+# FREETZ_FAVICON_CUMA is not set
+# FREETZ_FAVICON_DSL123 is not set
+# FREETZ_FAVICON_HANSOLO is not set
+# FREETZ_FAVICON_PRISRAK is not set
+FREETZ_FAVICON_STRING="none"
+FREETZ_TAGGING_NONE=y
+# FREETZ_TAGGING_CUMA is not set
+# FREETZ_TAGGING_NG is not set
+# FREETZ_TAGGING_PIMPED is not set
+FREETZ_WEBIF_LINK=y
+# end of Web Interface
+
+#
+# Additional informations
+#
+FREETZ_ADD_JUIS_CHECK=y
+# FREETZ_ADD_JUIS_CHECK__SSL is not set
+FREETZ_ADD_UIMODS=y
+# FREETZ_REMOVE_BOX_INFO is not set
+# FREETZ_REMOVE_FREETZ_INFO is not set
+FREETZ_USER_DEFINED_COMMENT=""
+# FREETZ_IMAGE_NAME_CUSTOM is not set
+FREETZ_CREATE_SEPARATE_OPTIONS_CFG=y
+# FREETZ_DOT_CONFIG_DONOTADD is not set
+FREETZ_DOT_CONFIG_STRIPPED=y
+# FREETZ_DOT_CONFIG_COMPLETE is not set
+# end of Additional informations
+
+#
+# Build system ---------------------------------------------
+#
+
+#
+# Toolchain options
+#
+FREETZ_BUILD_TOOLCHAIN=y
+FREETZ_TOOLCHAIN_CCACHE=y
+FREETZ_TOOLCHAIN_MINIMIZE_REQUIRED_GLIBC_VERSION=y
+
+#
+# Kernel toolchain options ----------------------------------------
+#
+FREETZ_KERNEL_VERSION_3_10_107=y
+FREETZ_KERNEL_BINUTILS_2_25_DEFAULT=y
+# FREETZ_KERNEL_BINUTILS_2_24 is not set
+FREETZ_KERNEL_BINUTILS_2_25=y
+# FREETZ_KERNEL_BINUTILS_2_26 is not set
+FREETZ_KERNEL_GCC_5_5=y
+FREETZ_KERNEL_GCC_5=y
+FREETZ_KERNEL_GCC_4_MIN=y
+FREETZ_KERNEL_GCC_4_6_MIN=y
+FREETZ_KERNEL_GCC_4_7_MIN=y
+FREETZ_KERNEL_GCC_4_8_MIN=y
+FREETZ_KERNEL_GCC_5_MIN=y
+FREETZ_KERNEL_GCC_5_MAX=y
+FREETZ_KERNEL_GCC_8_3_MAX=y
+FREETZ_KERNEL_GCC_8_4_MAX=y
+FREETZ_KERNEL_GCC_8_MAX=y
+FREETZ_KERNEL_GCC_9_MAX=y
+FREETZ_KERNEL_BINUTILS_VERSION="2.25.1"
+FREETZ_KERNEL_GCC_VERSION="5.5.0"
+
+#
+# Target toolchain options ----------------------------------------
+#
+FREETZ_SEPARATE_AVM_UCLIBC_FORCE=y
+FREETZ_SEPARATE_AVM_UCLIBC=y
+# FREETZ_TARGET_UNSUPPORTED_VERSIONS is not set
+FREETZ_TARGET_UCLIBC_1_0_48=y
+FREETZ_TARGET_UCLIBC_SUPPORTS_inotify=y
+FREETZ_TARGET_UCLIBC_SUPPORTS_libubacktrace=y
+FREETZ_TARGET_UCLIBC_REQUIRES_libubacktrace=y
+FREETZ_TARGET_BINUTILS_2_42_DEFAULT=y
+FREETZ_TARGET_BINUTILS_2_42=y
+FREETZ_TARGET_GCC_13_3=y
+FREETZ_TARGET_GCC_4_6_MIN=y
+FREETZ_TARGET_GCC_4_7_MIN=y
+FREETZ_TARGET_GCC_4_8_MIN=y
+FREETZ_TARGET_GCC_4_9_MIN=y
+FREETZ_TARGET_GCC_5_1_MIN=y
+FREETZ_TARGET_GCC_5_4_MIN=y
+FREETZ_TARGET_GCC_5_5_MIN=y
+FREETZ_TARGET_GCC_8_3_MIN=y
+FREETZ_TARGET_GCC_8_4_MIN=y
+FREETZ_TARGET_GCC_9_3_MIN=y
+FREETZ_TARGET_GCC_13_3_MIN=y
+FREETZ_TARGET_GCC_13=y
+FREETZ_TARGET_GCC_4_MIN=y
+FREETZ_TARGET_GCC_5_MIN=y
+FREETZ_TARGET_GCC_8_MIN=y
+FREETZ_TARGET_GCC_9_MIN=y
+FREETZ_TARGET_GCC_13_MIN=y
+FREETZ_TARGET_GCC_13_3_MAX=y
+FREETZ_TARGET_GCC_13_MAX=y
+FREETZ_TARGET_GCC_DEFAULT_AS_NEEDED=y
+# FREETZ_STDCXXLIB_FORCE_GNULIBSTDCXX is not set
+FREETZ_STDCXXLIB_USE_UCLIBCXX=y
+FREETZ_STDCXXLIB_USE_UCLIBCXX_CHOICE=y
+# FREETZ_STDCXXLIB_USE_GNULIBSTDCXX_CHOICE is not set
+FREETZ_TARGET_UCLIBC_1=y
+FREETZ_TARGET_UCLIBC_VERSION="1.0.48"
+FREETZ_TARGET_UCLIBC_MAJOR_VERSION="1"
+FREETZ_TARGET_BINUTILS_VERSION="2.42"
+FREETZ_TARGET_GCC_VERSION="13.3.0"
+FREETZ_GNULIBATOMIC_VERSION="1.2.0"
+FREETZ_GNULIBSTDCXX_VERSION="6.0.32"
+FREETZ_STDCXXLIB="uclibcxx"
+FREETZ_TARGET_CFLAGS="-Ofast -pipe"
+FREETZ_RPATH="/usr/lib/freetz"
+# FREETZ_TARGET_UCLIBC_DODEBUG is not set
+FREETZ_TARGET_UCLIBC_REDUCED_LOCALE_SET=y
+FREETZ_TARGET_UCLIBC_PROVIDES_SSP=y
+
+#
+# Host-tools options ----------------------------------
+#
+# FREETZ_TOOLS_PATCHELF_VERSION_ABANDON is not set
+FREETZ_TOOLS_PATCHELF_VERSION_CURRENT=y
+# FREETZ_TOOLS_UBOOT_STATIC is not set
+# FREETZ_TOOLS_WGET_STATIC is not set
+# FREETZ_TOOLS_KCONFIG_BUTTONS is not set
+# FREETZ_ROOTEMU_FAKEROOT is not set
+FREETZ_ROOTEMU_PSEUDO=y
+# FREETZ_HOSTTOOLS_DOWNLOAD is not set
+FREETZ_HOSTTOOLS_BUILD=y
+# end of Toolchain options
+
+#
+# Build system options
+#
+# FREETZ_ANCIENT_SYSTEM is not set
+FREETZ_MENUCONFIG_REVISION=y
+# FREETZ_VERBOSITY_FWMOD_0 is not set
+# FREETZ_VERBOSITY_FWMOD_1 is not set
+FREETZ_VERBOSITY_FWMOD_2=y
+FREETZ_VERBOSITY_FWMOD=2
+# FREETZ_VERBOSITY_LEVEL_0 is not set
+# FREETZ_VERBOSITY_LEVEL_1 is not set
+FREETZ_VERBOSITY_LEVEL_2=y
+FREETZ_VERBOSITY_LEVEL=2
+FREETZ_SIZEINFO_COMPRESSED=y
+# FREETZ_SIZEINFO_UNCOMPRESSED is not set
+FREETZ_JLEVEL=0
+FREETZ_CHECK_CHANGED=y
+# end of Build system options
+
+#
+# Firmware packaging (fwmod) options
+#
+# FREETZ_FWMOD_SKIP_UNPACK is not set
+FREETZ_FWMOD_VALIDATE=y
+# FREETZ_FWMOD_SKIP_MODIFY is not set
+# FREETZ_FWMOD_SKIP_PACK is not set
+FREETZ_FWMOD_SIGN=y
+FREETZ_FWMOD_SIGN_PASSWORD="freetz"
+# end of Firmware packaging (fwmod) options
+
+#
+# SquashFS options
+#
+# FREETZ_SQUASHFS_BLOCKSIZE_ORIG is not set
+FREETZ_SQUASHFS_BLOCKSIZE_65536=y
+FREETZ_SQUASHFS_BLOCKSIZE=65536
+# end of SquashFS options
+
+#
+# Strip options
+#
+FREETZ_STRIP_BINARIES=y
+# FREETZ_STRIP_MODULES_NONE is not set
+FREETZ_STRIP_MODULES_FREETZ=y
+# FREETZ_STRIP_MODULES_ALL is not set
+# FREETZ_STRIP_SCRIPTS is not set
+# end of Strip options
+
+#
+# Download options
+#
+FREETZ_DL_SITE_USER=""
+FREETZ_DL_DETECT_IMAGE_NAME=y
+FREETZ_DL_VCS_REPO_FIRST=y
+FREETZ_DL_VCS_FROM_MIRRORS=y
+FREETZ_DL_TOOLCHAIN_SITE=""
+FREETZ_DL_KERNEL_TOOLCHAIN_VERSION="rXXXXX"
+FREETZ_DL_KERNEL_TOOLCHAIN_HASH="19602e8c6f9e24afc573f1d0a48341ed6091b86bfacc8afb867e2ef81ab96bba"
+FREETZ_DL_TARGET_TOOLCHAIN_VERSION="rXXXXX"
+FREETZ_DL_TARGET_TOOLCHAIN_HASH="9849f195b6c0c1419ced54c091199c3f170f9baea08d2469a460c0f0e9dad0df"
+FREETZ_DL_TOOLCHAIN_SUFFIX="shared-glibc"
+# FREETZ_DL_KERNEL_OVERRIDE is not set
+FREETZ_DL_KERNEL_SOURCE_ID="7490_07.56"
+FREETZ_DL_KERNEL_VANILLA_SOURCE="linux-${FREETZ_KERNEL_VANILLA_VERSION}.tar.xz"
+FREETZ_DL_KERNEL_VANILLA_HASH="948ae756ba90b3b981fb8245789ea1426d43c351921df566dd5463171883edc3"
+FREETZ_DL_KERNEL_AVMDIFF_VERSION="ADv1"
+FREETZ_DL_KERNEL_AVMDIFF_SOURCE="kernel_${FREETZ_KERNEL_VERSION}-${FREETZ_DL_KERNEL_SOURCE_ID}${FREETZ_SYSTEM_TYPE_CORE_SUFFIX}-${FREETZ_DL_KERNEL_AVMDIFF_VERSION}.patch.xz"
+FREETZ_DL_KERNEL_AVMDIFF_HASH="ce6b9ce905f70b058f3d0825b88dadb990d3ea59c9b2f4c56349cad08f92be3f"
+FREETZ_DL_SITE="http://localhost"
+FREETZ_DL_SOURCE="${FREETZ_TYPE_PREFIX}-${FREETZ_TYPE_LANGUAGE}${FREETZ_TYPE_PREFIX_LABOR_FIRMWARE}.detected.image"
+# end of Download options
+
+FREETZ_AVM_HAS_FIRMWARE_06_2X=y
+FREETZ_AVM_HAS_FIRMWARE_06_5X=y
+FREETZ_AVM_HAS_FIRMWARE_06_8X=y
+FREETZ_AVM_HAS_FIRMWARE_06_9X=y
+FREETZ_AVM_HAS_FIRMWARE_07_0X=y
+FREETZ_AVM_HAS_FIRMWARE_07_1X=y
+FREETZ_AVM_HAS_FIRMWARE_07_2X=y
+FREETZ_AVM_HAS_FIRMWARE_07_5X=y
+FREETZ_AVM_HAS_LANG_DE=y
+FREETZ_AVM_HAS_LANG_EN=y
+FREETZ_TYPE_DSL=y
+FREETZ_AVM_HAS_TEMPERATURE_SENSOR=y
+FREETZ_AVM_HAS_MULTI_ANNEX=y
+FREETZ_AVM_HAS_IPV6=y
+FREETZ_AVM_HAS_PTY_SUPPORT=y
+FREETZ_AVM_HAS_PRINTK=y
+FREETZ_AVM_HAS_BUGON_IN_NET_CORE=y
+FREETZ_AVM_HAS_KERNEL_CONFIG_AREA=y
+FREETZ_AVM_HAS_JUIS_SUPPORT=y
+FREETZ_AVM_HAS_MULTID_LEASES_FORMAT_V2=y
+FREETZ_AVM_HAS_LIBC_FILE="libc.so.1"
+FREETZ_AVM_HAS_AVMMULTID_PRELOAD=y
+FREETZ_AVM_SQUASHFS_VERSION=4
+FREETZ_SQUASHFS_VERSION=4
+FREETZ_AVM_SQUASHFS_ENDIANNESS="be"
+FREETZ_AVM_SQUASHFS_COMPRESSION="xz"
+FREETZ_AVM_IMAGES_SUBDIR="var/tmp"
+FREETZ_AVM_HAS_SEPARATE_FILESYSTEM_IMAGE=y
+FREETZ_AVM_HAS_INNER_OUTER_FILESYSTEM=y
+FREETZ_AVM_OUTER_FILESYSTEM_TYPE="SquashFS"
+FREETZ_AVM_SIGNATURE_KEY="010001x00cbdcfcc6ac9a1657a1c6f197e3056f1d68b8bb7deb480249e5f0ded677c54fde10be5a14b1e6a395483bd4bee608c09d385b1e90564ca84b9272926c45bfd328d7da876567e3e15f719800a53ecc21af583431d0c40806ca89f6f958e188ec69572df09e24de71eaa0782c01877158f286afd95037e7eb059367c466095944e1"
+FREETZ_AVM_HAS_BRANDING_avm=y
+FREETZ_AVM_HAS_LEDPAGE=y
+FREETZ_AVM_HAS_BRANDING_avme=y
+FREETZ_AVM_HAS_MULTIPLE_LANGUAGES=y
+FREETZ_AVM_HAS_LANGUAGE_de=y
+FREETZ_AVM_HAS_LANGUAGE_en=y
+FREETZ_AVM_HAS_LANGUAGE_es=y
+FREETZ_AVM_HAS_LANGUAGE_fr=y
+FREETZ_AVM_HAS_LANGUAGE_it=y
+FREETZ_AVM_HAS_LANGUAGE_pl=y
+FREETZ_AVM_HAS_CTLMGR_CTL=y
+FREETZ_AVM_HAS_DMESG_FILE=y
+FREETZ_AVM_HAS_INETD=y
+FREETZ_AVM_HAS_OPENSSL=y
+FREETZ_AVM_HAS_OPENSSL_VERSION_1=y
+FREETZ_AVM_HAS_SHOWDSLDSTAT=y
+FREETZ_AVM_HAS_SIGNATURE=y
+FREETZ_AVM_HAS_TR064=y
+FREETZ_AVM_HAS_TR069=y
+FREETZ_AVM_HAS_TR069_FWUPDATE=y
+FREETZ_AVM_HAS_UDEV=y
+FREETZ_AVM_HAS_WLAN=y
+FREETZ_AVM_PROP_ARCH_BE=y
+FREETZ_AVM_PROP_ARCH_MIPS=y
+FREETZ_AVM_PROP_HWREV="185"
+FREETZ_AVM_PROP_LIBC_UCLIBC=y
+FREETZ_AVM_PROP_MAJOR="113"
+FREETZ_AVM_PROP_NAME="FRITZ!Box 7490"
+FREETZ_AVM_PROP_SQUASHFS_ENDIANN_BE=y
+FREETZ_AVM_SERIAL_CONSOLE_DEVICE="/dev/ttyS0"
+FREETZ_AVM_HAS_TC=y
+FREETZ_AVM_HAS_NEXUS=y
+FREETZ_AVM_HAS_REBOOT_SCRIPT=y
+FREETZ_AVM_HAS_IP_BINARY=y
+FREETZ_AVM_HAS_MESHD=y
+FREETZ_AVM_PROP_SQUASHFS_VERSION_4=y
+FREETZ_AVM_PROP_SQUASHFS_COMPRESSION_XZ=y
+FREETZ_AVM_HAS_ETCSERVICES=y
+FREETZ_AVM_HAS_MULTIPLE_BRANDINGS=y
+FREETZ_AVM_PROP_ALL_REGIONS=y
+FREETZ_AVM_HAS_PLCD=y
+FREETZ_AVM_HAS_AHA=y
+FREETZ_AVM_HAS_SVCTL=y
+FREETZ_AVM_PROP_GCC_5_5=y
+FREETZ_AVM_PROP_UCLIBC_SEPARATE=y
+FREETZ_AVM_HAS_KMOD=y
+FREETZ_AVM_HAS_FWLAYOUT_2=y
+FREETZ_AVM_PROP_SEPARATE_FILESYSTEM_IMAGE=y
+FREETZ_AVM_HAS_NOEXEC=y
+FREETZ_AVM_HAS_AURA_USB=y
+FREETZ_AVM_HAS_USB_HOST=y
+FREETZ_AVM_HAS_DSLD=y
+FREETZ_AVM_HAS_VPN=y
+FREETZ_AVM_HAS_PRINTSERV=y
+FREETZ_AVM_HAS_MEDIASRV=y
+FREETZ_AVM_HAS_KIDS=y
+FREETZ_AVM_HAS_FAT_MODULE=y
+FREETZ_AVM_HAS_NLS_MODULE=y
+FREETZ_AVM_HAS_BRANDING_1und1=y
+FREETZ_AVM_HAS_ANNEX_SELECTION=y
+FREETZ_AVM_HAS_MYFRITZ=y
+FREETZ_AVM_HAS_NAS=y
+FREETZ_AVM_HAS_NTFS=y
+FREETZ_AVM_HAS_WEBDAV=y
+FREETZ_AVM_HAS_CHRONYD=y
+FREETZ_AVM_HAS_TAM=y
+FREETZ_AVM_HAS_PHONE=y
+FREETZ_AVM_HAS_DDNSD=y
+FREETZ_AVM_HAS_UMTS=y
+FREETZ_AVM_HAS_DTRACE=y
+FREETZ_AVM_HAS_E2FSPROGS=y
+FREETZ_AVM_HAS_DSL_CONTROL=y
+FREETZ_AVM_HAS_PCPD=y
+FREETZ_AVM_PROP_INNER_OUTER_FILESYSTEM=y
+FREETZ_AVM_PROP_KERNEL_CONFIG_AREA_SIZE_64=y
+FREETZ_AVM_HAS_SAMBA_NQCS=y
+FREETZ_AVM_HAS_UNTRUSTEDD=y
+FREETZ_AVM_PROP_KERNEL_3_10_107=y
+FREETZ_AVM_HAS_WIREGUARD=y
+FREETZ_AVM_HAS_AVMCOUNTERD=y
+FREETZ_AVM_HAS_LIBFUSE=y
+FREETZ_AVM_HAS_DECT=y
+FREETZ_AVM_HAS_FAX=y
+FREETZ_AVM_HAS_BLK_DEV_LOOP_BUILTIN=y
+FREETZ_AVM_HAS_BLK_DEV_NBD_BUILTIN=y
+FREETZ_AVM_HAS_CRC16_BUILTIN=y
+FREETZ_AVM_HAS_EXT2_FS_BUILTIN=y
+FREETZ_AVM_HAS_EXT3_FS_BUILTIN=y
+FREETZ_AVM_HAS_EXT4_FS_BUILTIN=y
+FREETZ_AVM_HAS_FS_MBCACHE_BUILTIN=y
+FREETZ_AVM_HAS_FUSE_FS_BUILTIN=y
+FREETZ_AVM_HAS_JBD2_BUILTIN=y
+FREETZ_AVM_HAS_JBD_BUILTIN=y
+FREETZ_AVM_HAS_MTD_BLOCK2MTD_BUILTIN=y
+FREETZ_AVM_HAS_MTD_NAND_BUILTIN=y
+FREETZ_AVM_HAS_NLS_UTF8_BUILTIN=y
+FREETZ_AVM_HAS_SWAP_BUILTIN=y
+FREETZ_AVM_HAS_TUN_BUILTIN=y
+FREETZ_AVM_HAS_CRYPTO_AES_BUILTIN=y
+FREETZ_AVM_HAS_CRYPTO_ALGAPI_BUILTIN=y
+FREETZ_AVM_HAS_FW_LOADER_BUILTIN=y
+FREETZ_AVM_HAS_LZO_COMPRESS_BUILTIN=y
+FREETZ_AVM_HAS_LZO_DECOMPRESS_BUILTIN=y
+FREETZ_AVM_HAS_CRYPTO_HASH_BUILTIN=y
+FREETZ_AVM_HAS_ANTFS_FS_BUILTIN=y
+FREETZ_AVM_HAS_NET_CLS_U32_BUILTIN=y
+FREETZ_AVM_VERSION_07_5X=y
+FREETZ_AVM_VERSION_04_XX_MIN=y
+FREETZ_AVM_VERSION_05_2X_MIN=y
+FREETZ_AVM_VERSION_05_5X_MIN=y
+FREETZ_AVM_VERSION_06_0X_MIN=y
+FREETZ_AVM_VERSION_06_2X_MIN=y
+FREETZ_AVM_VERSION_06_5X_MIN=y
+FREETZ_AVM_VERSION_06_8X_MIN=y
+FREETZ_AVM_VERSION_06_9X_MIN=y
+FREETZ_AVM_VERSION_07_0X_MIN=y
+FREETZ_AVM_VERSION_07_1X_MIN=y
+FREETZ_AVM_VERSION_07_2X_MIN=y
+FREETZ_AVM_VERSION_07_5X_MIN=y
+FREETZ_AVM_VERSION_07_5X_MAX=y
+FREETZ_AVM_VERSION_07_8X_MAX=y
+FREETZ_AVM_VERSION_08_0X_MAX=y
+FREETZ_SYSTEM_TYPE_VR9=y
+FREETZ_SYSTEM_TYPE="vr9"
+FREETZ_CPU_MODEL_MIPS_34Kc=y
+FREETZ_TARGET_ARCH_BE=y
+FREETZ_TARGET_ARCH_MIPS=y
+FREETZ_KERNEL_ARCH="mips"
+FREETZ_TARGET_ARCH="mips"
+FREETZ_TARGET_ARCH_ENDIANNESS_DEPENDENT="mips"
+FREETZ_TARGET_TRIPLET_VENDOR="unknown"
+FREETZ_TARGET_GNU_TRIPLET="${FREETZ_TARGET_ARCH_ENDIANNESS_DEPENDENT}-${FREETZ_TARGET_TRIPLET_VENDOR}-linux-gnu${FREETZ_TARGET_TRIPLET_GNU_ABI}"
+FREETZ_TARGET_UCLIBC_TRIPLET="${FREETZ_TARGET_ARCH_ENDIANNESS_DEPENDENT}-linux-uclibc${FREETZ_TARGET_TRIPLET_UCLIBC_ABI}"
+FREETZ_TARGET_CROSS="${FREETZ_TARGET_UCLIBC_TRIPLET}-"
+FREETZ_TARGET_MAKE_PATH="toolchain/target/bin"
+FREETZ_KERNEL_CROSS="${FREETZ_TARGET_GNU_TRIPLET}-"
+FREETZ_KERNEL_MAKE_PATH="toolchain/kernel/bin"
+FREETZ_AVM_GCC_5_5=y
+FREETZ_AVM_GCC_5=y
+FREETZ_AVM_GCC_3_4_MIN=y
+FREETZ_AVM_GCC_4_6_MIN=y
+FREETZ_AVM_GCC_4_7_MIN=y
+FREETZ_AVM_GCC_4_8_MIN=y
+FREETZ_AVM_GCC_4_9_MIN=y
+FREETZ_AVM_GCC_5_1_MIN=y
+FREETZ_AVM_GCC_5_4_MIN=y
+FREETZ_AVM_GCC_5_5_MIN=y
+FREETZ_AVM_GCC_4_MIN=y
+FREETZ_AVM_GCC_5_MIN=y
+FREETZ_AVM_GCC_5_5_MAX=y
+FREETZ_AVM_GCC_8_3_MAX=y
+FREETZ_AVM_GCC_8_4_MAX=y
+FREETZ_AVM_GCC_9_3_MAX=y
+FREETZ_AVM_GCC_13_3_MAX=y
+FREETZ_AVM_GCC_5_MAX=y
+FREETZ_AVM_GCC_8_MAX=y
+FREETZ_AVM_GCC_9_MAX=y
+FREETZ_AVM_GCC_13_MAX=y
+FREETZ_GCC_ABI="32"
+FREETZ_GCC_ARCH="mips32r2"
+FREETZ_GCC_CPU="34kc"
+FREETZ_GCC_FLOAT_ABI="soft"
+FREETZ_KERNEL_VERSION_3_10=y
+FREETZ_KERNEL_VERSION="3.10.107"
+FREETZ_KERNEL_VERSION_MAJOR="3.10"
+FREETZ_KERNEL_VANILLA_DLDIR="3.x"
+FREETZ_KERNEL_VANILLA_VERSION="${FREETZ_KERNEL_VERSION}"
+FREETZ_KERNEL_VERSION_MODULES_SUBDIR="3.10.107"
+FREETZ_KERNEL_VERSION_2_6_13_MIN=y
+FREETZ_KERNEL_VERSION_2_6_19_MIN=y
+FREETZ_KERNEL_VERSION_2_6_28_MIN=y
+FREETZ_KERNEL_VERSION_2_6_32_MIN=y
+FREETZ_KERNEL_VERSION_2_6_39_MIN=y
+FREETZ_KERNEL_VERSION_3_MIN=y
+FREETZ_KERNEL_VERSION_3_10_MIN=y
+FREETZ_KERNEL_VERSION_3_10_MAX=y
+FREETZ_KERNEL_VERSION_3_12_MAX=y
+FREETZ_KERNEL_VERSION_3_MAX=y
+FREETZ_KERNEL_VERSION_4_1_MAX=y
+FREETZ_KERNEL_VERSION_4_4_MAX=y
+FREETZ_KERNEL_VERSION_4_9_MAX=y
+FREETZ_KERNEL_VERSION_4_19_MAX=y
+FREETZ_KERNEL_VERSION_4_MAX=y
+FREETZ_KERNEL_VERSION_5_4_MAX=y
+FREETZ_KERNEL_VERSION_5_15_MAX=y
+FREETZ_KERNEL_VERSION_5_MAX=y
+FREETZ_KERNEL_VERSION_3=y
+FREETZ_AVM_KERNEL_CONFIG_AREA_SIZE=64
+FREETZ_AVM_KERNEL_CONFIG_AREA_KNOWN=y
+FREETZ_AVM_UCLIBC_NPTL_ENABLED=y
+FREETZ_AVM_UCLIBC_XLOCALE_ENABLED=y
+FREETZ_AVM_SOURCE_7490_07_56=y
+FREETZ_AVM_SOURCE_ID="7490_07.56"
+FREETZ_AVM_SOURCE_FOR_SYSTEM_TYPE_VR9=y
+FREETZ_DL_JUIS_BUILDTYPE="1"
+FREETZ_DL_JUIS_COUNTRY="049"
+FREETZ_DL_JUIS_LANG="de"
+FREETZ_DL_JUIS_OEM="avm"
+FREETZ_DL_JUIS_FLAG="empty"
+FREETZ_DL_JUIS_ANNEX="B"
+FREETZ_DL_JUIS_FOS="07.50-100%REV%"
+FREETZ_DL_JUIS_OID="3431C4"
+FREETZ_DL_JUIS_STRING="Version=${FREETZ_AVM_PROP_MAJOR}.${FREETZ_DL_JUIS_FOS} Serial=${FREETZ_DL_JUIS_OID}%SER% Name=${FREETZ_AVM_PROP_NAME} HW=${FREETZ_AVM_PROP_HWREV} OEM=${FREETZ_DL_JUIS_OEM} Lang=${FREETZ_DL_JUIS_LANG} Annex=${FREETZ_DL_JUIS_ANNEX} Country=${FREETZ_DL_JUIS_COUNTRY} Flag=${FREETZ_DL_JUIS_FLAG} Buildtype=${FREETZ_DL_JUIS_BUILDTYPE} Nonce=%NNC%"
+FREETZ_REPLACE_KERNEL_AVAILABLE=y
+FREETZ_REPLACE_MODULE_AVAILABLE=y
+FREETZ_KERNEL_AVMDIFF_AVAILABLE=y
+FREETZ_TYPE_PREFIX="7490"
+FREETZ_TYPE_PREFIX_SERIES_SUBDIR="07_5X"
+FREETZ_TARGET_MESON_FAMILY="mips"
+FREETZ_TARGET_MESON_CPU="mips"
+FREETZ_TARGET_MESON_ENDIAN="big"
+FREETZ_INSTALL_BASE=y
+FREETZ_REPLACE_BUSYBOX=y

--- a/config7590
+++ b/config7590
@@ -1,0 +1,3187 @@
+#
+# Automatically generated file; DO NOT EDIT.
+# Freetz Configuration
+#
+FREETZ_HAVE_DOT_CONFIG=y
+
+#
+# Freetz revision  -----------------------------------------
+#
+
+#
+#  freetz-ng 23876M-59831cbff master 2024-06-15
+#
+
+#
+# User competence ------------------------------------------
+#
+# FREETZ_USER_LEVEL_BEGINNER is not set
+FREETZ_USER_LEVEL_EXPERT=y
+# FREETZ_USER_LEVEL_DEVELOPER is not set
+FREETZ_SHOW_EXPERT=y
+
+#
+# Hardware/Firmware ----------------------------------------
+#
+
+#
+# Hardware series
+#
+# FREETZ_SERIES_X is not set
+FREETZ_SERIES_6=y
+FREETZ_SERIES_5=y
+# FREETZ_SERIES_4 is not set
+# FREETZ_SERIES_3 is not set
+# FREETZ_SERIES_2 is not set
+# FREETZ_SERIES_1 is not set
+# FREETZ_SERIES_0 is not set
+
+#
+# 
+#
+# FREETZ_SERIES_ALL is not set
+# end of Hardware series
+
+#
+# WAN
+#
+# FREETZ_TYPE_4040 is not set
+# FREETZ_TYPE_4050 is not set
+# FREETZ_TYPE_4060 is not set
+
+#
+# Fiber
+#
+# FREETZ_TYPE_5590 is not set
+# FREETZ_TYPE_5690 is not set
+
+#
+# Cable
+#
+# FREETZ_TYPE_6590 is not set
+# FREETZ_TYPE_6591 is not set
+# FREETZ_TYPE_6660 is not set
+# FREETZ_TYPE_6670 is not set
+# FREETZ_TYPE_6690 is not set
+
+#
+# LTE
+#
+# FREETZ_TYPE_6850_4G is not set
+# FREETZ_TYPE_6850_5G is not set
+# FREETZ_TYPE_6890 is not set
+
+#
+# Fon WLAN
+#
+# FREETZ_TYPE_7510 is not set
+# FREETZ_TYPE_7520 is not set
+# FREETZ_TYPE_7521 is not set
+# FREETZ_TYPE_7530 is not set
+# FREETZ_TYPE_7539 is not set
+# FREETZ_TYPE_7560 is not set
+# FREETZ_TYPE_7580 is not set
+# FREETZ_TYPE_7581 is not set
+# FREETZ_TYPE_7582 is not set
+# FREETZ_TYPE_7583 is not set
+# FREETZ_TYPE_7584 is not set
+FREETZ_TYPE_7590=y
+# FREETZ_TYPE_7599 is not set
+# FREETZ_TYPE_7690 is not set
+FREETZ_TYPE_LANG_DE=y
+# FREETZ_TYPE_LANG_EN is not set
+FREETZ_TYPE_LANGUAGE="xx"
+# FREETZ_TYPE_FIRMWARE_06_8X is not set
+# FREETZ_TYPE_FIRMWARE_06_9X is not set
+# FREETZ_TYPE_FIRMWARE_07_0X is not set
+# FREETZ_TYPE_FIRMWARE_07_1X is not set
+# FREETZ_TYPE_FIRMWARE_07_2X is not set
+FREETZ_TYPE_FIRMWARE_07_5X=y
+# FREETZ_TYPE_FIRMWARE_08_0X_LABOR is not set
+
+#
+#  >> This firmware fits on AVM and AVME devices
+#
+FREETZ_AVM_VERSION_LATEST_MAJOR=y
+FREETZ_TYPE_FIRMWARE_DETECT_LATEST=y
+FREETZ_TYPE_FIRMWARE_FINAL=y
+FREETZ_AVM_HAS_FIRMWARE_LABOR=y
+
+#
+# Original components --------------------------------------
+#
+FREETZ_TARGET_IPV6_SUPPORT=y
+
+#
+# Removal patches
+#
+# FREETZ_SELECT_HARDENING is not set
+
+#
+# Removal patches ------------------------------------------
+#
+FREETZ_REMOVE_LEFTOVER=y
+# FREETZ_REMOVE_MULTI_ANNEX_FIRMWARE_DIFFS is not set
+# FREETZ_REMOVE_DSLD is not set
+# FREETZ_REMOVE_SHOWDSLDSTAT is not set
+# FREETZ_REMOVE_ASSISTANT is not set
+# FREETZ_REMOVE_PCPD is not set
+# FREETZ_REMOVE_PLCD is not set
+# FREETZ_REMOVE_MESHD is not set
+# FREETZ_REMOVE_NEXUS is not set
+# FREETZ_REMOVE_AHA is not set
+# FREETZ_REMOVE_AURA_USB is not set
+# FREETZ_REMOVE_WEBDAV is not set
+# FREETZ_REMOVE_MEDIASRV is not set
+# FREETZ_REMOVE_NAS is not set
+# FREETZ_REMOVE_MYFRITZ is not set
+# FREETZ_REMOVE_DDNSD is not set
+# FREETZ_REMOVE_AVM_VPN is not set
+# FREETZ_REMOVE_AVM_WIREGUARD is not set
+# FREETZ_REMOVE_AVMCOUNTERD is not set
+# FREETZ_REMOVE_LANGUAGE is not set
+# FREETZ_REMOVE_BRANDING is not set
+# FREETZ_REMOVE_CAPIOVERTCP is not set
+FREETZ_REMOVE_CHRONYD=y
+# FREETZ_REMOVE_DECT is not set
+FREETZ_REMOVE_DTRACE=y
+# FREETZ_REMOVE_FTPD is not set
+# FREETZ_REMOVE_HELP is not set
+# FREETZ_REMOVE_LIBFUSE is not set
+# FREETZ_REMOVE_FAT is not set
+# FREETZ_REMOVE_NTFS is not set
+# FREETZ_REMOVE_NLS is not set
+# FREETZ_REMOVE_USBHOST is not set
+# FREETZ_REMOVE_PRINTSERV is not set
+# FREETZ_REMOVE_RUNCLOCK is not set
+# FREETZ_REMOVE_SAMBA is not set
+# FREETZ_REMOVE_SUPPORT is not set
+# FREETZ_REMOVE_PUBKEY is not set
+# FREETZ_REMOVE_TR069 is not set
+# FREETZ_REMOVE_UMTSD is not set
+# FREETZ_REMOVE_UPNP is not set
+# FREETZ_REMOVE_KIDS is not set
+# FREETZ_REMOVE_QOS is not set
+# end of Removal patches
+
+#
+# Other patches
+#
+
+#
+# Web menu patches -----------------------------------------
+#
+# FREETZ_PATCH_ATA is not set
+# FREETZ_PATCH_FAXPAGES is not set
+# FREETZ_PATCH_GSMVOICE is not set
+# FREETZ_PATCH_SIGNED is not set
+# FREETZ_PATCH_SECURE is not set
+# FREETZ_MODIFY_DSL_WARNING is not set
+# FREETZ_MODIFY_DSL_SPECTRUM is not set
+# FREETZ_MODIFY_DSL_SETTINGS is not set
+# FREETZ_MODIFY_COUNTER is not set
+# FREETZ_PATCH_MODFS_BOOT_MANAGER is not set
+
+#
+# USB patches ----------------------------------------------
+#
+FREETZ_PATCH_UDEVMOUNT=y
+
+#
+# Intern NTFS
+#
+
+#
+# Intern Fat
+#
+# FREETZ_UDEVMOUNT_EXT2 is not set
+
+#
+# Intern Ext3
+#
+
+#
+# Intern Ext4
+#
+# FREETZ_UDEVMOUNT_HFS is not set
+# FREETZ_UDEVMOUNT_HFS_PLUS is not set
+# FREETZ_UDEVMOUNT_REISER_FS is not set
+# FREETZ_PATCH_MAXDEVCOUNT is not set
+# FREETZ_CUSTOM_UDEV_RULES is not set
+# FREETZ_DROP_NOEXEC_EXTERNAL is not set
+
+#
+# Replacement patches --------------------------------------
+#
+# FREETZ_REPLACE_DTRACE is not set
+# FREETZ_REPLACE_ONLINECHANGED is not set
+
+#
+# Additional patches ---------------------------------------
+#
+# FREETZ_ADD_SWAPOPTIONS is not set
+# FREETZ_ADD_TELNETD is not set
+# FREETZ_ADD_ETCNETCONFIG is not set
+FREETZ_CUSTOM_ETCSERVICES=y
+FREETZ_ENFORCE_TMP_PERMISSIONS=y
+FREETZ_ENFORCE_BRANDING_none=y
+# FREETZ_ENFORCE_BRANDING_1und1 is not set
+# FREETZ_ENFORCE_BRANDING_avm is not set
+# FREETZ_ENFORCE_BRANDING_avme is not set
+
+#
+# Misc patches ---------------------------------------------
+#
+# FREETZ_DISABLE_SERIAL_CONSOLE is not set
+# FREETZ_RUN_TELEFON_IN_INHAUS_MODE is not set
+
+#
+# AVM daemons ----------------------------------------------
+#
+# FREETZ_AVMDAEMON_DISABLE_IGD is not set
+# FREETZ_AVMDAEMON_DISABLE_IGM is not set
+# FREETZ_AVMDAEMON_DISABLE_TR069 is not set
+FREETZ_AVMDAEMON_DISABLE_MULTIDPORTS=y
+FREETZ_AVMDAEMON_DISABLE_DNS=y
+FREETZ_AVMDAEMON_DISABLE_DHCP=y
+FREETZ_AVMDAEMON_DISABLE_LLMNR=y
+# end of Other patches
+
+#
+# Additional components ------------------------------------
+#
+
+#
+# Packages
+#
+
+#
+# A
+#
+# FREETZ_PACKAGE_ACME is not set
+# FREETZ_PACKAGE_APACHE2 is not set
+# FREETZ_PACKAGE_ATOP is not set
+# FREETZ_PACKAGE_AUTOFS is not set
+# FREETZ_PACKAGE_AUTOSSH is not set
+# FREETZ_PACKAGE_AVAHI is not set
+# end of A
+
+#
+# B
+#
+# FREETZ_PACKAGE_BASH is not set
+# FREETZ_PACKAGE_BFTPD is not set
+# FREETZ_PACKAGE_BFUSB is not set
+# FREETZ_PACKAGE_BIND is not set
+# FREETZ_PACKAGE_BIP is not set
+# FREETZ_PACKAGE_BIRD is not set
+# FREETZ_PACKAGE_BITTWIST is not set
+# FREETZ_PACKAGE_BLUEZ_UTILS is not set
+# FREETZ_PACKAGE_BRIDGE_UTILS is not set
+# FREETZ_PACKAGE_BVI is not set
+# end of B
+
+#
+# C
+#
+FREETZ_PACKAGE_CA_BUNDLE=y
+# FREETZ_PACKAGE_CALLMONITOR is not set
+# FREETZ_PACKAGE_CCID is not set
+# FREETZ_PACKAGE_CHECKMAILD is not set
+# FREETZ_PACKAGE_CIFSMOUNT is not set
+# FREETZ_PACKAGE_CLASSPATH is not set
+# FREETZ_PACKAGE_CNTLM is not set
+# FREETZ_PACKAGE_COMGT is not set
+# FREETZ_PACKAGE_CRYPTSETUP is not set
+# FREETZ_PACKAGE_CTORRENT is not set
+# FREETZ_PACKAGE_CURL is not set
+# FREETZ_PACKAGE_CURLFTPFS is not set
+# end of C
+
+#
+# D
+#
+# FREETZ_PACKAGE_DANTE is not set
+# FREETZ_PACKAGE_DAVFS2 is not set
+# FREETZ_PACKAGE_DBUS is not set
+# FREETZ_PACKAGE_DEBOOTSTRAP is not set
+# FREETZ_PACKAGE_DECO is not set
+# FREETZ_PACKAGE_DECRYPT_FRITZOS_CFG is not set
+# FREETZ_PACKAGE_DEHYDRATED is not set
+# FREETZ_PACKAGE_DEJAVU_FONTS_TTF is not set
+# FREETZ_PACKAGE_DIGITEMP is not set
+# FREETZ_PACKAGE_DNS2TCP is not set
+# FREETZ_PACKAGE_DNSMASQ is not set
+# FREETZ_PACKAGE_DOSFSTOOLS is not set
+FREETZ_PACKAGE_DROPBEAR=y
+FREETZ_PACKAGE_DROPBEAR_SFTP_SERVER=y
+# FREETZ_PACKAGE_DROPBEAR_SERVER_ONLY is not set
+# FREETZ_PACKAGE_DROPBEAR_WITH_ZLIB is not set
+FREETZ_PACKAGE_DROPBEAR_DISABLE_HOST_LOOKUP=y
+# FREETZ_PACKAGE_DROPBEAR_ENABLE_MOTD is not set
+# FREETZ_PACKAGE_DROPBEAR_UTMP is not set
+# FREETZ_PACKAGE_DROPBEAR_WTMP is not set
+# FREETZ_PACKAGE_DROPBEAR_STATIC is not set
+FREETZ_PACKAGE_DROPBEAR_AUTHORIZED_KEYS=y
+# FREETZ_PACKAGE_DROPBEAR_NONFREETZ is not set
+# FREETZ_PACKAGE_DTACH is not set
+# FREETZ_PACKAGE_DTC is not set
+# FREETZ_PACKAGE_DVBSNOOP is not set
+# FREETZ_PACKAGE_DVBSTREAM is not set
+# FREETZ_PACKAGE_DVBTUNE is not set
+# end of D
+
+#
+# E
+#
+# FREETZ_PACKAGE_EMAILRELAY is not set
+# FREETZ_PACKAGE_EMPTY is not set
+# FREETZ_PACKAGE_ESPEAK is not set
+# end of E
+
+#
+# F
+#
+# FREETZ_PACKAGE_FFMPEG is not set
+# FREETZ_PACKAGE_FORTUNE is not set
+# FREETZ_PACKAGE_FOWSR is not set
+# FREETZ_PACKAGE_FTDI1 is not set
+# FREETZ_PACKAGE_FUSE is not set
+# end of F
+
+#
+# G
+#
+# FREETZ_PACKAGE_GETDNS is not set
+# FREETZ_PACKAGE_GHOSTSCRIPT_FONTS is not set
+# FREETZ_PACKAGE_GIT is not set
+# FREETZ_PACKAGE_GNTPSEND is not set
+# FREETZ_PACKAGE_GNU_MAKE is not set
+# FREETZ_PACKAGE_GNUTLS is not set
+# FREETZ_PACKAGE_GOCR is not set
+# FREETZ_PACKAGE_GW6 is not set
+# end of G
+
+#
+# H
+#
+# FREETZ_PACKAGE_HAPROXY is not set
+FREETZ_PACKAGE_HASERL=y
+# FREETZ_PACKAGE_HASERL_WITH_LUA is not set
+# FREETZ_PACKAGE_HD_IDLE is not set
+# FREETZ_PACKAGE_HDPARM is not set
+# FREETZ_PACKAGE_HOL is not set
+# FREETZ_PACKAGE_HTML2TEXT is not set
+# FREETZ_PACKAGE_HTOP is not set
+# FREETZ_PACKAGE_HTPDATE is not set
+# FREETZ_PACKAGE_HTTPRY is not set
+# FREETZ_PACKAGE_HTTPTUNNEL is not set
+# end of H
+
+#
+# I
+#
+# FREETZ_PACKAGE_IFSTAT is not set
+# FREETZ_PACKAGE_IFTOP is not set
+# FREETZ_PACKAGE_IGMPPROXY is not set
+# FREETZ_PACKAGE_IMAGEMAGICK is not set
+# FREETZ_PACKAGE_INADYN_MT is not set
+# FREETZ_PACKAGE_INADYN_OPENDNS is not set
+FREETZ_PACKAGE_INETD=y
+# FREETZ_PACKAGE_INETD_TIME is not set
+# FREETZ_PACKAGE_IODINE is not set
+# FREETZ_PACKAGE_IPERF is not set
+# FREETZ_PACKAGE_IPTRAF is not set
+# FREETZ_PACKAGE_IPUTILS is not set
+# FREETZ_PACKAGE_IRSSI is not set
+# FREETZ_PACKAGE_ISC_DHCP is not set
+# end of I
+
+#
+# J
+#
+# FREETZ_PACKAGE_JAMVM is not set
+# FREETZ_PACKAGE_JQ is not set
+# FREETZ_PACKAGE_JS is not set
+FREETZ_PACKAGE_JUIS_CHECK=y
+# end of J
+
+#
+# K
+#
+# FREETZ_PACKAGE_KNOCK is not set
+# end of K
+
+#
+# L
+#
+# FREETZ_PACKAGE_LCD4LINUX is not set
+# FREETZ_PACKAGE_LFTP is not set
+# FREETZ_PACKAGE_LIGHTTPD is not set
+# FREETZ_PACKAGE_LUA is not set
+# FREETZ_PACKAGE_LYNX is not set
+# end of L
+
+#
+# M
+#
+# FREETZ_PACKAGE_MADPLAY is not set
+FREETZ_PACKAGE_MC=y
+# FREETZ_PACKAGE_MC_WITH_NCURSES is not set
+FREETZ_PACKAGE_MC_WITH_NCURSESW=y
+# FREETZ_PACKAGE_MC_WITH_SLANG is not set
+# FREETZ_PACKAGE_MC_WITH_BACKGROUND is not set
+# FREETZ_PACKAGE_MC_WITH_CHARSET is not set
+FREETZ_PACKAGE_MC_WITH_INTERNAL_EDIT=y
+# FREETZ_PACKAGE_MC_WITH_DIFF_VIEWER is not set
+FREETZ_PACKAGE_MC_WITH_SUBSHELL=y
+# FREETZ_PACKAGE_MC_WITH_VFS is not set
+FREETZ_PACKAGE_MC_WITH_HELP=y
+FREETZ_PACKAGE_MC_WITH_SYNTAX=y
+# FREETZ_PACKAGE_MCABBER is not set
+# FREETZ_PACKAGE_MEDIATOMB is not set
+# FREETZ_PACKAGE_MICROPERL is not set
+# FREETZ_PACKAGE_MINI_SNMPD is not set
+# FREETZ_PACKAGE_MINICOM is not set
+# FREETZ_PACKAGE_MINIDLNA is not set
+# FREETZ_PACKAGE_MINISATIP is not set
+FREETZ_PACKAGE_MOD=y
+FREETZ_PACKAGE_MODCGI=y
+# FREETZ_PACKAGE_MODULE_INIT_TOOLS is not set
+# FREETZ_PACKAGE_MOSQUITTO is not set
+# FREETZ_PACKAGE_MTR is not set
+# end of M
+
+#
+# N
+#
+# FREETZ_PACKAGE_NAGIOS is not set
+# FREETZ_PACKAGE_NANO is not set
+# FREETZ_PACKAGE_NC6 is not set
+# FREETZ_PACKAGE_NCFTP is not set
+# FREETZ_PACKAGE_NETATALK is not set
+# FREETZ_PACKAGE_NETCAT is not set
+# FREETZ_PACKAGE_NETPBM is not set
+# FREETZ_PACKAGE_NETSNMP is not set
+# FREETZ_PACKAGE_NFS_UTILS is not set
+
+#
+# NFS-root (not available, needs replace kernel)
+#
+# FREETZ_PACKAGE_NGIRCD is not set
+# FREETZ_PACKAGE_NMAP is not set
+# FREETZ_PACKAGE_NOIP is not set
+# FREETZ_PACKAGE_NZBGET is not set
+# end of N
+
+#
+# O
+#
+# FREETZ_PACKAGE_OBEXFTP is not set
+# FREETZ_PACKAGE_OIDENTD is not set
+# FREETZ_PACKAGE_OPENCONNECT is not set
+# FREETZ_PACKAGE_OPENDD is not set
+# FREETZ_PACKAGE_OPENNTPD is not set
+FREETZ_PACKAGE_OPENSSH=y
+FREETZ_PACKAGE_OPENSSH_VERSION_CURRENT=y
+FREETZ_PACKAGE_OPENSSH_AUTHORIZED_KEYS=y
+# FREETZ_PACKAGE_OPENSSH_sshd is not set
+
+#
+# SSH client (ssh) (not available, provided by dropbear)
+#
+
+#
+# Secure copy (scp) (not available, provided by dropbear)
+#
+# FREETZ_PACKAGE_OPENSSH_CLIENTUTILS is not set
+# FREETZ_PACKAGE_OPENSSH_KEYUTILS is not set
+# FREETZ_PACKAGE_OPENSSH_sftp is not set
+FREETZ_PACKAGE_OPENSSH_sftp_server=y
+
+#
+# Configuration ---
+#
+# FREETZ_PACKAGE_OPENSSH_INTERNAL_CRYPTO is not set
+# FREETZ_PACKAGE_OPENSSH_STATIC is not set
+# FREETZ_PACKAGE_OPENSSL is not set
+# FREETZ_PACKAGE_OPENVPN is not set
+# FREETZ_PACKAGE_OWFS is not set
+# end of O
+
+#
+# P
+#
+# FREETZ_PACKAGE_P7ZIP is not set
+# FREETZ_PACKAGE_PCSC_LITE is not set
+# FREETZ_PACKAGE_PHONEBOOK_TOOLS is not set
+# FREETZ_PACKAGE_PINGTUNNEL is not set
+# FREETZ_PACKAGE_POLIPO is not set
+# FREETZ_PACKAGE_PPP is not set
+FREETZ_BOX_CERTIFICATE_SUPPORT_AVAILABLE=y
+# FREETZ_PACKAGE_PRIVATEKEYPASSWORD is not set
+# FREETZ_PACKAGE_PRIVOXY is not set
+# FREETZ_PACKAGE_PROXYCHAINS_NG is not set
+# FREETZ_PACKAGE_PSL is not set
+# FREETZ_PACKAGE_PYLOAD is not set
+# FREETZ_PACKAGE_PYTHON is not set
+# end of P
+
+#
+# Q
+#
+# FREETZ_PACKAGE_QUAGGA is not set
+# end of Q
+
+#
+# R
+#
+# FREETZ_PACKAGE_RADVD is not set
+# FREETZ_PACKAGE_RCAPID is not set
+# FREETZ_PACKAGE_RIPMIME is not set
+# FREETZ_PACKAGE_RPCBIND is not set
+# FREETZ_PACKAGE_RRDTOOL is not set
+# FREETZ_PACKAGE_RSYNC is not set
+# FREETZ_PACKAGE_RTMPDUMP is not set
+# FREETZ_PACKAGE_RUSH is not set
+# end of R
+
+#
+# S
+#
+# FREETZ_PACKAGE_SABLEVM_SDK is not set
+# FREETZ_PACKAGE_SAMBA is not set
+# FREETZ_PACKAGE_SCREEN is not set
+# FREETZ_PACKAGE_SER2NET is not set
+# FREETZ_PACKAGE_SFK is not set
+# FREETZ_PACKAGE_SHELLINABOX is not set
+# FREETZ_PACKAGE_SIPROXD is not set
+# FREETZ_PACKAGE_SISPMCTL is not set
+# FREETZ_PACKAGE_SLANG is not set
+# FREETZ_PACKAGE_SLURM is not set
+# FREETZ_PACKAGE_SMARTMONTOOLS is not set
+# FREETZ_PACKAGE_SMSTOOLS3 is not set
+# FREETZ_PACKAGE_SMUSBUTIL is not set
+# FREETZ_PACKAGE_SOCAT is not set
+# FREETZ_PACKAGE_SPAWN_FCGI is not set
+# FREETZ_PACKAGE_SQLITE is not set
+# FREETZ_PACKAGE_SQUASHFS3 is not set
+# FREETZ_PACKAGE_SQUASHFS4_BE is not set
+# FREETZ_PACKAGE_SQUASHFS4_LE is not set
+# FREETZ_PACKAGE_SSHFS_FUSE is not set
+# FREETZ_PACKAGE_SSLH is not set
+# FREETZ_PACKAGE_STREAMRIPPER is not set
+# FREETZ_PACKAGE_STUNNEL is not set
+# FREETZ_PACKAGE_SUBVERSION is not set
+# FREETZ_PACKAGE_SUDO is not set
+# FREETZ_PACKAGE_SYNCE_DCCM is not set
+
+#
+# SynCE serial (not available, needs replace kernel)
+#
+# end of S
+
+#
+# T
+#
+# FREETZ_PACKAGE_TCP_WRAPPERS is not set
+# FREETZ_PACKAGE_TCPDUMP is not set
+# FREETZ_PACKAGE_TCPPROXY is not set
+# FREETZ_PACKAGE_TESSERACT is not set
+# FREETZ_PACKAGE_TICHKSUM is not set
+# FREETZ_PACKAGE_TIFF is not set
+# FREETZ_PACKAGE_TINC is not set
+# FREETZ_PACKAGE_TINYPROXY is not set
+# FREETZ_PACKAGE_TMUX is not set
+# FREETZ_PACKAGE_TOR is not set
+# FREETZ_PACKAGE_TRANSMISSION is not set
+# FREETZ_PACKAGE_TREE is not set
+# FREETZ_PACKAGE_TRICKLE is not set
+# end of T
+
+#
+# U
+#
+# FREETZ_PACKAGE_UDPXY is not set
+# FREETZ_PACKAGE_UMURMUR is not set
+# FREETZ_PACKAGE_UNBOUND is not set
+# FREETZ_PACKAGE_UNRAR is not set
+# FREETZ_PACKAGE_USBIDS is not set
+# end of U
+
+#
+# V
+#
+# FREETZ_PACKAGE_VIM is not set
+FREETZ_PACKAGE_VLMCSD=y
+FREETZ_PACKAGE_VLMCSDSETUP=y
+# FREETZ_PACKAGE_VNSTAT is not set
+# FREETZ_PACKAGE_VPNC is not set
+# FREETZ_PACKAGE_VSFTPD is not set
+# FREETZ_PACKAGE_VTUN is not set
+# end of V
+
+#
+# W
+#
+FREETZ_PACKAGE_WGET=y
+FREETZ_PACKAGE_WGET_WITH_SSL=y
+FREETZ_PACKAGE_WGET_OPENSSL=y
+# FREETZ_PACKAGE_WGET_GNUTLS is not set
+FREETZ_PACKAGE_WGET_CA_BUNDLE=y
+# FREETZ_PACKAGE_WGET_STATIC is not set
+FREETZ_WGET=y
+# FREETZ_PACKAGE_WHOIS is not set
+# FREETZ_PACKAGE_WIREGUARD is not set
+# FREETZ_PACKAGE_WOL is not set
+# FREETZ_PACKAGE_WPUT is not set
+# end of W
+
+#
+# X
+#
+# FREETZ_PACKAGE_XMAIL is not set
+# FREETZ_PACKAGE_XPDF is not set
+# FREETZ_PACKAGE_XRELAYD is not set
+# FREETZ_PACKAGE_XSLTPROC is not set
+# FREETZ_PACKAGE_XZ is not set
+# end of X
+
+#
+# ----------------------------------------
+#
+
+#
+# Debug helpers
+#
+# FREETZ_PACKAGE_GDB is not set
+# FREETZ_PACKAGE_INOTIFY_TOOLS is not set
+# FREETZ_PACKAGE_LDD is not set
+# FREETZ_PACKAGE_LSOF is not set
+# FREETZ_PACKAGE_LTRACE is not set
+# FREETZ_PACKAGE_NANO_SHELL is not set
+# FREETZ_PACKAGE_PCIUTILS is not set
+# FREETZ_PACKAGE_STRACE is not set
+# FREETZ_PACKAGE_USBUTILS is not set
+# FREETZ_PACKAGE_VERMAGIC is not set
+# end of Debug helpers
+
+#
+# Unstable
+#
+# FREETZ_PACKAGE_ASTERISK is not set
+# FREETZ_PACKAGE_COLLECTD is not set
+# FREETZ_PACKAGE_GPTFDISK is not set
+# FREETZ_PACKAGE_HP_UTILS is not set
+# FREETZ_PACKAGE_HPLIP is not set
+# FREETZ_PACKAGE_MINI_FO is not set
+# FREETZ_PACKAGE_MYSQL is not set
+# FREETZ_PACKAGE_PHP is not set
+# FREETZ_PACKAGE_SANE_BACKENDS is not set
+# FREETZ_PACKAGE_SCANBUTTOND is not set
+# FREETZ_PACKAGE_USBROOT is not set
+# FREETZ_PACKAGE_VIRTUALIP_CGI is not set
+# FREETZ_PACKAGE_ZABBIX is not set
+# end of Unstable
+
+#
+# Web interfaces
+#
+
+#
+# Addhole (needs dnsmasq)
+#
+FREETZ_PACKAGE_AUTHORIZED_KEYS=y
+# FREETZ_PACKAGE_AVM_PORTFW is not set
+# FREETZ_PACKAGE_DNSD_CGI is not set
+# FREETZ_PACKAGE_DOWNLOADER is not set
+# FREETZ_PACKAGE_NFSD_CGI is not set
+# FREETZ_PACKAGE_ONLINECHANGED_CGI is not set
+# FREETZ_PACKAGE_PHPXMAIL is not set
+# FREETZ_PACKAGE_RRDSTATS is not set
+# FREETZ_PACKAGE_SPINDOWN_CGI is not set
+FREETZ_PACKAGE_SYSLOGD_CGI=y
+# FREETZ_PACKAGE_VNSTAT_CGI is not set
+# FREETZ_PACKAGE_WOL_CGI is not set
+# end of Web interfaces
+# end of Packages
+
+#
+# Shared libraries
+#
+
+#
+# Apache Portable Runtime libs
+#
+# FREETZ_LIB_libapr is not set
+# FREETZ_LIB_libaprutil is not set
+# end of Apache Portable Runtime libs
+
+#
+# Avahi libraries
+#
+# FREETZ_LIB_libavahi_common is not set
+# FREETZ_LIB_libavahi_core is not set
+# FREETZ_LIB_libavahi_client is not set
+# end of Avahi libraries
+
+#
+# Charsets & Internationalization
+#
+FREETZ_LIB_libintl=y
+# FREETZ_LIB_libfribidi is not set
+# FREETZ_LIB_libutf8proc is not set
+# end of Charsets & Internationalization
+
+#
+# Crypto & SSL
+#
+
+#
+# GnuPG ----------------------------------
+#
+# FREETZ_LIB_libgpg_error is not set
+# FREETZ_LIB_libgcrypt is not set
+
+#
+# GnuTLS ---------------------------------
+#
+# FREETZ_LIB_libgnutls is not set
+# FREETZ_LIB_libtasn1 is not set
+
+#
+# mbed TLS -------------------------------
+#
+# FREETZ_LIB_libmbedcrypto is not set
+# FREETZ_LIB_libmbedtls is not set
+# FREETZ_LIB_libmbedx509 is not set
+FREETZ_MBEDTLS_VERSION_CURRENT=y
+
+#
+# Nettle ---------------------------------
+#
+# FREETZ_LIB_libnettle is not set
+# FREETZ_LIB_libhogweed is not set
+
+#
+# OpenSSL --------------------------------
+#
+FREETZ_LIB_libcrypto=y
+FREETZ_LIB_libssl=y
+# FREETZ_OPENSSL_VERSION_2 is not set
+FREETZ_OPENSSL_VERSION_3=y
+
+#
+# OpenSSL configuration
+#
+FREETZ_OPENSSL_SHLIB_VERSION="3"
+FREETZ_OPENSSL_LIBCRYPTO_EXTRA_LIBS="-ldl -pthread -latomic"
+FREETZ_LIB_libcrypto_WITH_EC=y
+# FREETZ_LIB_libcrypto_WITH_RC4 is not set
+# FREETZ_LIB_libcrypto_WITH_ZLIB is not set
+FREETZ_OPENSSL_SMALL_FOOTPRINT=y
+FREETZ_OPENSSL_CONFIG_DIR="/mod/etc/ssl"
+# end of OpenSSL configuration
+
+FREETZ_OPENSSL_VERSION_1_MIN=y
+FREETZ_OPENSSL_VERSION_2_MIN=y
+FREETZ_OPENSSL_VERSION_3_MIN=y
+
+#
+# PolarSSL -------------------------------
+#
+# FREETZ_LIB_libpolarssl12 is not set
+# FREETZ_LIB_libpolarssl13 is not set
+
+#
+# Misc -----------------------------------
+#
+# FREETZ_LIB_libgsasl is not set
+# FREETZ_LIB_libssh2 is not set
+# end of Crypto & SSL
+
+#
+# Data compression
+#
+# FREETZ_LIB_libdeflate is not set
+# FREETZ_LIB_liblz4 is not set
+# FREETZ_LIB_liblzo2 is not set
+# FREETZ_LIB_liblzma is not set
+FREETZ_LIB_libz=y
+# end of Data compression
+
+#
+# Database
+#
+# FREETZ_LIB_libdb is not set
+# FREETZ_LIB_libmaxminddb is not set
+# FREETZ_LIB_libsqlite3 is not set
+# end of Database
+
+#
+# File systems
+#
+
+#
+# e2fsprogs libraries
+#
+# FREETZ_LIB_libblkid is not set
+# FREETZ_LIB_libcom_err is not set
+# FREETZ_LIB_libe2p is not set
+# FREETZ_LIB_libext2fs is not set
+# FREETZ_LIB_libss is not set
+# FREETZ_LIB_libuuid is not set
+# end of e2fsprogs libraries
+
+# FREETZ_LIB_libfuse is not set
+# FREETZ_LIB_libntfs is not set
+# end of File systems
+
+#
+# Freetz
+#
+FREETZ_LIB_libmultid=y
+FREETZ_LIB_libmultid_WITH_ANYIP=y
+FREETZ_LIB_libmultid_WITH_DNS=y
+FREETZ_LIB_libmultid_WITH_DHCP=y
+FREETZ_LIB_libmultid_WITH_LLMNR=y
+# end of Freetz
+
+#
+# GCC
+#
+FREETZ_LIB_libatomic=y
+FREETZ_LIB_libgcc_s=y
+# FREETZ_LIB_libstdc__ is not set
+# end of GCC
+
+#
+# GLib
+#
+FREETZ_LIB_libglib_2=y
+FREETZ_LIB_libglib_2_VERSION_CURRENT=y
+# FREETZ_LIB_libgio_2 is not set
+# FREETZ_LIB_libgobject_2 is not set
+# FREETZ_LIB_libgmodule_2 is not set
+# FREETZ_LIB_libgthread_2 is not set
+# end of GLib
+
+#
+# Graphics & fonts
+#
+# FREETZ_LIB_libcairo is not set
+# FREETZ_LIB_libfontconfig is not set
+# FREETZ_LIB_libfreetype is not set
+# FREETZ_LIB_libharfbuzz is not set
+# FREETZ_LIB_libart_lgpl_2 is not set
+# FREETZ_LIB_libexif is not set
+# FREETZ_LIB_libjpeg is not set
+# FREETZ_LIB_liblept is not set
+# FREETZ_LIB_libpng16 is not set
+# FREETZ_LIB_libgd is not set
+# FREETZ_LIB_libopenjpeg is not set
+# FREETZ_LIB_libopenjp2 is not set
+# FREETZ_LIB_libpango_1 is not set
+# FREETZ_LIB_libpangoft2_1 is not set
+# FREETZ_LIB_libpangocairo_1 is not set
+# FREETZ_LIB_libpixman_1 is not set
+# FREETZ_LIB_libtesseract is not set
+# FREETZ_LIB_libtiff is not set
+# FREETZ_LIB_libtiffxx is not set
+# FREETZ_LIB_libnetpbm is not set
+# end of Graphics & fonts
+
+#
+# Multi precision arithmetic libs
+#
+FREETZ_LIB_libgmp=y
+FREETZ_LIB_libmpfr=y
+FREETZ_LIB_libmpc=y
+# end of Multi precision arithmetic libs
+
+#
+# Multimedia
+#
+# FREETZ_LIB_libdvbcsa is not set
+
+#
+# Audio and video codecs
+#
+
+#
+# Audio codecs
+#
+# FREETZ_LIB_libFLAC is not set
+# FREETZ_LIB_libmad is not set
+# FREETZ_LIB_libogg is not set
+# FREETZ_LIB_libopus is not set
+# FREETZ_LIB_libspeex is not set
+# FREETZ_LIB_libspeexdsp is not set
+# end of Audio codecs
+
+#
+# FFmpeg libraries
+#
+# FREETZ_LIB_libavcodec is not set
+# FREETZ_LIB_libavdevice is not set
+# FREETZ_LIB_libavfilter is not set
+# FREETZ_LIB_libavformat is not set
+# FREETZ_LIB_libavutil is not set
+# FREETZ_LIB_libpostproc is not set
+# FREETZ_LIB_libswresample is not set
+# FREETZ_LIB_libswscale is not set
+# end of FFmpeg libraries
+
+#
+# Video codecs
+#
+
+#
+# Vorbis video codec ---------------------
+#
+# FREETZ_LIB_libvorbis is not set
+# FREETZ_LIB_libvorbisenc is not set
+# FREETZ_LIB_libvorbisfile is not set
+# end of Video codecs
+# end of Audio and video codecs
+
+#
+# ID3 tag reading libs
+#
+# FREETZ_LIB_libid3tag is not set
+# FREETZ_LIB_libtag is not set
+# end of ID3 tag reading libs
+# end of Multimedia
+
+#
+# ncurses
+#
+FREETZ_SHARE_terminfo=y
+FREETZ_SHARE_terminfo_ansi=y
+FREETZ_SHARE_terminfo_gnome=y
+FREETZ_SHARE_terminfo_konsole=y
+FREETZ_SHARE_terminfo_linux=y
+FREETZ_SHARE_terminfo_putty=y
+FREETZ_SHARE_terminfo_rxvt=y
+FREETZ_SHARE_terminfo_screen=y
+FREETZ_SHARE_terminfo_screenMINUSw=y
+FREETZ_SHARE_terminfo_sun=y
+FREETZ_SHARE_terminfo_vt100=y
+FREETZ_SHARE_terminfo_vt102=y
+FREETZ_SHARE_terminfo_vt102MINUSnsgr=y
+FREETZ_SHARE_terminfo_vt102MINUSw=y
+FREETZ_SHARE_terminfo_vt200=y
+FREETZ_SHARE_terminfo_vt220=y
+FREETZ_SHARE_terminfo_vt52=y
+FREETZ_SHARE_terminfo_xterm=y
+FREETZ_SHARE_terminfo_xtermMINUS256color=y
+FREETZ_SHARE_terminfo_xtermMINUScolor=y
+FREETZ_SHARE_terminfo_xtermMINUSxfree86=y
+# FREETZ_SHARE_terminfo_showall is not set
+FREETZ_LIB_libncurses=y
+FREETZ_LIB_libform=y
+FREETZ_LIB_libmenu=y
+FREETZ_LIB_libpanel=y
+FREETZ_LIB_libncursesw=y
+FREETZ_LIB_libformw=y
+FREETZ_LIB_libmenuw=y
+FREETZ_LIB_libpanelw=y
+# end of ncurses
+
+#
+# Networking
+#
+
+#
+# ATM ------------------------------------
+#
+# FREETZ_LIB_libatm is not set
+
+#
+# Bluetooth ------------------------------
+#
+# FREETZ_LIB_libbluetooth is not set
+# FREETZ_LIB_libopenobex is not set
+
+#
+# ISDN & CAPI ----------------------------
+#
+# FREETZ_LIB_libcapi20 is not set
+
+#
+# Misc networking ------------------------
+#
+# FREETZ_LIB_libdnet is not set
+# FREETZ_LIB_libgsm is not set
+# FREETZ_LIB_libiksemel is not set
+# FREETZ_LIB_libldns is not set
+# FREETZ_LIB_libmnl is not set
+# FREETZ_LIB_libnet is not set
+# FREETZ_LIB_liboping is not set
+# FREETZ_LIB_libosip2 is not set
+# FREETZ_LIB_libosipparser2 is not set
+# FREETZ_LIB_libpcap is not set
+# FREETZ_LIB_libunbound is not set
+# FREETZ_LIB_libspandsp is not set
+# FREETZ_LIB_libsrtp is not set
+# FREETZ_LIB_libtirpc is not set
+# FREETZ_LIB_libudns is not set
+# end of Networking
+
+#
+# PJ Project
+#
+# FREETZ_LIB_libpj is not set
+# FREETZ_LIB_libpjlib_util is not set
+# FREETZ_LIB_libpjmedia is not set
+# FREETZ_LIB_libpjmedia_audiodev is not set
+# FREETZ_LIB_libpjmedia_codec is not set
+# FREETZ_LIB_libpjmedia_videodev is not set
+# FREETZ_LIB_libpjnath is not set
+# FREETZ_LIB_libpjsip is not set
+# FREETZ_LIB_libpjsip_simple is not set
+# FREETZ_LIB_libpjsip_ua is not set
+# FREETZ_LIB_libpjsua is not set
+
+#
+# 3rdparty libraries
+#
+# FREETZ_LIB_libg7221codec is not set
+# FREETZ_LIB_libilbccodec is not set
+# FREETZ_LIB_libmilenage is not set
+# end of PJ Project
+
+#
+# Readline
+#
+# FREETZ_LIB_libreadline is not set
+# FREETZ_LIB_libhistory is not set
+# end of Readline
+
+#
+# Regular expressions
+#
+# FREETZ_LIB_libonig is not set
+# FREETZ_LIB_libpcre is not set
+# FREETZ_LIB_libpcreposix is not set
+FREETZ_LIB_libpcre2=y
+# FREETZ_LIB_libpcre2_posix is not set
+# end of Regular expressions
+
+#
+# uClibc
+#
+FREETZ_LIB_ld_uClibc=y
+# FREETZ_LIB_libthread_db is not set
+FREETZ_LIB_libuClibc=y
+# FREETZ_LIB_libuClibc__ is not set
+# end of uClibc
+
+#
+# USB & FTDI
+#
+# FREETZ_LIB_libusb_0 is not set
+# FREETZ_LIB_libusb_1 is not set
+# FREETZ_LIB_libftdi is not set
+# FREETZ_LIB_libftdi1 is not set
+# end of USB & FTDI
+
+#
+# Web and WebDAV
+#
+# FREETZ_LIB_libcurl is not set
+# FREETZ_LIB_libidn is not set
+# FREETZ_LIB_libjansson is not set
+# FREETZ_LIB_libjs is not set
+# FREETZ_LIB_libneon is not set
+# FREETZ_LIB_libpsl is not set
+# FREETZ_LIB_libserf is not set
+# end of Web and WebDAV
+
+#
+# XML & XSLT
+#
+# FREETZ_LIB_libexpat is not set
+# FREETZ_LIB_libxml2 is not set
+# FREETZ_LIB_libxslt is not set
+# FREETZ_LIB_libexslt is not set
+# end of XML & XSLT
+
+# FREETZ_LIB_libattr is not set
+# FREETZ_LIB_libcap is not set
+# FREETZ_LIB_libcap_ng is not set
+# FREETZ_LIB_libdrop_ambient is not set
+# FREETZ_LIB_libconfig is not set
+# FREETZ_LIB_libconfuse is not set
+# FREETZ_LIB_libdaemon is not set
+# FREETZ_LIB_libdbus is not set
+# FREETZ_LIB_libdevmapper is not set
+# FREETZ_LIB_libelf is not set
+# FREETZ_LIB_libev is not set
+# FREETZ_LIB_libevent is not set
+# FREETZ_LIB_libffi is not set
+# FREETZ_LIB_liblua is not set
+# FREETZ_LIB_libnfsidmap is not set
+# FREETZ_LIB_libpcsclite is not set
+FREETZ_LIB_libpopt=y
+# FREETZ_LIB_libprivatekeypassword is not set
+# FREETZ_LIB_libprotobuf_c is not set
+# FREETZ_LIB_librrd is not set
+# FREETZ_LIB_libslang is not set
+# FREETZ_LIB_libsynce is not set
+# FREETZ_LIB_libsysfs is not set
+# FREETZ_LIB_libltdl is not set
+# FREETZ_LIB_libuv is not set
+# FREETZ_LIB_libyaml is not set
+# end of Shared libraries
+
+#
+# Kernel modules
+#
+FREETZ_MODULES_KOON=y
+FREETZ_MODULES_OWN=""
+
+#
+# block
+#
+# FREETZ_MODULE_block2mtd is not set
+# end of block
+
+#
+# crypto
+#
+# FREETZ_MODULE_pcompress is not set
+# end of crypto
+
+#
+# drivers
+#
+# FREETZ_MODULE_bfusb is not set
+# FREETZ_MODULE_btusb is not set
+# FREETZ_MODULE_capiconn is not set
+# FREETZ_MODULE_cdrom is not set
+# FREETZ_MODULE_dummy is not set
+# FREETZ_MODULE_dm_mod is not set
+# FREETZ_MODULE_dm_crypt is not set
+# FREETZ_MODULE_loop is not set
+# FREETZ_MODULE_musb_hdrc is not set
+# FREETZ_MODULE_nbd is not set
+# FREETZ_MODULE_sg is not set
+# FREETZ_MODULE_slhc is not set
+# FREETZ_MODULE_sr_mod is not set
+# FREETZ_MODULE_usb_storage is not set
+# FREETZ_MODULE_usblp is not set
+# FREETZ_MODULE_usbmon is not set
+
+#
+#  ppp
+#
+# FREETZ_MODULE_ppp_async is not set
+# FREETZ_MODULE_ppp_deflate is not set
+# FREETZ_MODULE_ppp_generic is not set
+# FREETZ_MODULE_ppp_mppe is not set
+# FREETZ_MODULE_pppoe is not set
+
+#
+#  serial
+#
+# FREETZ_MODULE_ch341 is not set
+# FREETZ_MODULE_cp2101 is not set
+# FREETZ_MODULE_cp210x is not set
+# FREETZ_MODULE_ftdi_sio is not set
+# FREETZ_MODULE_ipaq is not set
+# FREETZ_MODULE_option is not set
+# FREETZ_MODULE_pl2303 is not set
+# FREETZ_MODULE_usbserial is not set
+# end of drivers
+
+#
+# fs
+#
+# FREETZ_MODULE_ext2 is not set
+# FREETZ_MODULE_fat is not set
+# FREETZ_MODULE_hfs is not set
+# FREETZ_MODULE_hfsplus is not set
+# FREETZ_MODULE_iso9660 is not set
+# FREETZ_MODULE_mini_fo is not set
+# FREETZ_MODULE_minix is not set
+# FREETZ_MODULE_msdos is not set
+# FREETZ_MODULE_reiserfs is not set
+# FREETZ_MODULE_udf is not set
+# FREETZ_MODULE_unionfs is not set
+
+#
+#  net
+#
+# FREETZ_MODULE_autofs4 is not set
+# FREETZ_MODULE_cifs is not set
+
+#
+#  nfs
+#
+# FREETZ_MODULE_nfs is not set
+# FREETZ_MODULE_nfsd is not set
+
+#
+#  nls
+#
+# FREETZ_MODULE_nls_cp437 is not set
+# FREETZ_MODULE_nls_cp850 is not set
+# FREETZ_MODULE_nls_iso8859_1 is not set
+# FREETZ_MODULE_nls_iso8859_15 is not set
+# FREETZ_MODULE_nls_utf8 is not set
+# end of fs
+
+#
+# lib
+#
+# FREETZ_MODULE_crc_ccitt is not set
+# end of lib
+
+#
+# net
+#
+# FREETZ_MODULE_tun is not set
+
+#
+#  bt
+#
+# FREETZ_MODULE_bluetooth is not set
+# FREETZ_MODULE_bnep is not set
+# FREETZ_MODULE_rfcomm is not set
+
+#
+#  qos
+#
+# FREETZ_MODULE_sch_llq is not set
+# FREETZ_MODULE_sch_sfq is not set
+# FREETZ_MODULE_sch_tbf is not set
+# end of net
+# end of Kernel modules
+
+#
+# Busybox applets
+#
+FREETZ_BUSYBOX__VERSION_V136=y
+FREETZ_BUSYBOX__VERSION_STRING="1.36.1"
+FREETZ_BUSYBOX__RECOMMENDED=y
+FREETZ_BUSYBOX__MANDATORY=y
+FREETZ_BUSYBOX__MANDATORY_05_2X=y
+FREETZ_BUSYBOX__MANDATORY_06_5X=y
+FREETZ_BUSYBOX__MANDATORY_07_0X=y
+FREETZ_BUSYBOX__MANDATORY_07_2X=y
+FREETZ_BUSYBOX__MANDATORY_07_5X=y
+FREETZ_BUSYBOX__BUILD_TIMESTAMP=y
+FREETZ_BUSYBOX__KEEP_BINARIES=y
+FREETZ_BUSYBOX__IPV6_UTILS=y
+# FREETZ_BUSYBOX__PACKER is not set
+# FREETZ_BUSYBOX__NETWORK is not set
+# FREETZ_BUSYBOX__TERMINAL is not set
+# FREETZ_BUSYBOX__DEVELOPER is not set
+
+#
+# 
+#
+FREETZ_BUSYBOX_ADDGROUP=y
+FREETZ_BUSYBOX_ADDUSER=y
+FREETZ_BUSYBOX_AR=y
+FREETZ_BUSYBOX_ARP=y
+FREETZ_BUSYBOX_ARPING=y
+FREETZ_BUSYBOX_ASH=y
+FREETZ_BUSYBOX_ASH_ALIAS=y
+FREETZ_BUSYBOX_ASH_BASH_COMPAT=y
+FREETZ_BUSYBOX_ASH_BASH_NOT_FOUND_HOOK=y
+FREETZ_BUSYBOX_ASH_CMDCMD=y
+FREETZ_BUSYBOX_ASH_ECHO=y
+FREETZ_BUSYBOX_ASH_EXPAND_PRMT=y
+FREETZ_BUSYBOX_ASH_GETOPTS=y
+FREETZ_BUSYBOX_ASH_INTERNAL_GLOB=y
+FREETZ_BUSYBOX_ASH_JOB_CONTROL=y
+FREETZ_BUSYBOX_ASH_OPTIMIZE_FOR_SIZE=y
+FREETZ_BUSYBOX_ASH_PRINTF=y
+FREETZ_BUSYBOX_ASH_RANDOM_SUPPORT=y
+FREETZ_BUSYBOX_ASH_TEST=y
+FREETZ_BUSYBOX_AWK=y
+FREETZ_BUSYBOX_BASE64=y
+FREETZ_BUSYBOX_BASENAME=y
+FREETZ_BUSYBOX_BBCONFIG=y
+FREETZ_BUSYBOX_BB_SYSCTL=y
+FREETZ_BUSYBOX_BC=y
+FREETZ_BUSYBOX_BEEP=y
+FREETZ_BUSYBOX_BRCTL=y
+FREETZ_BUSYBOX_BUNZIP2=y
+FREETZ_BUSYBOX_BUSYBOX=y
+FREETZ_BUSYBOX_BZCAT=y
+FREETZ_BUSYBOX_BZIP2=y
+FREETZ_BUSYBOX_CAT=y
+FREETZ_BUSYBOX_CHGRP=y
+FREETZ_BUSYBOX_CHMOD=y
+FREETZ_BUSYBOX_CHOWN=y
+FREETZ_BUSYBOX_CHROOT=y
+FREETZ_BUSYBOX_CHRT=y
+FREETZ_BUSYBOX_CMP=y
+FREETZ_BUSYBOX_CP=y
+FREETZ_BUSYBOX_CPIO=y
+FREETZ_BUSYBOX_CROND=y
+FREETZ_BUSYBOX_CRONTAB=y
+FREETZ_BUSYBOX_CRYPTPW=y
+FREETZ_BUSYBOX_CUT=y
+FREETZ_BUSYBOX_DATE=y
+FREETZ_BUSYBOX_DD=y
+FREETZ_BUSYBOX_DELGROUP=y
+FREETZ_BUSYBOX_DELUSER=y
+FREETZ_BUSYBOX_DEVMEM=y
+FREETZ_BUSYBOX_DF=y
+FREETZ_BUSYBOX_DIRNAME=y
+FREETZ_BUSYBOX_DNSDOMAINNAME=y
+FREETZ_BUSYBOX_DU=y
+FREETZ_BUSYBOX_ECHO=y
+FREETZ_BUSYBOX_EGREP=y
+FREETZ_BUSYBOX_ENV=y
+FREETZ_BUSYBOX_ETHER_WAKE=y
+FREETZ_BUSYBOX_EXPR=y
+FREETZ_BUSYBOX_EXPR_MATH_SUPPORT_64=y
+FREETZ_BUSYBOX_FACTOR=y
+FREETZ_BUSYBOX_FALSE=y
+FREETZ_BUSYBOX_FEATURE_ADDUSER_TO_GROUP=y
+FREETZ_BUSYBOX_FEATURE_ALLOW_EXEC=y
+FREETZ_BUSYBOX_FEATURE_BRCTL_FANCY=y
+FREETZ_BUSYBOX_FEATURE_BRCTL_SHOW=y
+FREETZ_BUSYBOX_FEATURE_COMPRESS_BBCONFIG=y
+FREETZ_BUSYBOX_FEATURE_COMPRESS_USAGE=y
+FREETZ_BUSYBOX_FEATURE_DATE_COMPAT=y
+FREETZ_BUSYBOX_FEATURE_DATE_ISOFMT=y
+FREETZ_BUSYBOX_FEATURE_DD_IBS_OBS=y
+FREETZ_BUSYBOX_FEATURE_DD_SIGNAL_HANDLING=y
+FREETZ_BUSYBOX_FEATURE_DD_STATUS=y
+FREETZ_BUSYBOX_FEATURE_DEL_USER_FROM_GROUP=y
+FREETZ_BUSYBOX_FEATURE_DEVPTS=y
+FREETZ_BUSYBOX_FEATURE_DF_FANCY=y
+FREETZ_BUSYBOX_FEATURE_DU_DEFAULT_BLOCKSIZE_1K=y
+FREETZ_BUSYBOX_FEATURE_EDITING=y
+FREETZ_BUSYBOX_FEATURE_EDITING_FANCY_PROMPT=y
+FREETZ_BUSYBOX_FEATURE_EDITING_WINCH=y
+FREETZ_BUSYBOX_FEATURE_ENV_LONG_OPTIONS=y
+FREETZ_BUSYBOX_FEATURE_FANCY_ECHO=y
+FREETZ_BUSYBOX_FEATURE_FANCY_HEAD=y
+FREETZ_BUSYBOX_FEATURE_FANCY_PING=y
+FREETZ_BUSYBOX_FEATURE_FANCY_SLEEP=y
+FREETZ_BUSYBOX_FEATURE_FANCY_TAIL=y
+FREETZ_BUSYBOX_FEATURE_FAST_TOP=y
+FREETZ_BUSYBOX_FEATURE_FIND_DEPTH=y
+FREETZ_BUSYBOX_FEATURE_FIND_EXEC=y
+FREETZ_BUSYBOX_FEATURE_FIND_GROUP=y
+FREETZ_BUSYBOX_FEATURE_FIND_INUM=y
+FREETZ_BUSYBOX_FEATURE_FIND_MAXDEPTH=y
+FREETZ_BUSYBOX_FEATURE_FIND_MMIN=y
+FREETZ_BUSYBOX_FEATURE_FIND_MTIME=y
+FREETZ_BUSYBOX_FEATURE_FIND_NEWER=y
+FREETZ_BUSYBOX_FEATURE_FIND_NOT=y
+FREETZ_BUSYBOX_FEATURE_FIND_PAREN=y
+FREETZ_BUSYBOX_FEATURE_FIND_PATH=y
+FREETZ_BUSYBOX_FEATURE_FIND_PERM=y
+FREETZ_BUSYBOX_FEATURE_FIND_PRINT0=y
+FREETZ_BUSYBOX_FEATURE_FIND_PRUNE=y
+FREETZ_BUSYBOX_FEATURE_FIND_REGEX=y
+FREETZ_BUSYBOX_FEATURE_FIND_SIZE=y
+FREETZ_BUSYBOX_FEATURE_FIND_TYPE=y
+FREETZ_BUSYBOX_FEATURE_FIND_USER=y
+FREETZ_BUSYBOX_FEATURE_FIND_XDEV=y
+FREETZ_BUSYBOX_FEATURE_FTPGETPUT_LONG_OPTIONS=y
+FREETZ_BUSYBOX_FEATURE_GETOPT_LONG=y
+FREETZ_BUSYBOX_FEATURE_GREP_CONTEXT=y
+FREETZ_BUSYBOX_FEATURE_HEXDUMP_REVERSE=y
+FREETZ_BUSYBOX_FEATURE_HTTPD_AUTH_MD5=y
+FREETZ_BUSYBOX_FEATURE_HTTPD_BASIC_AUTH=y
+FREETZ_BUSYBOX_FEATURE_HTTPD_CGI=y
+FREETZ_BUSYBOX_FEATURE_HTTPD_CONFIG_WITH_SCRIPT_INTERPR=y
+FREETZ_BUSYBOX_FEATURE_HTTPD_ENCODE_URL_STR=y
+FREETZ_BUSYBOX_FEATURE_HUMAN_READABLE=y
+FREETZ_BUSYBOX_FEATURE_HWIB=y
+FREETZ_BUSYBOX_FEATURE_IFCONFIG_BROADCAST_PLUS=y
+FREETZ_BUSYBOX_FEATURE_IFCONFIG_HW=y
+FREETZ_BUSYBOX_FEATURE_IFCONFIG_MEMSTART_IOADDR_IRQ=y
+FREETZ_BUSYBOX_FEATURE_IFCONFIG_SLIP=y
+FREETZ_BUSYBOX_FEATURE_IFCONFIG_STATUS=y
+FREETZ_BUSYBOX_FEATURE_IFUPDOWN_IP=y
+FREETZ_BUSYBOX_FEATURE_IFUPDOWN_IPV4=y
+FREETZ_BUSYBOX_FEATURE_IFUPDOWN_IPV6=y
+FREETZ_BUSYBOX_FEATURE_IFUPDOWN_MAPPING=y
+FREETZ_BUSYBOX_FEATURE_INETD_SUPPORT_BUILTIN_CHARGEN=y
+FREETZ_BUSYBOX_FEATURE_INETD_SUPPORT_BUILTIN_DAYTIME=y
+FREETZ_BUSYBOX_FEATURE_INETD_SUPPORT_BUILTIN_DISCARD=y
+FREETZ_BUSYBOX_FEATURE_INETD_SUPPORT_BUILTIN_ECHO=y
+FREETZ_BUSYBOX_FEATURE_INETD_SUPPORT_BUILTIN_TIME=y
+FREETZ_BUSYBOX_FEATURE_INIT_MODIFY_CMDLINE=y
+FREETZ_BUSYBOX_FEATURE_INIT_QUIET=y
+FREETZ_BUSYBOX_FEATURE_INIT_SCTTY=y
+FREETZ_BUSYBOX_FEATURE_INIT_SYSLOG=y
+FREETZ_BUSYBOX_FEATURE_IP_ADDRESS=y
+FREETZ_BUSYBOX_FEATURE_IPC_SYSLOG=y
+FREETZ_BUSYBOX_FEATURE_IP_LINK=y
+FREETZ_BUSYBOX_FEATURE_IP_NEIGH=y
+FREETZ_BUSYBOX_FEATURE_IP_ROUTE=y
+FREETZ_BUSYBOX_FEATURE_IP_RULE=y
+FREETZ_BUSYBOX_FEATURE_IP_TUNNEL=y
+FREETZ_BUSYBOX_FEATURE_IPV6=y
+FREETZ_BUSYBOX_FEATURE_KILL_REMOVED=y
+FREETZ_BUSYBOX_FEATURE_KLOGD_KLOGCTL=y
+FREETZ_BUSYBOX_FEATURE_LOGREAD_REDUCED_LOCKING=y
+FREETZ_BUSYBOX_FEATURE_LS_COLOR=y
+FREETZ_BUSYBOX_FEATURE_LS_FILETYPES=y
+FREETZ_BUSYBOX_FEATURE_LS_FOLLOWLINKS=y
+FREETZ_BUSYBOX_FEATURE_LS_RECURSIVE=y
+FREETZ_BUSYBOX_FEATURE_LS_SORTFILES=y
+FREETZ_BUSYBOX_FEATURE_LS_TIMESTAMPS=y
+FREETZ_BUSYBOX_FEATURE_LS_USERNAME=y
+FREETZ_BUSYBOX_FEATURE_MAKEDEVS_TABLE=y
+FREETZ_BUSYBOX_FEATURE_MD5_SHA1_SUM_CHECK=y
+FREETZ_BUSYBOX_FEATURE_MKDIR_LONG_OPTIONS=y
+FREETZ_BUSYBOX_FEATURE_MOUNT_CIFS=y
+FREETZ_BUSYBOX_FEATURE_MOUNT_FAKE=y
+FREETZ_BUSYBOX_FEATURE_MOUNT_FLAGS=y
+FREETZ_BUSYBOX_FEATURE_MOUNT_FSTAB=y
+FREETZ_BUSYBOX_FEATURE_MOUNT_HELPERS=y
+FREETZ_BUSYBOX_FEATURE_MOUNT_LABEL=y
+FREETZ_BUSYBOX_FEATURE_MOUNT_LOOP=y
+FREETZ_BUSYBOX_FEATURE_MOUNT_LOOP_CREATE=y
+FREETZ_BUSYBOX_FEATURE_MOUNT_OTHERTAB=y
+FREETZ_BUSYBOX_FEATURE_MOUNT_VERBOSE=y
+FREETZ_BUSYBOX_FEATURE_MTAB_SUPPORT=y
+FREETZ_BUSYBOX_FEATURE_MV_LONG_OPTIONS=y
+FREETZ_BUSYBOX_FEATURE_NETSTAT_PRG=y
+FREETZ_BUSYBOX_FEATURE_NETSTAT_WIDE=y
+FREETZ_BUSYBOX_FEATURE_NOLOGIN=y
+FREETZ_BUSYBOX_FEATURE_NON_POSIX_CP=y
+FREETZ_BUSYBOX_FEATURE_PASSWD_WEAK_CHECK=y
+FREETZ_BUSYBOX_FEATURE_PIDFILE=y
+FREETZ_BUSYBOX_FEATURE_PIDOF_OMIT=y
+FREETZ_BUSYBOX_FEATURE_PIDOF_SINGLE=y
+FREETZ_BUSYBOX_FEATURE_PREFER_IPV4_ADDRESS=y
+FREETZ_BUSYBOX_FEATURE_PRESERVE_HARDLINKS=y
+FREETZ_BUSYBOX_FEATURE_READLINK_FOLLOW=y
+FREETZ_BUSYBOX_FEATURE_REMOTE_LOG=y
+FREETZ_BUSYBOX_FEATURE_RMDIR_LONG_OPTIONS=y
+FREETZ_BUSYBOX_FEATURE_ROTATE_LOGFILE=y
+FREETZ_BUSYBOX_FEATURE_RTMINMAX=y
+FREETZ_BUSYBOX_FEATURE_SEAMLESS_BZ2=y
+FREETZ_BUSYBOX_FEATURE_SEAMLESS_GZ=y
+FREETZ_BUSYBOX_FEATURE_SEAMLESS_LZMA=y
+FREETZ_BUSYBOX_FEATURE_SEAMLESS_XZ=y
+FREETZ_BUSYBOX_FEATURE_SEAMLESS_Z=y
+FREETZ_BUSYBOX_FEATURE_SECURETTY=y
+FREETZ_BUSYBOX_FEATURE_SETCONSOLE_LONG_OPTIONS=y
+FREETZ_BUSYBOX_FEATURE_SHADOWPASSWDS=y
+FREETZ_BUSYBOX_FEATURE_SH_EMBEDDED_SCRIPTS=y
+FREETZ_BUSYBOX_FEATURE_SH_HISTFILESIZE=y
+FREETZ_BUSYBOX_FEATURE_SH_MATH=y
+FREETZ_BUSYBOX_FEATURE_SH_MATH_64=y
+FREETZ_BUSYBOX_FEATURE_SHOW_THREADS=y
+FREETZ_BUSYBOX_FEATURE_SH_READ_FRAC=y
+FREETZ_BUSYBOX_FEATURE_SKIP_ROOTFS=y
+FREETZ_BUSYBOX_FEATURE_SORT_BIG=y
+FREETZ_BUSYBOX_FEATURE_SPLIT_FANCY=y
+FREETZ_BUSYBOX_FEATURE_START_STOP_DAEMON_FANCY=y
+FREETZ_BUSYBOX_FEATURE_STAT_FILESYSTEM=y
+FREETZ_BUSYBOX_FEATURE_STAT_FORMAT=y
+FREETZ_BUSYBOX_FEATURE_SUID=y
+FREETZ_BUSYBOX_FEATURE_SWAPONOFF_LABEL=y
+FREETZ_BUSYBOX_FEATURE_SWAPON_PRI=y
+FREETZ_BUSYBOX_FEATURE_SYSLOG=y
+FREETZ_BUSYBOX_FEATURE_SYSLOGD_DUP=y
+FREETZ_BUSYBOX_FEATURE_TAB_COMPLETION=y
+FREETZ_BUSYBOX_FEATURE_TAR_CREATE=y
+FREETZ_BUSYBOX_FEATURE_TAR_FROM=y
+FREETZ_BUSYBOX_FEATURE_TAR_GNU_EXTENSIONS=y
+FREETZ_BUSYBOX_FEATURE_TAR_LONG_OPTIONS=y
+FREETZ_BUSYBOX_FEATURE_TAR_OLDGNU_COMPATIBILITY=y
+FREETZ_BUSYBOX_FEATURE_TAR_OLDSUN_COMPATIBILITY=y
+FREETZ_BUSYBOX_FEATURE_TAR_TO_COMMAND=y
+FREETZ_BUSYBOX_FEATURE_TAR_UNAME_GNAME=y
+FREETZ_BUSYBOX_FEATURE_TASKSET_FANCY=y
+FREETZ_BUSYBOX_FEATURE_TEE_USE_BLOCK_IO=y
+FREETZ_BUSYBOX_FEATURE_TEST_64=y
+FREETZ_BUSYBOX_FEATURE_TFTP_GET=y
+FREETZ_BUSYBOX_FEATURE_TFTP_PUT=y
+FREETZ_BUSYBOX_FEATURE_TOP_CPU_GLOBAL_PERCENTS=y
+FREETZ_BUSYBOX_FEATURE_TOP_CPU_USAGE_PERCENTAGE=y
+FREETZ_BUSYBOX_FEATURE_TOP_DECIMALS=y
+FREETZ_BUSYBOX_FEATURE_TOP_INTERACTIVE=y
+FREETZ_BUSYBOX_FEATURE_TOPMEM=y
+FREETZ_BUSYBOX_FEATURE_TOP_SMP_CPU=y
+FREETZ_BUSYBOX_FEATURE_TOP_SMP_PROCESS=y
+FREETZ_BUSYBOX_FEATURE_TOUCH_NODEREF=y
+FREETZ_BUSYBOX_FEATURE_TOUCH_SUSV3=y
+FREETZ_BUSYBOX_FEATURE_TRACEROUTE_USE_ICMP=y
+FREETZ_BUSYBOX_FEATURE_TRACEROUTE_VERBOSE=y
+FREETZ_BUSYBOX_FEATURE_TR_CLASSES=y
+FREETZ_BUSYBOX_FEATURE_TR_EQUIV=y
+FREETZ_BUSYBOX_FEATURE_UMOUNT_ALL=y
+FREETZ_BUSYBOX_FEATURE_UNZIP_CDF=y
+FREETZ_BUSYBOX_FEATURE_USE_INITTAB=y
+FREETZ_BUSYBOX_FEATURE_USE_SENDFILE=y
+FREETZ_BUSYBOX_FEATURE_UTMP=y
+FREETZ_BUSYBOX_FEATURE_VERBOSE=y
+FREETZ_BUSYBOX_FEATURE_VERBOSE_USAGE=y
+FREETZ_BUSYBOX_FEATURE_VI_8BIT=y
+FREETZ_BUSYBOX_FEATURE_VI_ASK_TERMINAL=y
+FREETZ_BUSYBOX_FEATURE_VI_COLON=y
+FREETZ_BUSYBOX_FEATURE_VI_DOT_CMD=y
+FREETZ_BUSYBOX_FEATURE_VI_READONLY=y
+FREETZ_BUSYBOX_FEATURE_VI_SEARCH=y
+FREETZ_BUSYBOX_FEATURE_VI_SET=y
+FREETZ_BUSYBOX_FEATURE_VI_SETOPTS=y
+FREETZ_BUSYBOX_FEATURE_VI_USE_SIGNALS=y
+FREETZ_BUSYBOX_FEATURE_VI_WIN_RESIZE=y
+FREETZ_BUSYBOX_FEATURE_VI_YANKMARK=y
+FREETZ_BUSYBOX_FEATURE_VOLUMEID_EXFAT=y
+FREETZ_BUSYBOX_FEATURE_VOLUMEID_F2FS=y
+FREETZ_BUSYBOX_FEATURE_WAIT_FOR_INIT=y
+FREETZ_BUSYBOX_FEATURE_WC_LARGE=y
+FREETZ_BUSYBOX_FEATURE_XARGS_SUPPORT_ARGS_FILE=y
+FREETZ_BUSYBOX_FEATURE_XARGS_SUPPORT_CONFIRMATION=y
+FREETZ_BUSYBOX_FEATURE_XARGS_SUPPORT_QUOTES=y
+FREETZ_BUSYBOX_FEATURE_XARGS_SUPPORT_TERMOPT=y
+FREETZ_BUSYBOX_FEATURE_XARGS_SUPPORT_ZERO_TERM=y
+FREETZ_BUSYBOX_FGCONSOLE=y
+FREETZ_BUSYBOX_FGREP=y
+FREETZ_BUSYBOX_FIND=y
+FREETZ_BUSYBOX_FLOCK=y
+FREETZ_BUSYBOX_FREE=y
+FREETZ_BUSYBOX_FSTRIM=y
+FREETZ_BUSYBOX_FTPGET=y
+FREETZ_BUSYBOX_FTPPUT=y
+FREETZ_BUSYBOX_FUSER=y
+FREETZ_BUSYBOX_GETOPT=y
+FREETZ_BUSYBOX_GREP=y
+FREETZ_BUSYBOX_GROUPS=y
+FREETZ_BUSYBOX_GUNZIP=y
+FREETZ_BUSYBOX_GZIP=y
+FREETZ_BUSYBOX_HALT=y
+FREETZ_BUSYBOX_HAVE_DOT_CONFIG=y
+FREETZ_BUSYBOX_HEAD=y
+FREETZ_BUSYBOX_HEXDUMP=y
+FREETZ_BUSYBOX_HOSTNAME=y
+FREETZ_BUSYBOX_HTTPD=y
+FREETZ_BUSYBOX_I2CTRANSFER=y
+FREETZ_BUSYBOX_ID=y
+FREETZ_BUSYBOX_IFCONFIG=y
+FREETZ_BUSYBOX_IFDOWN=y
+FREETZ_BUSYBOX_IFUP=y
+FREETZ_BUSYBOX_INCLUDE_SUSv2=y
+FREETZ_BUSYBOX_INETD=y
+FREETZ_BUSYBOX_INIT=y
+FREETZ_BUSYBOX_INOTIFYD=y
+FREETZ_BUSYBOX_INSTALL_APPLET_SYMLINKS=y
+FREETZ_BUSYBOX_IOCTL_HEX2STR_ERROR=y
+FREETZ_BUSYBOX_IOSTAT=y
+FREETZ_BUSYBOX_IP=y
+FREETZ_BUSYBOX_IPADDR=y
+FREETZ_BUSYBOX_IPLINK=y
+FREETZ_BUSYBOX_IPNEIGH=y
+FREETZ_BUSYBOX_IPROUTE=y
+FREETZ_BUSYBOX_IPRULE=y
+FREETZ_BUSYBOX_IPTUNNEL=y
+FREETZ_BUSYBOX_KILL=y
+FREETZ_BUSYBOX_KILLALL=y
+FREETZ_BUSYBOX_KILLALL5=y
+FREETZ_BUSYBOX_KLOGD=y
+FREETZ_BUSYBOX_LFS=y
+FREETZ_BUSYBOX_LN=y
+FREETZ_BUSYBOX_LOGGER=y
+FREETZ_BUSYBOX_LOGIN=y
+FREETZ_BUSYBOX_LOGNAME=y
+FREETZ_BUSYBOX_LOGREAD=y
+FREETZ_BUSYBOX_LONG_OPTS=y
+FREETZ_BUSYBOX_LS=y
+FREETZ_BUSYBOX_LSOF=y
+FREETZ_BUSYBOX_MAKEDEVS=y
+FREETZ_BUSYBOX_MD5SUM=y
+FREETZ_BUSYBOX_MKDIR=y
+FREETZ_BUSYBOX_MKFIFO=y
+FREETZ_BUSYBOX_MKNOD=y
+FREETZ_BUSYBOX_MKPASSWD=y
+FREETZ_BUSYBOX_MKSWAP=y
+FREETZ_BUSYBOX_MKTEMP=y
+FREETZ_BUSYBOX_MONOTONIC_SYSCALL=y
+FREETZ_BUSYBOX_MORE=y
+FREETZ_BUSYBOX_MOUNT=y
+FREETZ_BUSYBOX_MPSTAT=y
+FREETZ_BUSYBOX_MV=y
+FREETZ_BUSYBOX_NBDCLIENT=y
+FREETZ_BUSYBOX_NC=y
+FREETZ_BUSYBOX_NC_110_COMPAT=y
+FREETZ_BUSYBOX_NC_EXTRA=y
+FREETZ_BUSYBOX_NETCAT=y
+FREETZ_BUSYBOX_NETSTAT=y
+FREETZ_BUSYBOX_NICE=y
+FREETZ_BUSYBOX_NO_DEBUG_LIB=y
+FREETZ_BUSYBOX_NOHUP=y
+FREETZ_BUSYBOX_NOLOGIN=y
+FREETZ_BUSYBOX_NSLOOKUP=y
+FREETZ_BUSYBOX_OD=y
+FREETZ_BUSYBOX_PASSWD=y
+FREETZ_BUSYBOX_PIDOF=y
+FREETZ_BUSYBOX_PING=y
+FREETZ_BUSYBOX_PING6=y
+FREETZ_BUSYBOX_PIVOT_ROOT=y
+FREETZ_BUSYBOX_PLATFORM_LINUX=y
+FREETZ_BUSYBOX_PMAP=y
+FREETZ_BUSYBOX_POWEROFF=y
+FREETZ_BUSYBOX_PRINTENV=y
+FREETZ_BUSYBOX_PRINTF=y
+FREETZ_BUSYBOX_PS=y
+FREETZ_BUSYBOX_PSTREE=y
+FREETZ_BUSYBOX_PWD=y
+FREETZ_BUSYBOX_PWDX=y
+FREETZ_BUSYBOX_READLINK=y
+FREETZ_BUSYBOX_REALPATH=y
+FREETZ_BUSYBOX_REBOOT=y
+FREETZ_BUSYBOX_RENICE=y
+FREETZ_BUSYBOX_RESET=y
+FREETZ_BUSYBOX_RM=y
+FREETZ_BUSYBOX_RMDIR=y
+FREETZ_BUSYBOX_ROUTE=y
+FREETZ_BUSYBOX_SED=y
+FREETZ_BUSYBOX_SEQ=y
+FREETZ_BUSYBOX_SETCONSOLE=y
+FREETZ_BUSYBOX_SETSERIAL=y
+FREETZ_BUSYBOX_SHA3SUM=y
+FREETZ_BUSYBOX_SHOW_USAGE=y
+FREETZ_BUSYBOX_SHUF=y
+FREETZ_BUSYBOX_SLEEP=y
+FREETZ_BUSYBOX_SMEMCAP=y
+FREETZ_BUSYBOX_SORT=y
+FREETZ_BUSYBOX_SPLIT=y
+FREETZ_BUSYBOX_STACK_OPTIMIZATION_386=y
+FREETZ_BUSYBOX_START_STOP_DAEMON=y
+FREETZ_BUSYBOX_STAT=y
+FREETZ_BUSYBOX_STTY=y
+FREETZ_BUSYBOX_STUN_IP=y
+FREETZ_BUSYBOX_SWAPOFF=y
+FREETZ_BUSYBOX_SWAPON=y
+FREETZ_BUSYBOX_SWITCH_ROOT=y
+FREETZ_BUSYBOX_SYNC=y
+FREETZ_BUSYBOX_SYSLOGD=y
+FREETZ_BUSYBOX_TAIL=y
+FREETZ_BUSYBOX_TAR=y
+FREETZ_BUSYBOX_TASKSET=y
+FREETZ_BUSYBOX_TCPSVD=y
+FREETZ_BUSYBOX_TEE=y
+FREETZ_BUSYBOX_TEST=y
+FREETZ_BUSYBOX_TEST1=y
+FREETZ_BUSYBOX_TEST2=y
+FREETZ_BUSYBOX_TFTP=y
+FREETZ_BUSYBOX_TFTPD=y
+FREETZ_BUSYBOX_TIME=y
+FREETZ_BUSYBOX_TIMEOUT=y
+FREETZ_BUSYBOX_TOP=y
+FREETZ_BUSYBOX_TOUCH=y
+FREETZ_BUSYBOX_TR=y
+FREETZ_BUSYBOX_TRACEROUTE=y
+FREETZ_BUSYBOX_TRACEROUTE6=y
+FREETZ_BUSYBOX_TRUE=y
+FREETZ_BUSYBOX_TS=y
+FREETZ_BUSYBOX_TTY=y
+FREETZ_BUSYBOX_UDPSVD=y
+FREETZ_BUSYBOX_UMOUNT=y
+FREETZ_BUSYBOX_UNAME=y
+FREETZ_BUSYBOX_UNICODE_SUPPORT=y
+FREETZ_BUSYBOX_UNIQ=y
+FREETZ_BUSYBOX_UNXZ=y
+FREETZ_BUSYBOX_UNZIP=y
+FREETZ_BUSYBOX_UPTIME=y
+FREETZ_BUSYBOX_USE_BB_CRYPT=y
+FREETZ_BUSYBOX_USE_BB_CRYPT_SHA=y
+FREETZ_BUSYBOX_USERS=y
+FREETZ_BUSYBOX_USLEEP=y
+FREETZ_BUSYBOX_UUDECODE=y
+FREETZ_BUSYBOX_VCONFIG=y
+FREETZ_BUSYBOX_VERBOSE_RESOLUTION_ERRORS=y
+FREETZ_BUSYBOX_VI=y
+FREETZ_BUSYBOX_WC=y
+FREETZ_BUSYBOX_WHICH=y
+FREETZ_BUSYBOX_WHO=y
+FREETZ_BUSYBOX_WHOAMI=y
+FREETZ_BUSYBOX_WHOIS=y
+FREETZ_BUSYBOX_XARGS=y
+FREETZ_BUSYBOX_XXD=y
+FREETZ_BUSYBOX_XZ=y
+FREETZ_BUSYBOX_XZCAT=y
+FREETZ_BUSYBOX_YES=y
+FREETZ_BUSYBOX_ZCAT=y
+FREETZ_BUSYBOX___V136_HAVE_DOT_CONFIG=y
+
+#
+# Settings
+#
+# FREETZ_BUSYBOX___V136_DESKTOP is not set
+# FREETZ_BUSYBOX___V136_EXTRA_COMPAT is not set
+FREETZ_BUSYBOX___V136_INCLUDE_SUSv2=y
+FREETZ_BUSYBOX___V136_LONG_OPTS=y
+FREETZ_BUSYBOX___V136_SHOW_USAGE=y
+FREETZ_BUSYBOX___V136_FEATURE_VERBOSE_USAGE=y
+FREETZ_BUSYBOX___V136_FEATURE_COMPRESS_USAGE=y
+FREETZ_BUSYBOX___V136_LFS=y
+# FREETZ_BUSYBOX___V136_PAM is not set
+FREETZ_BUSYBOX___V136_FEATURE_DEVPTS=y
+FREETZ_BUSYBOX___V136_FEATURE_UTMP=y
+# FREETZ_BUSYBOX___V136_FEATURE_WTMP is not set
+FREETZ_BUSYBOX___V136_FEATURE_PIDFILE=y
+FREETZ_BUSYBOX___V136_PID_FILE_PATH="/var/run"
+FREETZ_BUSYBOX___V136_BUSYBOX=y
+# FREETZ_BUSYBOX___V136_FEATURE_SHOW_SCRIPT is not set
+# FREETZ_BUSYBOX___V136_FEATURE_INSTALLER is not set
+# FREETZ_BUSYBOX___V136_INSTALL_NO_USR is not set
+FREETZ_BUSYBOX___V136_FEATURE_SUID=y
+# FREETZ_BUSYBOX___V136_FEATURE_SUID_CONFIG is not set
+FREETZ_BUSYBOX___V136_BUSYBOX_EXEC_PATH="/proc/self/exe"
+# FREETZ_BUSYBOX___V136_SELINUX is not set
+# FREETZ_BUSYBOX___V136_FEATURE_CLEAN_UP is not set
+# FREETZ_BUSYBOX___V136_FEATURE_SYSLOG_INFO is not set
+FREETZ_BUSYBOX___V136_FEATURE_SYSLOG=y
+
+#
+# Build Options
+#
+# FREETZ_BUSYBOX___V136_STATIC is not set
+# FREETZ_BUSYBOX___V136_PIE is not set
+FREETZ_BUSYBOX___V136_CROSS_COMPILER_PREFIX=""
+FREETZ_BUSYBOX___V136_SYSROOT=""
+FREETZ_BUSYBOX___V136_EXTRA_CFLAGS=""
+FREETZ_BUSYBOX___V136_EXTRA_LDFLAGS=""
+FREETZ_BUSYBOX___V136_EXTRA_LDLIBS=""
+# FREETZ_BUSYBOX___V136_USE_PORTABLE_CODE is not set
+FREETZ_BUSYBOX___V136_STACK_OPTIMIZATION_386=y
+# FREETZ_BUSYBOX___V136_STATIC_LIBGCC is not set
+
+#
+# Installation Options ("make install" behavior)
+#
+FREETZ_BUSYBOX___V136_INSTALL_APPLET_SYMLINKS=y
+# FREETZ_BUSYBOX___V136_INSTALL_APPLET_HARDLINKS is not set
+# FREETZ_BUSYBOX___V136_INSTALL_APPLET_SCRIPT_WRAPPERS is not set
+# FREETZ_BUSYBOX___V136_INSTALL_APPLET_DONT is not set
+FREETZ_BUSYBOX___V136_PREFIX="./_install"
+
+#
+# Debugging Options
+#
+# FREETZ_BUSYBOX___V136_DEBUG is not set
+# FREETZ_BUSYBOX___V136_DEBUG_SANITIZE is not set
+# FREETZ_BUSYBOX___V136_UNIT_TEST is not set
+# FREETZ_BUSYBOX___V136_WERROR is not set
+# FREETZ_BUSYBOX___V136_WARN_SIMPLE_MSG is not set
+FREETZ_BUSYBOX___V136_NO_DEBUG_LIB=y
+# FREETZ_BUSYBOX___V136_DMALLOC is not set
+# FREETZ_BUSYBOX___V136_EFENCE is not set
+
+#
+# Library Tuning
+#
+# FREETZ_BUSYBOX___V136_FLOAT_DURATION is not set
+FREETZ_BUSYBOX___V136_FEATURE_RTMINMAX=y
+# FREETZ_BUSYBOX___V136_FEATURE_RTMINMAX_USE_LIBC_DEFINITIONS is not set
+FREETZ_BUSYBOX___V136_FEATURE_BUFFERS_USE_MALLOC=y
+# FREETZ_BUSYBOX___V136_FEATURE_BUFFERS_GO_ON_STACK is not set
+# FREETZ_BUSYBOX___V136_FEATURE_BUFFERS_GO_IN_BSS is not set
+FREETZ_BUSYBOX___V136_PASSWORD_MINLEN=6
+FREETZ_BUSYBOX___V136_MD5_SMALL=1
+FREETZ_BUSYBOX___V136_SHA1_SMALL=3
+# FREETZ_BUSYBOX___V136_SHA1_HWACCEL is not set
+# FREETZ_BUSYBOX___V136_SHA256_HWACCEL is not set
+FREETZ_BUSYBOX___V136_SHA3_SMALL=1
+FREETZ_BUSYBOX___V136_FEATURE_NON_POSIX_CP=y
+# FREETZ_BUSYBOX___V136_FEATURE_VERBOSE_CP_MESSAGE is not set
+FREETZ_BUSYBOX___V136_FEATURE_USE_SENDFILE=y
+FREETZ_BUSYBOX___V136_FEATURE_COPYBUF_KB=4
+FREETZ_BUSYBOX___V136_MONOTONIC_SYSCALL=y
+FREETZ_BUSYBOX___V136_IOCTL_HEX2STR_ERROR=y
+FREETZ_BUSYBOX___V136_FEATURE_EDITING=y
+FREETZ_BUSYBOX___V136_FEATURE_EDITING_MAX_LEN=1024
+# FREETZ_BUSYBOX___V136_FEATURE_EDITING_VI is not set
+FREETZ_BUSYBOX___V136_FEATURE_EDITING_HISTORY=255
+# FREETZ_BUSYBOX___V136_FEATURE_EDITING_SAVEHISTORY is not set
+# FREETZ_BUSYBOX___V136_FEATURE_REVERSE_SEARCH is not set
+FREETZ_BUSYBOX___V136_FEATURE_TAB_COMPLETION=y
+# FREETZ_BUSYBOX___V136_FEATURE_USERNAME_COMPLETION is not set
+FREETZ_BUSYBOX___V136_FEATURE_EDITING_FANCY_PROMPT=y
+FREETZ_BUSYBOX___V136_FEATURE_EDITING_WINCH=y
+# FREETZ_BUSYBOX___V136_FEATURE_EDITING_ASK_TERMINAL is not set
+# FREETZ_BUSYBOX___V136_LOCALE_SUPPORT is not set
+FREETZ_BUSYBOX___V136_UNICODE_SUPPORT=y
+# FREETZ_BUSYBOX___V136_FEATURE_CHECK_UNICODE_IN_ENV is not set
+FREETZ_BUSYBOX___V136_SUBST_WCHAR=63
+FREETZ_BUSYBOX___V136_LAST_SUPPORTED_WCHAR=767
+# FREETZ_BUSYBOX___V136_UNICODE_COMBINING_WCHARS is not set
+# FREETZ_BUSYBOX___V136_UNICODE_WIDE_WCHARS is not set
+# FREETZ_BUSYBOX___V136_UNICODE_BIDI_SUPPORT is not set
+# FREETZ_BUSYBOX___V136_UNICODE_PRESERVE_BROKEN is not set
+# FREETZ_BUSYBOX___V136_LOOP_CONFIGURE is not set
+# FREETZ_BUSYBOX___V136_NO_LOOP_CONFIGURE is not set
+FREETZ_BUSYBOX___V136_TRY_LOOP_CONFIGURE=y
+# end of Settings
+
+#
+# Applets
+#
+
+#
+# Archival Utilities
+#
+FREETZ_BUSYBOX___V136_FEATURE_SEAMLESS_XZ=y
+FREETZ_BUSYBOX___V136_FEATURE_SEAMLESS_LZMA=y
+FREETZ_BUSYBOX___V136_FEATURE_SEAMLESS_BZ2=y
+FREETZ_BUSYBOX___V136_FEATURE_SEAMLESS_GZ=y
+# FREETZ_BUSYBOX___V136_FEATURE_SEAMLESS_LZ is not set
+FREETZ_BUSYBOX___V136_FEATURE_SEAMLESS_Z=y
+FREETZ_BUSYBOX___V136_AR=y
+# FREETZ_BUSYBOX___V136_FEATURE_AR_LONG_FILENAMES is not set
+# FREETZ_BUSYBOX___V136_FEATURE_AR_CREATE is not set
+# FREETZ_BUSYBOX___V136_UNCOMPRESS is not set
+FREETZ_BUSYBOX___V136_GUNZIP=y
+FREETZ_BUSYBOX___V136_ZCAT=y
+# FREETZ_BUSYBOX___V136_FEATURE_GUNZIP_LONG_OPTIONS is not set
+FREETZ_BUSYBOX___V136_BUNZIP2=y
+FREETZ_BUSYBOX___V136_BZCAT=y
+# FREETZ_BUSYBOX___V136_LUNZIP is not set
+# FREETZ_BUSYBOX___V136_UNLZMA is not set
+# FREETZ_BUSYBOX___V136_LZCAT is not set
+# FREETZ_BUSYBOX___V136_LZMA is not set
+FREETZ_BUSYBOX___V136_UNXZ=y
+FREETZ_BUSYBOX___V136_XZCAT=y
+FREETZ_BUSYBOX___V136_XZ=y
+FREETZ_BUSYBOX___V136_BZIP2=y
+FREETZ_BUSYBOX___V136_BZIP2_SMALL=8
+FREETZ_BUSYBOX___V136_FEATURE_BZIP2_DECOMPRESS=y
+FREETZ_BUSYBOX___V136_CPIO=y
+# FREETZ_BUSYBOX___V136_FEATURE_CPIO_O is not set
+# FREETZ_BUSYBOX___V136_DPKG is not set
+# FREETZ_BUSYBOX___V136_DPKG_DEB is not set
+FREETZ_BUSYBOX___V136_GZIP=y
+# FREETZ_BUSYBOX___V136_FEATURE_GZIP_LONG_OPTIONS is not set
+FREETZ_BUSYBOX___V136_GZIP_FAST=0
+# FREETZ_BUSYBOX___V136_FEATURE_GZIP_LEVELS is not set
+FREETZ_BUSYBOX___V136_FEATURE_GZIP_DECOMPRESS=y
+# FREETZ_BUSYBOX___V136_LZIP is not set
+# FREETZ_BUSYBOX___V136_LZOP is not set
+# FREETZ_BUSYBOX___V136_UNLZOP is not set
+# FREETZ_BUSYBOX___V136_LZOPCAT is not set
+# FREETZ_BUSYBOX___V136_RPM is not set
+# FREETZ_BUSYBOX___V136_RPM2CPIO is not set
+FREETZ_BUSYBOX___V136_TAR=y
+FREETZ_BUSYBOX___V136_FEATURE_TAR_LONG_OPTIONS=y
+FREETZ_BUSYBOX___V136_FEATURE_TAR_CREATE=y
+# FREETZ_BUSYBOX___V136_FEATURE_TAR_AUTODETECT is not set
+FREETZ_BUSYBOX___V136_FEATURE_TAR_FROM=y
+FREETZ_BUSYBOX___V136_FEATURE_TAR_OLDGNU_COMPATIBILITY=y
+FREETZ_BUSYBOX___V136_FEATURE_TAR_OLDSUN_COMPATIBILITY=y
+FREETZ_BUSYBOX___V136_FEATURE_TAR_GNU_EXTENSIONS=y
+FREETZ_BUSYBOX___V136_FEATURE_TAR_TO_COMMAND=y
+FREETZ_BUSYBOX___V136_FEATURE_TAR_UNAME_GNAME=y
+# FREETZ_BUSYBOX___V136_FEATURE_TAR_NOPRESERVE_TIME is not set
+FREETZ_BUSYBOX___V136_UNZIP=y
+FREETZ_BUSYBOX___V136_FEATURE_UNZIP_CDF=y
+# FREETZ_BUSYBOX___V136_FEATURE_UNZIP_J_NUM is not set
+# FREETZ_BUSYBOX___V136_FEATURE_LZMA_FAST is not set
+# end of Archival Utilities
+
+#
+# Coreutils
+#
+FREETZ_BUSYBOX___V136_FEATURE_VERBOSE=y
+
+#
+# Common options for date and touch
+#
+
+#
+# Common options for cp and mv
+#
+FREETZ_BUSYBOX___V136_FEATURE_PRESERVE_HARDLINKS=y
+
+#
+# Common options for df, du, ls
+#
+FREETZ_BUSYBOX___V136_FEATURE_HUMAN_READABLE=y
+FREETZ_BUSYBOX___V136_BASENAME=y
+FREETZ_BUSYBOX___V136_CAT=y
+# FREETZ_BUSYBOX___V136_FEATURE_CATN is not set
+# FREETZ_BUSYBOX___V136_FEATURE_CATV is not set
+FREETZ_BUSYBOX___V136_CHGRP=y
+FREETZ_BUSYBOX___V136_CHMOD=y
+FREETZ_BUSYBOX___V136_CHOWN=y
+# FREETZ_BUSYBOX___V136_FEATURE_CHOWN_LONG_OPTIONS is not set
+FREETZ_BUSYBOX___V136_CHROOT=y
+# FREETZ_BUSYBOX___V136_CKSUM is not set
+# FREETZ_BUSYBOX___V136_CRC32 is not set
+# FREETZ_BUSYBOX___V136_COMM is not set
+FREETZ_BUSYBOX___V136_CP=y
+# FREETZ_BUSYBOX___V136_FEATURE_CP_LONG_OPTIONS is not set
+FREETZ_BUSYBOX___V136_CUT=y
+# FREETZ_BUSYBOX___V136_FEATURE_CUT_REGEX is not set
+FREETZ_BUSYBOX___V136_DATE=y
+FREETZ_BUSYBOX___V136_FEATURE_DATE_ISOFMT=y
+# FREETZ_BUSYBOX___V136_FEATURE_DATE_NANO is not set
+FREETZ_BUSYBOX___V136_FEATURE_DATE_COMPAT=y
+FREETZ_BUSYBOX___V136_DD=y
+FREETZ_BUSYBOX___V136_FEATURE_DD_SIGNAL_HANDLING=y
+# FREETZ_BUSYBOX___V136_FEATURE_DD_THIRD_STATUS_LINE is not set
+FREETZ_BUSYBOX___V136_FEATURE_DD_IBS_OBS=y
+FREETZ_BUSYBOX___V136_FEATURE_DD_STATUS=y
+FREETZ_BUSYBOX___V136_DF=y
+FREETZ_BUSYBOX___V136_FEATURE_DF_FANCY=y
+FREETZ_BUSYBOX___V136_FEATURE_SKIP_ROOTFS=y
+FREETZ_BUSYBOX___V136_DIRNAME=y
+FREETZ_BUSYBOX___V136_DOS2UNIX=y
+# FREETZ_BUSYBOX___V136_UNIX2DOS is not set
+FREETZ_BUSYBOX___V136_DU=y
+FREETZ_BUSYBOX___V136_FEATURE_DU_DEFAULT_BLOCKSIZE_1K=y
+FREETZ_BUSYBOX___V136_ECHO=y
+FREETZ_BUSYBOX___V136_FEATURE_FANCY_ECHO=y
+FREETZ_BUSYBOX___V136_ENV=y
+# FREETZ_BUSYBOX___V136_EXPAND is not set
+# FREETZ_BUSYBOX___V136_UNEXPAND is not set
+FREETZ_BUSYBOX___V136_EXPR=y
+FREETZ_BUSYBOX___V136_EXPR_MATH_SUPPORT_64=y
+FREETZ_BUSYBOX___V136_FACTOR=y
+FREETZ_BUSYBOX___V136_FALSE=y
+# FREETZ_BUSYBOX___V136_FOLD is not set
+FREETZ_BUSYBOX___V136_HEAD=y
+FREETZ_BUSYBOX___V136_FEATURE_FANCY_HEAD=y
+# FREETZ_BUSYBOX___V136_HOSTID is not set
+FREETZ_BUSYBOX___V136_ID=y
+FREETZ_BUSYBOX___V136_GROUPS=y
+# FREETZ_BUSYBOX___V136_INSTALL is not set
+# FREETZ_BUSYBOX___V136_LINK is not set
+FREETZ_BUSYBOX___V136_LN=y
+FREETZ_BUSYBOX___V136_LOGNAME=y
+FREETZ_BUSYBOX___V136_LS=y
+FREETZ_BUSYBOX___V136_FEATURE_LS_FILETYPES=y
+FREETZ_BUSYBOX___V136_FEATURE_LS_FOLLOWLINKS=y
+FREETZ_BUSYBOX___V136_FEATURE_LS_RECURSIVE=y
+# FREETZ_BUSYBOX___V136_FEATURE_LS_WIDTH is not set
+FREETZ_BUSYBOX___V136_FEATURE_LS_SORTFILES=y
+FREETZ_BUSYBOX___V136_FEATURE_LS_TIMESTAMPS=y
+FREETZ_BUSYBOX___V136_FEATURE_LS_USERNAME=y
+FREETZ_BUSYBOX___V136_FEATURE_LS_COLOR=y
+# FREETZ_BUSYBOX___V136_FEATURE_LS_COLOR_IS_DEFAULT is not set
+FREETZ_BUSYBOX___V136_MD5SUM=y
+# FREETZ_BUSYBOX___V136_SHA1SUM is not set
+# FREETZ_BUSYBOX___V136_SHA256SUM is not set
+# FREETZ_BUSYBOX___V136_SHA512SUM is not set
+FREETZ_BUSYBOX___V136_SHA3SUM=y
+
+#
+# Common options for md5sum, sha1sum, sha256sum, sha512sum, sha3sum
+#
+FREETZ_BUSYBOX___V136_FEATURE_MD5_SHA1_SUM_CHECK=y
+FREETZ_BUSYBOX___V136_MKDIR=y
+FREETZ_BUSYBOX___V136_MKFIFO=y
+FREETZ_BUSYBOX___V136_MKNOD=y
+FREETZ_BUSYBOX___V136_MKTEMP=y
+FREETZ_BUSYBOX___V136_MV=y
+FREETZ_BUSYBOX___V136_NICE=y
+# FREETZ_BUSYBOX___V136_NL is not set
+FREETZ_BUSYBOX___V136_NOHUP=y
+# FREETZ_BUSYBOX___V136_NPROC is not set
+FREETZ_BUSYBOX___V136_OD=y
+# FREETZ_BUSYBOX___V136_PASTE is not set
+FREETZ_BUSYBOX___V136_PRINTENV=y
+FREETZ_BUSYBOX___V136_PRINTF=y
+FREETZ_BUSYBOX___V136_PWD=y
+FREETZ_BUSYBOX___V136_READLINK=y
+FREETZ_BUSYBOX___V136_FEATURE_READLINK_FOLLOW=y
+FREETZ_BUSYBOX___V136_REALPATH=y
+FREETZ_BUSYBOX___V136_RM=y
+FREETZ_BUSYBOX___V136_RMDIR=y
+FREETZ_BUSYBOX___V136_SEQ=y
+# FREETZ_BUSYBOX___V136_SHRED is not set
+FREETZ_BUSYBOX___V136_SHUF=y
+FREETZ_BUSYBOX___V136_SLEEP=y
+FREETZ_BUSYBOX___V136_FEATURE_FANCY_SLEEP=y
+FREETZ_BUSYBOX___V136_SORT=y
+FREETZ_BUSYBOX___V136_FEATURE_SORT_BIG=y
+# FREETZ_BUSYBOX___V136_FEATURE_SORT_OPTIMIZE_MEMORY is not set
+FREETZ_BUSYBOX___V136_SPLIT=y
+FREETZ_BUSYBOX___V136_FEATURE_SPLIT_FANCY=y
+FREETZ_BUSYBOX___V136_STAT=y
+FREETZ_BUSYBOX___V136_FEATURE_STAT_FORMAT=y
+FREETZ_BUSYBOX___V136_FEATURE_STAT_FILESYSTEM=y
+FREETZ_BUSYBOX___V136_STTY=y
+# FREETZ_BUSYBOX___V136_SUM is not set
+FREETZ_BUSYBOX___V136_SYNC=y
+# FREETZ_BUSYBOX___V136_FEATURE_SYNC_FANCY is not set
+# FREETZ_BUSYBOX___V136_FSYNC is not set
+# FREETZ_BUSYBOX___V136_TAC is not set
+FREETZ_BUSYBOX___V136_TAIL=y
+FREETZ_BUSYBOX___V136_FEATURE_FANCY_TAIL=y
+FREETZ_BUSYBOX___V136_TEE=y
+FREETZ_BUSYBOX___V136_FEATURE_TEE_USE_BLOCK_IO=y
+FREETZ_BUSYBOX___V136_TEST=y
+FREETZ_BUSYBOX___V136_TEST1=y
+FREETZ_BUSYBOX___V136_TEST2=y
+FREETZ_BUSYBOX___V136_FEATURE_TEST_64=y
+FREETZ_BUSYBOX___V136_TIMEOUT=y
+FREETZ_BUSYBOX___V136_TOUCH=y
+FREETZ_BUSYBOX___V136_FEATURE_TOUCH_SUSV3=y
+FREETZ_BUSYBOX___V136_TR=y
+FREETZ_BUSYBOX___V136_FEATURE_TR_CLASSES=y
+FREETZ_BUSYBOX___V136_FEATURE_TR_EQUIV=y
+FREETZ_BUSYBOX___V136_TRUE=y
+# FREETZ_BUSYBOX___V136_TRUNCATE is not set
+# FREETZ_BUSYBOX___V136_TSORT is not set
+FREETZ_BUSYBOX___V136_TTY=y
+FREETZ_BUSYBOX___V136_UNAME=y
+FREETZ_BUSYBOX___V136_UNAME_OSNAME="GNU/Linux"
+# FREETZ_BUSYBOX___V136_BB_ARCH is not set
+FREETZ_BUSYBOX___V136_UNIQ=y
+# FREETZ_BUSYBOX___V136_UNLINK is not set
+FREETZ_BUSYBOX___V136_USLEEP=y
+FREETZ_BUSYBOX___V136_UUDECODE=y
+# FREETZ_BUSYBOX___V136_BASE32 is not set
+FREETZ_BUSYBOX___V136_BASE64=y
+# FREETZ_BUSYBOX___V136_UUENCODE is not set
+FREETZ_BUSYBOX___V136_WC=y
+FREETZ_BUSYBOX___V136_FEATURE_WC_LARGE=y
+FREETZ_BUSYBOX___V136_WHO=y
+# FREETZ_BUSYBOX___V136_W is not set
+FREETZ_BUSYBOX___V136_USERS=y
+FREETZ_BUSYBOX___V136_WHOAMI=y
+FREETZ_BUSYBOX___V136_YES=y
+# end of Coreutils
+
+#
+# Console Utilities
+#
+# FREETZ_BUSYBOX___V136_CHVT is not set
+# FREETZ_BUSYBOX___V136_CLEAR is not set
+# FREETZ_BUSYBOX___V136_DEALLOCVT is not set
+# FREETZ_BUSYBOX___V136_DUMPKMAP is not set
+FREETZ_BUSYBOX___V136_FGCONSOLE=y
+# FREETZ_BUSYBOX___V136_KBD_MODE is not set
+# FREETZ_BUSYBOX___V136_LOADFONT is not set
+# FREETZ_BUSYBOX___V136_SETFONT is not set
+# FREETZ_BUSYBOX___V136_LOADKMAP is not set
+# FREETZ_BUSYBOX___V136_OPENVT is not set
+FREETZ_BUSYBOX___V136_RESET=y
+# FREETZ_BUSYBOX___V136_RESIZE is not set
+FREETZ_BUSYBOX___V136_SETCONSOLE=y
+FREETZ_BUSYBOX___V136_FEATURE_SETCONSOLE_LONG_OPTIONS=y
+# FREETZ_BUSYBOX___V136_SETKEYCODES is not set
+# FREETZ_BUSYBOX___V136_SETLOGCONS is not set
+# FREETZ_BUSYBOX___V136_SHOWKEY is not set
+# end of Console Utilities
+
+#
+# Debian Utilities
+#
+# FREETZ_BUSYBOX___V136_PIPE_PROGRESS is not set
+# FREETZ_BUSYBOX___V136_RUN_PARTS is not set
+FREETZ_BUSYBOX___V136_START_STOP_DAEMON=y
+# FREETZ_BUSYBOX___V136_FEATURE_START_STOP_DAEMON_LONG_OPTIONS is not set
+FREETZ_BUSYBOX___V136_FEATURE_START_STOP_DAEMON_FANCY=y
+FREETZ_BUSYBOX___V136_WHICH=y
+# end of Debian Utilities
+
+#
+# klibc-utils
+#
+# FREETZ_BUSYBOX___V136_MINIPS is not set
+# FREETZ_BUSYBOX___V136_NUKE is not set
+# FREETZ_BUSYBOX___V136_RESUME is not set
+# FREETZ_BUSYBOX___V136_RUN_INIT is not set
+# end of klibc-utils
+
+#
+# Editors
+#
+FREETZ_BUSYBOX___V136_AWK=y
+# FREETZ_BUSYBOX___V136_FEATURE_AWK_LIBM is not set
+# FREETZ_BUSYBOX___V136_FEATURE_AWK_GNU_EXTENSIONS is not set
+FREETZ_BUSYBOX___V136_CMP=y
+# FREETZ_BUSYBOX___V136_DIFF is not set
+# FREETZ_BUSYBOX___V136_ED is not set
+# FREETZ_BUSYBOX___V136_PATCH is not set
+FREETZ_BUSYBOX___V136_SED=y
+FREETZ_BUSYBOX___V136_VI=y
+FREETZ_BUSYBOX___V136_FEATURE_VI_MAX_LEN=4096
+FREETZ_BUSYBOX___V136_FEATURE_VI_8BIT=y
+FREETZ_BUSYBOX___V136_FEATURE_VI_COLON=y
+# FREETZ_BUSYBOX___V136_FEATURE_VI_COLON_EXPAND is not set
+FREETZ_BUSYBOX___V136_FEATURE_VI_YANKMARK=y
+FREETZ_BUSYBOX___V136_FEATURE_VI_SEARCH=y
+# FREETZ_BUSYBOX___V136_FEATURE_VI_REGEX_SEARCH is not set
+FREETZ_BUSYBOX___V136_FEATURE_VI_USE_SIGNALS=y
+FREETZ_BUSYBOX___V136_FEATURE_VI_DOT_CMD=y
+FREETZ_BUSYBOX___V136_FEATURE_VI_READONLY=y
+FREETZ_BUSYBOX___V136_FEATURE_VI_SETOPTS=y
+FREETZ_BUSYBOX___V136_FEATURE_VI_SET=y
+FREETZ_BUSYBOX___V136_FEATURE_VI_WIN_RESIZE=y
+FREETZ_BUSYBOX___V136_FEATURE_VI_ASK_TERMINAL=y
+# FREETZ_BUSYBOX___V136_FEATURE_VI_UNDO is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VI_VERBOSE_STATUS is not set
+FREETZ_BUSYBOX___V136_FEATURE_ALLOW_EXEC=y
+# end of Editors
+
+#
+# Finding Utilities
+#
+FREETZ_BUSYBOX___V136_FIND=y
+FREETZ_BUSYBOX___V136_FEATURE_FIND_PRINT0=y
+FREETZ_BUSYBOX___V136_FEATURE_FIND_MTIME=y
+# FREETZ_BUSYBOX___V136_FEATURE_FIND_ATIME is not set
+# FREETZ_BUSYBOX___V136_FEATURE_FIND_CTIME is not set
+FREETZ_BUSYBOX___V136_FEATURE_FIND_MMIN=y
+# FREETZ_BUSYBOX___V136_FEATURE_FIND_AMIN is not set
+# FREETZ_BUSYBOX___V136_FEATURE_FIND_CMIN is not set
+FREETZ_BUSYBOX___V136_FEATURE_FIND_PERM=y
+FREETZ_BUSYBOX___V136_FEATURE_FIND_TYPE=y
+# FREETZ_BUSYBOX___V136_FEATURE_FIND_EXECUTABLE is not set
+FREETZ_BUSYBOX___V136_FEATURE_FIND_XDEV=y
+FREETZ_BUSYBOX___V136_FEATURE_FIND_MAXDEPTH=y
+FREETZ_BUSYBOX___V136_FEATURE_FIND_NEWER=y
+FREETZ_BUSYBOX___V136_FEATURE_FIND_INUM=y
+# FREETZ_BUSYBOX___V136_FEATURE_FIND_SAMEFILE is not set
+FREETZ_BUSYBOX___V136_FEATURE_FIND_EXEC=y
+# FREETZ_BUSYBOX___V136_FEATURE_FIND_EXEC_PLUS is not set
+FREETZ_BUSYBOX___V136_FEATURE_FIND_USER=y
+FREETZ_BUSYBOX___V136_FEATURE_FIND_GROUP=y
+FREETZ_BUSYBOX___V136_FEATURE_FIND_NOT=y
+FREETZ_BUSYBOX___V136_FEATURE_FIND_DEPTH=y
+FREETZ_BUSYBOX___V136_FEATURE_FIND_PAREN=y
+FREETZ_BUSYBOX___V136_FEATURE_FIND_SIZE=y
+FREETZ_BUSYBOX___V136_FEATURE_FIND_PRUNE=y
+# FREETZ_BUSYBOX___V136_FEATURE_FIND_QUIT is not set
+# FREETZ_BUSYBOX___V136_FEATURE_FIND_DELETE is not set
+# FREETZ_BUSYBOX___V136_FEATURE_FIND_EMPTY is not set
+FREETZ_BUSYBOX___V136_FEATURE_FIND_PATH=y
+FREETZ_BUSYBOX___V136_FEATURE_FIND_REGEX=y
+# FREETZ_BUSYBOX___V136_FEATURE_FIND_LINKS is not set
+FREETZ_BUSYBOX___V136_GREP=y
+FREETZ_BUSYBOX___V136_EGREP=y
+FREETZ_BUSYBOX___V136_FGREP=y
+FREETZ_BUSYBOX___V136_FEATURE_GREP_CONTEXT=y
+FREETZ_BUSYBOX___V136_XARGS=y
+FREETZ_BUSYBOX___V136_FEATURE_XARGS_SUPPORT_CONFIRMATION=y
+FREETZ_BUSYBOX___V136_FEATURE_XARGS_SUPPORT_QUOTES=y
+FREETZ_BUSYBOX___V136_FEATURE_XARGS_SUPPORT_TERMOPT=y
+FREETZ_BUSYBOX___V136_FEATURE_XARGS_SUPPORT_ZERO_TERM=y
+# FREETZ_BUSYBOX___V136_FEATURE_XARGS_SUPPORT_REPL_STR is not set
+# FREETZ_BUSYBOX___V136_FEATURE_XARGS_SUPPORT_PARALLEL is not set
+FREETZ_BUSYBOX___V136_FEATURE_XARGS_SUPPORT_ARGS_FILE=y
+# end of Finding Utilities
+
+#
+# Init Utilities
+#
+# FREETZ_BUSYBOX___V136_BOOTCHARTD is not set
+FREETZ_BUSYBOX___V136_HALT=y
+FREETZ_BUSYBOX___V136_POWEROFF=y
+FREETZ_BUSYBOX___V136_REBOOT=y
+FREETZ_BUSYBOX___V136_FEATURE_WAIT_FOR_INIT=y
+FREETZ_BUSYBOX___V136_INIT=y
+# FREETZ_BUSYBOX___V136_LINUXRC is not set
+FREETZ_BUSYBOX___V136_FEATURE_USE_INITTAB=y
+FREETZ_BUSYBOX___V136_FEATURE_KILL_REMOVED=y
+FREETZ_BUSYBOX___V136_FEATURE_KILL_DELAY=0
+FREETZ_BUSYBOX___V136_FEATURE_INIT_SCTTY=y
+FREETZ_BUSYBOX___V136_FEATURE_INIT_SYSLOG=y
+FREETZ_BUSYBOX___V136_FEATURE_INIT_QUIET=y
+# FREETZ_BUSYBOX___V136_FEATURE_INIT_COREDUMPS is not set
+FREETZ_BUSYBOX___V136_INIT_TERMINAL_TYPE="linux"
+FREETZ_BUSYBOX___V136_FEATURE_INIT_MODIFY_CMDLINE=y
+# end of Init Utilities
+
+#
+# Login/Password Management Utilities
+#
+FREETZ_BUSYBOX___V136_FEATURE_SHADOWPASSWDS=y
+FREETZ_BUSYBOX___V136_USE_BB_CRYPT=y
+FREETZ_BUSYBOX___V136_USE_BB_CRYPT_SHA=y
+# FREETZ_BUSYBOX___V136_ADD_SHELL is not set
+# FREETZ_BUSYBOX___V136_REMOVE_SHELL is not set
+FREETZ_BUSYBOX___V136_ADDGROUP=y
+FREETZ_BUSYBOX___V136_FEATURE_ADDUSER_TO_GROUP=y
+FREETZ_BUSYBOX___V136_ADDUSER=y
+# FREETZ_BUSYBOX___V136_FEATURE_CHECK_NAMES is not set
+FREETZ_BUSYBOX___V136_LAST_ID=60000
+FREETZ_BUSYBOX___V136_FIRST_SYSTEM_ID=100
+FREETZ_BUSYBOX___V136_LAST_SYSTEM_ID=899
+# FREETZ_BUSYBOX___V136_CHPASSWD is not set
+FREETZ_BUSYBOX___V136_FEATURE_DEFAULT_PASSWD_ALGO="sha512"
+FREETZ_BUSYBOX___V136_CRYPTPW=y
+FREETZ_BUSYBOX___V136_MKPASSWD=y
+FREETZ_BUSYBOX___V136_DELUSER=y
+FREETZ_BUSYBOX___V136_DELGROUP=y
+FREETZ_BUSYBOX___V136_FEATURE_DEL_USER_FROM_GROUP=y
+# FREETZ_BUSYBOX___V136_GETTY is not set
+FREETZ_BUSYBOX___V136_LOGIN=y
+# FREETZ_BUSYBOX___V136_LOGIN_SESSION_AS_CHILD is not set
+# FREETZ_BUSYBOX___V136_LOGIN_SCRIPTS is not set
+FREETZ_BUSYBOX___V136_FEATURE_NOLOGIN=y
+FREETZ_BUSYBOX___V136_FEATURE_SECURETTY=y
+FREETZ_BUSYBOX___V136_PASSWD=y
+FREETZ_BUSYBOX___V136_FEATURE_PASSWD_WEAK_CHECK=y
+# FREETZ_BUSYBOX___V136_SU is not set
+# FREETZ_BUSYBOX___V136_SULOGIN is not set
+# FREETZ_BUSYBOX___V136_VLOCK is not set
+# end of Login/Password Management Utilities
+
+#
+# Linux Ext2 FS Progs
+#
+# FREETZ_BUSYBOX___V136_CHATTR is not set
+# FREETZ_BUSYBOX___V136_FSCK is not set
+# FREETZ_BUSYBOX___V136_LSATTR is not set
+# FREETZ_BUSYBOX___V136_TUNE2FS is not set
+# end of Linux Ext2 FS Progs
+
+#
+# Linux Module Utilities
+#
+# FREETZ_BUSYBOX___V136_DEPMOD is not set
+# FREETZ_BUSYBOX___V136_MODINFO is not set
+
+#
+# Options common to multiple modutils
+#
+# end of Linux Module Utilities
+
+#
+# Linux System Utilities
+#
+# FREETZ_BUSYBOX___V136_ACPID is not set
+# FREETZ_BUSYBOX___V136_BLKDISCARD is not set
+# FREETZ_BUSYBOX___V136_BLOCKDEV is not set
+# FREETZ_BUSYBOX___V136_CAL is not set
+FREETZ_BUSYBOX___V136_CHRT=y
+# FREETZ_BUSYBOX___V136_EJECT is not set
+# FREETZ_BUSYBOX___V136_FATATTR is not set
+# FREETZ_BUSYBOX___V136_FBSET is not set
+# FREETZ_BUSYBOX___V136_FDFORMAT is not set
+# FREETZ_BUSYBOX___V136_FDISK is not set
+# FREETZ_BUSYBOX___V136_FINDFS is not set
+FREETZ_BUSYBOX___V136_FLOCK=y
+# FREETZ_BUSYBOX___V136_FDFLUSH is not set
+# FREETZ_BUSYBOX___V136_FREERAMDISK is not set
+# FREETZ_BUSYBOX___V136_FSCK_MINIX is not set
+# FREETZ_BUSYBOX___V136_FSFREEZE is not set
+FREETZ_BUSYBOX___V136_FSTRIM=y
+FREETZ_BUSYBOX___V136_GETOPT=y
+FREETZ_BUSYBOX___V136_FEATURE_GETOPT_LONG=y
+FREETZ_BUSYBOX___V136_HEXDUMP=y
+# FREETZ_BUSYBOX___V136_HD is not set
+FREETZ_BUSYBOX___V136_XXD=y
+# FREETZ_BUSYBOX___V136_HWCLOCK is not set
+# FREETZ_BUSYBOX___V136_IONICE is not set
+# FREETZ_BUSYBOX___V136_IPCRM is not set
+# FREETZ_BUSYBOX___V136_IPCS is not set
+# FREETZ_BUSYBOX___V136_LOSETUP is not set
+# FREETZ_BUSYBOX___V136_LSPCI is not set
+# FREETZ_BUSYBOX___V136_LSUSB is not set
+# FREETZ_BUSYBOX___V136_MDEV is not set
+# FREETZ_BUSYBOX___V136_MESG is not set
+# FREETZ_BUSYBOX___V136_MKE2FS is not set
+# FREETZ_BUSYBOX___V136_MKFS_EXT2 is not set
+# FREETZ_BUSYBOX___V136_MKFS_MINIX is not set
+# FREETZ_BUSYBOX___V136_MKFS_REISER is not set
+# FREETZ_BUSYBOX___V136_MKDOSFS is not set
+# FREETZ_BUSYBOX___V136_MKFS_VFAT is not set
+FREETZ_BUSYBOX___V136_MKSWAP=y
+# FREETZ_BUSYBOX___V136_FEATURE_MKSWAP_UUID is not set
+FREETZ_BUSYBOX___V136_MORE=y
+FREETZ_BUSYBOX___V136_MOUNT=y
+FREETZ_BUSYBOX___V136_FEATURE_MOUNT_FAKE=y
+FREETZ_BUSYBOX___V136_FEATURE_MOUNT_VERBOSE=y
+FREETZ_BUSYBOX___V136_FEATURE_MOUNT_HELPERS=y
+FREETZ_BUSYBOX___V136_FEATURE_MOUNT_LABEL=y
+FREETZ_BUSYBOX___V136_FEATURE_MOUNT_CIFS=y
+FREETZ_BUSYBOX___V136_FEATURE_MOUNT_FLAGS=y
+FREETZ_BUSYBOX___V136_FEATURE_MOUNT_FSTAB=y
+FREETZ_BUSYBOX___V136_FEATURE_MOUNT_OTHERTAB=y
+# FREETZ_BUSYBOX___V136_MOUNTPOINT is not set
+FREETZ_BUSYBOX___V136_NOLOGIN=y
+# FREETZ_BUSYBOX___V136_NOLOGIN_DEPENDENCIES is not set
+# FREETZ_BUSYBOX___V136_NSENTER is not set
+FREETZ_BUSYBOX___V136_PIVOT_ROOT=y
+# FREETZ_BUSYBOX___V136_RDATE is not set
+# FREETZ_BUSYBOX___V136_RDEV is not set
+# FREETZ_BUSYBOX___V136_READPROFILE is not set
+FREETZ_BUSYBOX___V136_RENICE=y
+# FREETZ_BUSYBOX___V136_REV is not set
+# FREETZ_BUSYBOX___V136_RTCWAKE is not set
+# FREETZ_BUSYBOX___V136_SCRIPT is not set
+# FREETZ_BUSYBOX___V136_SCRIPTREPLAY is not set
+# FREETZ_BUSYBOX___V136_SETARCH is not set
+# FREETZ_BUSYBOX___V136_LINUX32 is not set
+# FREETZ_BUSYBOX___V136_LINUX64 is not set
+# FREETZ_BUSYBOX___V136_SETPRIV is not set
+# FREETZ_BUSYBOX___V136_SETSID is not set
+FREETZ_BUSYBOX___V136_SWAPON=y
+# FREETZ_BUSYBOX___V136_FEATURE_SWAPON_DISCARD is not set
+FREETZ_BUSYBOX___V136_FEATURE_SWAPON_PRI=y
+FREETZ_BUSYBOX___V136_SWAPOFF=y
+FREETZ_BUSYBOX___V136_FEATURE_SWAPONOFF_LABEL=y
+FREETZ_BUSYBOX___V136_SWITCH_ROOT=y
+FREETZ_BUSYBOX___V136_TASKSET=y
+FREETZ_BUSYBOX___V136_FEATURE_TASKSET_FANCY=y
+# FREETZ_BUSYBOX___V136_FEATURE_TASKSET_CPULIST is not set
+# FREETZ_BUSYBOX___V136_UEVENT is not set
+FREETZ_BUSYBOX___V136_UMOUNT=y
+FREETZ_BUSYBOX___V136_FEATURE_UMOUNT_ALL=y
+# FREETZ_BUSYBOX___V136_UNSHARE is not set
+# FREETZ_BUSYBOX___V136_WALL is not set
+
+#
+# Common options for mount/umount
+#
+FREETZ_BUSYBOX___V136_FEATURE_MOUNT_LOOP=y
+FREETZ_BUSYBOX___V136_FEATURE_MOUNT_LOOP_CREATE=y
+FREETZ_BUSYBOX___V136_FEATURE_MTAB_SUPPORT=y
+FREETZ_BUSYBOX___V136_VOLUMEID=y
+
+#
+# Filesystem/Volume identification
+#
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_BCACHE is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_BTRFS is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_CRAMFS is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_EROFS is not set
+FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_EXFAT=y
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_EXT is not set
+FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_F2FS=y
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_FAT is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_HFS is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_ISO9660 is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_JFS is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_LINUXRAID is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_LINUXSWAP is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_LUKS is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_MINIX is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_NILFS is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_NTFS is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_OCFS2 is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_REISERFS is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_ROMFS is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_SYSV is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_UBIFS is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_UDF is not set
+# FREETZ_BUSYBOX___V136_FEATURE_VOLUMEID_XFS is not set
+# end of Filesystem/Volume identification
+# end of Linux System Utilities
+
+#
+# Miscellaneous Utilities
+#
+# FREETZ_BUSYBOX___V136_ADJTIMEX is not set
+# FREETZ_BUSYBOX___V136_ASCII is not set
+FREETZ_BUSYBOX___V136_BBCONFIG=y
+FREETZ_BUSYBOX___V136_FEATURE_COMPRESS_BBCONFIG=y
+FREETZ_BUSYBOX___V136_BC=y
+# FREETZ_BUSYBOX___V136_DC is not set
+FREETZ_BUSYBOX___V136_FEATURE_DC_BIG=y
+# FREETZ_BUSYBOX___V136_FEATURE_BC_INTERACTIVE is not set
+# FREETZ_BUSYBOX___V136_FEATURE_BC_LONG_OPTIONS is not set
+FREETZ_BUSYBOX___V136_BEEP=y
+FREETZ_BUSYBOX___V136_FEATURE_BEEP_FREQ=4000
+FREETZ_BUSYBOX___V136_FEATURE_BEEP_LENGTH_MS=30
+# FREETZ_BUSYBOX___V136_CHAT is not set
+# FREETZ_BUSYBOX___V136_CONSPY is not set
+FREETZ_BUSYBOX___V136_CROND=y
+# FREETZ_BUSYBOX___V136_FEATURE_CROND_D is not set
+# FREETZ_BUSYBOX___V136_FEATURE_CROND_CALL_SENDMAIL is not set
+# FREETZ_BUSYBOX___V136_FEATURE_CROND_ROOT_NOLOG is not set
+# FREETZ_BUSYBOX___V136_FEATURE_CROND_SPECIAL_TIMES is not set
+FREETZ_BUSYBOX___V136_FEATURE_CROND_DIR="/mod/var/spool/cron"
+FREETZ_BUSYBOX___V136_CRONTAB=y
+# FREETZ_BUSYBOX___V136_DEVFSD is not set
+# FREETZ_BUSYBOX___V136_FEATURE_DEVFS is not set
+FREETZ_BUSYBOX___V136_DEVMEM=y
+# FREETZ_BUSYBOX___V136_FBSPLASH is not set
+# FREETZ_BUSYBOX___V136_FLASH_ERASEALL is not set
+# FREETZ_BUSYBOX___V136_FLASH_LOCK is not set
+# FREETZ_BUSYBOX___V136_FLASH_UNLOCK is not set
+# FREETZ_BUSYBOX___V136_FLASHCP is not set
+# FREETZ_BUSYBOX___V136_HDPARM is not set
+# FREETZ_BUSYBOX___V136_HEXEDIT is not set
+# FREETZ_BUSYBOX___V136_I2CGET is not set
+# FREETZ_BUSYBOX___V136_I2CSET is not set
+# FREETZ_BUSYBOX___V136_I2CDUMP is not set
+# FREETZ_BUSYBOX___V136_I2CDETECT is not set
+FREETZ_BUSYBOX___V136_I2CTRANSFER=y
+FREETZ_BUSYBOX___V136_INOTIFYD=y
+# FREETZ_BUSYBOX___V136_LESS is not set
+# FREETZ_BUSYBOX___V136_LSSCSI is not set
+FREETZ_BUSYBOX___V136_MAKEDEVS=y
+# FREETZ_BUSYBOX___V136_FEATURE_MAKEDEVS_LEAF is not set
+FREETZ_BUSYBOX___V136_FEATURE_MAKEDEVS_TABLE=y
+# FREETZ_BUSYBOX___V136_MAN is not set
+# FREETZ_BUSYBOX___V136_MICROCOM is not set
+# FREETZ_BUSYBOX___V136_MIM is not set
+# FREETZ_BUSYBOX___V136_MT is not set
+# FREETZ_BUSYBOX___V136_NANDWRITE is not set
+# FREETZ_BUSYBOX___V136_PARTPROBE is not set
+# FREETZ_BUSYBOX___V136_RAIDAUTORUN is not set
+# FREETZ_BUSYBOX___V136_READAHEAD is not set
+# FREETZ_BUSYBOX___V136_RFKILL is not set
+# FREETZ_BUSYBOX___V136_RUNLEVEL is not set
+# FREETZ_BUSYBOX___V136_RX is not set
+# FREETZ_BUSYBOX___V136_SEEDRNG is not set
+# FREETZ_BUSYBOX___V136_SETFATTR is not set
+FREETZ_BUSYBOX___V136_SETSERIAL=y
+# FREETZ_BUSYBOX___V136_STRINGS is not set
+FREETZ_BUSYBOX___V136_TIME=y
+# FREETZ_BUSYBOX___V136_TREE is not set
+FREETZ_BUSYBOX___V136_TS=y
+# FREETZ_BUSYBOX___V136_TTYSIZE is not set
+# FREETZ_BUSYBOX___V136_VOLNAME is not set
+# FREETZ_BUSYBOX___V136_WATCHDOG is not set
+# end of Miscellaneous Utilities
+
+#
+# Networking Utilities
+#
+FREETZ_BUSYBOX___V136_FEATURE_IPV6=y
+# FREETZ_BUSYBOX___V136_FEATURE_UNIX_LOCAL is not set
+FREETZ_BUSYBOX___V136_FEATURE_PREFER_IPV4_ADDRESS=y
+FREETZ_BUSYBOX___V136_VERBOSE_RESOLUTION_ERRORS=y
+# FREETZ_BUSYBOX___V136_FEATURE_ETC_NETWORKS is not set
+# FREETZ_BUSYBOX___V136_FEATURE_ETC_SERVICES is not set
+FREETZ_BUSYBOX___V136_FEATURE_HWIB=y
+FREETZ_BUSYBOX___V136_ARP=y
+FREETZ_BUSYBOX___V136_ARPING=y
+FREETZ_BUSYBOX___V136_BRCTL=y
+FREETZ_BUSYBOX___V136_FEATURE_BRCTL_FANCY=y
+FREETZ_BUSYBOX___V136_FEATURE_BRCTL_SHOW=y
+# FREETZ_BUSYBOX___V136_DNSD is not set
+FREETZ_BUSYBOX___V136_ETHER_WAKE=y
+# FREETZ_BUSYBOX___V136_FTPD is not set
+FREETZ_BUSYBOX___V136_FTPGET=y
+FREETZ_BUSYBOX___V136_FTPPUT=y
+FREETZ_BUSYBOX___V136_FEATURE_FTPGETPUT_LONG_OPTIONS=y
+FREETZ_BUSYBOX___V136_HOSTNAME=y
+FREETZ_BUSYBOX___V136_DNSDOMAINNAME=y
+FREETZ_BUSYBOX___V136_HTTPD=y
+FREETZ_BUSYBOX___V136_FEATURE_HTTPD_PORT_DEFAULT=80
+# FREETZ_BUSYBOX___V136_FEATURE_HTTPD_RANGES is not set
+# FREETZ_BUSYBOX___V136_FEATURE_HTTPD_SETUID is not set
+FREETZ_BUSYBOX___V136_FEATURE_HTTPD_BASIC_AUTH=y
+FREETZ_BUSYBOX___V136_FEATURE_HTTPD_AUTH_MD5=y
+FREETZ_BUSYBOX___V136_FEATURE_HTTPD_CGI=y
+FREETZ_BUSYBOX___V136_FEATURE_HTTPD_CONFIG_WITH_SCRIPT_INTERPR=y
+# FREETZ_BUSYBOX___V136_FEATURE_HTTPD_SET_REMOTE_PORT_TO_ENV is not set
+FREETZ_BUSYBOX___V136_FEATURE_HTTPD_ENCODE_URL_STR=y
+# FREETZ_BUSYBOX___V136_FEATURE_HTTPD_ERROR_PAGES is not set
+# FREETZ_BUSYBOX___V136_FEATURE_HTTPD_PROXY is not set
+# FREETZ_BUSYBOX___V136_FEATURE_HTTPD_GZIP is not set
+# FREETZ_BUSYBOX___V136_FEATURE_HTTPD_ETAG is not set
+# FREETZ_BUSYBOX___V136_FEATURE_HTTPD_LAST_MODIFIED is not set
+# FREETZ_BUSYBOX___V136_FEATURE_HTTPD_DATE is not set
+# FREETZ_BUSYBOX___V136_FEATURE_HTTPD_ACL_IP is not set
+FREETZ_BUSYBOX___V136_IFCONFIG=y
+FREETZ_BUSYBOX___V136_FEATURE_IFCONFIG_STATUS=y
+FREETZ_BUSYBOX___V136_FEATURE_IFCONFIG_SLIP=y
+FREETZ_BUSYBOX___V136_FEATURE_IFCONFIG_MEMSTART_IOADDR_IRQ=y
+FREETZ_BUSYBOX___V136_FEATURE_IFCONFIG_HW=y
+FREETZ_BUSYBOX___V136_FEATURE_IFCONFIG_BROADCAST_PLUS=y
+# FREETZ_BUSYBOX___V136_IFENSLAVE is not set
+# FREETZ_BUSYBOX___V136_IFPLUGD is not set
+FREETZ_BUSYBOX___V136_IFUP=y
+FREETZ_BUSYBOX___V136_IFDOWN=y
+FREETZ_BUSYBOX___V136_IFUPDOWN_IFSTATE_PATH="/var/run/ifstate"
+FREETZ_BUSYBOX___V136_FEATURE_IFUPDOWN_IP=y
+FREETZ_BUSYBOX___V136_FEATURE_IFUPDOWN_IPV4=y
+FREETZ_BUSYBOX___V136_FEATURE_IFUPDOWN_IPV6=y
+FREETZ_BUSYBOX___V136_FEATURE_IFUPDOWN_MAPPING=y
+# FREETZ_BUSYBOX___V136_FEATURE_IFUPDOWN_EXTERNAL_DHCP is not set
+FREETZ_BUSYBOX___V136_INETD=y
+FREETZ_BUSYBOX___V136_FEATURE_INETD_SUPPORT_BUILTIN_ECHO=y
+FREETZ_BUSYBOX___V136_FEATURE_INETD_SUPPORT_BUILTIN_DISCARD=y
+FREETZ_BUSYBOX___V136_FEATURE_INETD_SUPPORT_BUILTIN_TIME=y
+FREETZ_BUSYBOX___V136_FEATURE_INETD_SUPPORT_BUILTIN_DAYTIME=y
+FREETZ_BUSYBOX___V136_FEATURE_INETD_SUPPORT_BUILTIN_CHARGEN=y
+FREETZ_BUSYBOX___V136_IP=y
+FREETZ_BUSYBOX___V136_IPADDR=y
+FREETZ_BUSYBOX___V136_IPLINK=y
+FREETZ_BUSYBOX___V136_IPROUTE=y
+FREETZ_BUSYBOX___V136_IPTUNNEL=y
+FREETZ_BUSYBOX___V136_IPRULE=y
+FREETZ_BUSYBOX___V136_IPNEIGH=y
+FREETZ_BUSYBOX___V136_FEATURE_IP_ADDRESS=y
+FREETZ_BUSYBOX___V136_FEATURE_IP_LINK=y
+FREETZ_BUSYBOX___V136_FEATURE_IP_ROUTE=y
+FREETZ_BUSYBOX___V136_FEATURE_IP_ROUTE_DIR="/etc/iproute2"
+FREETZ_BUSYBOX___V136_FEATURE_IP_TUNNEL=y
+FREETZ_BUSYBOX___V136_FEATURE_IP_RULE=y
+FREETZ_BUSYBOX___V136_FEATURE_IP_NEIGH=y
+# FREETZ_BUSYBOX___V136_FEATURE_IP_RARE_PROTOCOLS is not set
+# FREETZ_BUSYBOX___V136_IPCALC is not set
+# FREETZ_BUSYBOX___V136_FAKEIDENTD is not set
+# FREETZ_BUSYBOX___V136_NAMEIF is not set
+FREETZ_BUSYBOX___V136_NBDCLIENT=y
+FREETZ_BUSYBOX___V136_NC=y
+FREETZ_BUSYBOX___V136_NETCAT=y
+# FREETZ_BUSYBOX___V136_NC_SERVER is not set
+FREETZ_BUSYBOX___V136_NC_EXTRA=y
+FREETZ_BUSYBOX___V136_NC_110_COMPAT=y
+FREETZ_BUSYBOX___V136_NETSTAT=y
+FREETZ_BUSYBOX___V136_FEATURE_NETSTAT_WIDE=y
+FREETZ_BUSYBOX___V136_FEATURE_NETSTAT_PRG=y
+FREETZ_BUSYBOX___V136_NSLOOKUP=y
+# FREETZ_BUSYBOX___V136_FEATURE_NSLOOKUP_BIG is not set
+# FREETZ_BUSYBOX___V136_NTPD is not set
+FREETZ_BUSYBOX___V136_PING=y
+FREETZ_BUSYBOX___V136_PING6=y
+FREETZ_BUSYBOX___V136_FEATURE_FANCY_PING=y
+# FREETZ_BUSYBOX___V136_PSCAN is not set
+FREETZ_BUSYBOX___V136_ROUTE=y
+# FREETZ_BUSYBOX___V136_SENDARP is not set
+# FREETZ_BUSYBOX___V136_SLATTACH is not set
+# FREETZ_BUSYBOX___V136_SSL_CLIENT is not set
+FREETZ_BUSYBOX___V136_STUN_IP=y
+# FREETZ_BUSYBOX___V136_TC is not set
+FREETZ_BUSYBOX___V136_TCPSVD=y
+FREETZ_BUSYBOX___V136_UDPSVD=y
+# FREETZ_BUSYBOX___V136_TELNET is not set
+FREETZ_BUSYBOX___V136_TFTP=y
+# FREETZ_BUSYBOX___V136_FEATURE_TFTP_PROGRESS_BAR is not set
+# FREETZ_BUSYBOX___V136_FEATURE_TFTP_HPA_COMPAT is not set
+FREETZ_BUSYBOX___V136_TFTPD=y
+FREETZ_BUSYBOX___V136_FEATURE_TFTP_GET=y
+FREETZ_BUSYBOX___V136_FEATURE_TFTP_PUT=y
+# FREETZ_BUSYBOX___V136_FEATURE_TFTP_BLOCKSIZE is not set
+# FREETZ_BUSYBOX___V136_TFTP_DEBUG is not set
+FREETZ_BUSYBOX___V136_TRACEROUTE=y
+FREETZ_BUSYBOX___V136_TRACEROUTE6=y
+FREETZ_BUSYBOX___V136_FEATURE_TRACEROUTE_VERBOSE=y
+FREETZ_BUSYBOX___V136_FEATURE_TRACEROUTE_USE_ICMP=y
+# FREETZ_BUSYBOX___V136_TUNCTL is not set
+FREETZ_BUSYBOX___V136_VCONFIG=y
+FREETZ_BUSYBOX___V136_WHOIS=y
+# FREETZ_BUSYBOX___V136_ZCIP is not set
+# FREETZ_BUSYBOX___V136_UDHCPD is not set
+# FREETZ_BUSYBOX___V136_DUMPLEASES is not set
+# FREETZ_BUSYBOX___V136_DHCPRELAY is not set
+# FREETZ_BUSYBOX___V136_UDHCPC is not set
+# FREETZ_BUSYBOX___V136_UDHCPC6 is not set
+FREETZ_BUSYBOX___V136_IFUPDOWN_UDHCPC_CMD_OPTIONS="-R -n"
+# end of Networking Utilities
+
+#
+# Print Utilities
+#
+# FREETZ_BUSYBOX___V136_LPD is not set
+# FREETZ_BUSYBOX___V136_LPR is not set
+# FREETZ_BUSYBOX___V136_LPQ is not set
+# end of Print Utilities
+
+#
+# Mail Utilities
+#
+# FREETZ_BUSYBOX___V136_MAKEMIME is not set
+# FREETZ_BUSYBOX___V136_POPMAILDIR is not set
+# FREETZ_BUSYBOX___V136_REFORMIME is not set
+# FREETZ_BUSYBOX___V136_SENDMAIL is not set
+# end of Mail Utilities
+
+#
+# Process Utilities
+#
+FREETZ_BUSYBOX___V136_FEATURE_FAST_TOP=y
+FREETZ_BUSYBOX___V136_FEATURE_SHOW_THREADS=y
+FREETZ_BUSYBOX___V136_FREE=y
+FREETZ_BUSYBOX___V136_FUSER=y
+FREETZ_BUSYBOX___V136_IOSTAT=y
+FREETZ_BUSYBOX___V136_KILL=y
+FREETZ_BUSYBOX___V136_KILLALL=y
+FREETZ_BUSYBOX___V136_KILLALL5=y
+FREETZ_BUSYBOX___V136_LSOF=y
+FREETZ_BUSYBOX___V136_MPSTAT=y
+# FREETZ_BUSYBOX___V136_NMETER is not set
+# FREETZ_BUSYBOX___V136_PGREP is not set
+# FREETZ_BUSYBOX___V136_PKILL is not set
+FREETZ_BUSYBOX___V136_PIDOF=y
+FREETZ_BUSYBOX___V136_FEATURE_PIDOF_SINGLE=y
+FREETZ_BUSYBOX___V136_FEATURE_PIDOF_OMIT=y
+FREETZ_BUSYBOX___V136_PMAP=y
+# FREETZ_BUSYBOX___V136_POWERTOP is not set
+FREETZ_BUSYBOX___V136_PS=y
+FREETZ_BUSYBOX___V136_FEATURE_PS_WIDE=y
+FREETZ_BUSYBOX___V136_FEATURE_PS_LONG=y
+FREETZ_BUSYBOX___V136_PSTREE=y
+FREETZ_BUSYBOX___V136_PWDX=y
+FREETZ_BUSYBOX___V136_SMEMCAP=y
+FREETZ_BUSYBOX___V136_BB_SYSCTL=y
+FREETZ_BUSYBOX___V136_TOP=y
+FREETZ_BUSYBOX___V136_FEATURE_TOP_INTERACTIVE=y
+FREETZ_BUSYBOX___V136_FEATURE_TOP_CPU_USAGE_PERCENTAGE=y
+FREETZ_BUSYBOX___V136_FEATURE_TOP_CPU_GLOBAL_PERCENTS=y
+FREETZ_BUSYBOX___V136_FEATURE_TOP_SMP_CPU=y
+FREETZ_BUSYBOX___V136_FEATURE_TOP_DECIMALS=y
+FREETZ_BUSYBOX___V136_FEATURE_TOP_SMP_PROCESS=y
+FREETZ_BUSYBOX___V136_FEATURE_TOPMEM=y
+FREETZ_BUSYBOX___V136_UPTIME=y
+# FREETZ_BUSYBOX___V136_FEATURE_UPTIME_UTMP_SUPPORT is not set
+# FREETZ_BUSYBOX___V136_WATCH is not set
+# end of Process Utilities
+
+#
+# Runit Utilities
+#
+# FREETZ_BUSYBOX___V136_CHPST is not set
+# FREETZ_BUSYBOX___V136_SETUIDGID is not set
+# FREETZ_BUSYBOX___V136_ENVUIDGID is not set
+# FREETZ_BUSYBOX___V136_ENVDIR is not set
+# FREETZ_BUSYBOX___V136_SOFTLIMIT is not set
+# FREETZ_BUSYBOX___V136_RUNSV is not set
+# FREETZ_BUSYBOX___V136_RUNSVDIR is not set
+# FREETZ_BUSYBOX___V136_SV is not set
+# FREETZ_BUSYBOX___V136_SVC is not set
+# FREETZ_BUSYBOX___V136_SVOK is not set
+# FREETZ_BUSYBOX___V136_SVLOGD is not set
+# end of Runit Utilities
+
+#
+# Shells
+#
+FREETZ_BUSYBOX___V136_SH_IS_ASH=y
+FREETZ_BUSYBOX___V136_BASH_IS_ASH=y
+FREETZ_BUSYBOX___V136_SHELL_ASH=y
+FREETZ_BUSYBOX___V136_ASH=y
+FREETZ_BUSYBOX___V136_ASH_OPTIMIZE_FOR_SIZE=y
+FREETZ_BUSYBOX___V136_ASH_INTERNAL_GLOB=y
+FREETZ_BUSYBOX___V136_ASH_BASH_COMPAT=y
+# FREETZ_BUSYBOX___V136_ASH_BASH_SOURCE_CURDIR is not set
+FREETZ_BUSYBOX___V136_ASH_BASH_NOT_FOUND_HOOK=y
+FREETZ_BUSYBOX___V136_ASH_JOB_CONTROL=y
+FREETZ_BUSYBOX___V136_ASH_ALIAS=y
+FREETZ_BUSYBOX___V136_ASH_RANDOM_SUPPORT=y
+FREETZ_BUSYBOX___V136_ASH_EXPAND_PRMT=y
+# FREETZ_BUSYBOX___V136_ASH_IDLE_TIMEOUT is not set
+# FREETZ_BUSYBOX___V136_ASH_MAIL is not set
+FREETZ_BUSYBOX___V136_ASH_ECHO=y
+FREETZ_BUSYBOX___V136_ASH_PRINTF=y
+FREETZ_BUSYBOX___V136_ASH_TEST=y
+# FREETZ_BUSYBOX___V136_ASH_SLEEP is not set
+# FREETZ_BUSYBOX___V136_ASH_HELP is not set
+FREETZ_BUSYBOX___V136_ASH_GETOPTS=y
+FREETZ_BUSYBOX___V136_ASH_CMDCMD=y
+# FREETZ_BUSYBOX___V136_CTTYHACK is not set
+# FREETZ_BUSYBOX___V136_HUSH is not set
+# FREETZ_BUSYBOX___V136_SHELL_HUSH is not set
+
+#
+# Options common to all shells
+#
+FREETZ_BUSYBOX___V136_FEATURE_SH_MATH=y
+FREETZ_BUSYBOX___V136_FEATURE_SH_MATH_64=y
+# FREETZ_BUSYBOX___V136_FEATURE_SH_MATH_BASE is not set
+# FREETZ_BUSYBOX___V136_FEATURE_SH_EXTRA_QUIET is not set
+FREETZ_BUSYBOX___V136_FEATURE_SH_READ_FRAC=y
+FREETZ_BUSYBOX___V136_FEATURE_SH_HISTFILESIZE=y
+FREETZ_BUSYBOX___V136_FEATURE_SH_EMBEDDED_SCRIPTS=y
+# end of Shells
+
+#
+# System Logging Utilities
+#
+FREETZ_BUSYBOX___V136_KLOGD=y
+FREETZ_BUSYBOX___V136_FEATURE_KLOGD_KLOGCTL=y
+FREETZ_BUSYBOX___V136_LOGGER=y
+FREETZ_BUSYBOX___V136_LOGREAD=y
+FREETZ_BUSYBOX___V136_FEATURE_LOGREAD_REDUCED_LOCKING=y
+FREETZ_BUSYBOX___V136_SYSLOGD=y
+FREETZ_BUSYBOX___V136_FEATURE_ROTATE_LOGFILE=y
+FREETZ_BUSYBOX___V136_FEATURE_REMOTE_LOG=y
+FREETZ_BUSYBOX___V136_FEATURE_SYSLOGD_DUP=y
+# FREETZ_BUSYBOX___V136_FEATURE_SYSLOGD_CFG is not set
+# FREETZ_BUSYBOX___V136_FEATURE_SYSLOGD_PRECISE_TIMESTAMPS is not set
+FREETZ_BUSYBOX___V136_FEATURE_SYSLOGD_READ_BUFFER_SIZE=256
+FREETZ_BUSYBOX___V136_FEATURE_IPC_SYSLOG=y
+FREETZ_BUSYBOX___V136_FEATURE_IPC_SYSLOG_BUFFER_SIZE=16
+# FREETZ_BUSYBOX___V136_FEATURE_KMSG_SYSLOG is not set
+# end of System Logging Utilities
+# end of Busybox applets
+
+# EXTERNAL_ENABLED is not set
+
+#
+# Mod customizations ---------------------------------------
+#
+
+#
+# Web Interface
+#
+# FREETZ_BACKUP_ENCRYPTION is not set
+# FREETZ_BACKUP_DECODING is not set
+# FREETZ_BACKUP_EXPORT is not set
+FREETZ_LANG_DE=y
+# FREETZ_LANG_EN is not set
+FREETZ_LANG_STRING="de"
+FREETZ_SECURITY_LEVEL=0
+FREETZ_STYLE_GREY=y
+FREETZ_STYLE="grey"
+
+#
+# Freetz skins
+#
+FREETZ_SKIN_cuma=y
+FREETZ_SKIN_legacy=y
+# FREETZ_SKIN_newfreetz is not set
+# FREETZ_SKIN_phoenix is not set
+# end of Freetz skins
+
+FREETZ_FAVICON_NONE=y
+# FREETZ_FAVICON_ATOMPHIL is not set
+# FREETZ_FAVICON_CUMA is not set
+# FREETZ_FAVICON_DSL123 is not set
+# FREETZ_FAVICON_HANSOLO is not set
+# FREETZ_FAVICON_PRISRAK is not set
+FREETZ_FAVICON_STRING="none"
+FREETZ_TAGGING_NONE=y
+# FREETZ_TAGGING_CUMA is not set
+# FREETZ_TAGGING_NG is not set
+# FREETZ_TAGGING_PIMPED is not set
+FREETZ_WEBIF_LINK=y
+# end of Web Interface
+
+#
+# Additional informations
+#
+FREETZ_ADD_JUIS_CHECK=y
+# FREETZ_ADD_JUIS_CHECK__SSL is not set
+FREETZ_ADD_UIMODS=y
+# FREETZ_REMOVE_BOX_INFO is not set
+# FREETZ_REMOVE_FREETZ_INFO is not set
+FREETZ_USER_DEFINED_COMMENT=""
+# FREETZ_IMAGE_NAME_CUSTOM is not set
+FREETZ_CREATE_SEPARATE_OPTIONS_CFG=y
+# FREETZ_DOT_CONFIG_DONOTADD is not set
+FREETZ_DOT_CONFIG_STRIPPED=y
+# FREETZ_DOT_CONFIG_COMPLETE is not set
+# end of Additional informations
+
+#
+# Build system ---------------------------------------------
+#
+
+#
+# Toolchain options
+#
+FREETZ_BUILD_TOOLCHAIN=y
+FREETZ_TOOLCHAIN_CCACHE=y
+FREETZ_TOOLCHAIN_MINIMIZE_REQUIRED_GLIBC_VERSION=y
+
+#
+# Kernel toolchain options ----------------------------------------
+#
+FREETZ_KERNEL_VERSION_4_9_325=y
+FREETZ_KERNEL_BINUTILS_2_31_DEFAULT=y
+FREETZ_KERNEL_BINUTILS_2_31=y
+FREETZ_KERNEL_GCC_8_4=y
+FREETZ_KERNEL_GCC_8=y
+FREETZ_KERNEL_GCC_4_MIN=y
+FREETZ_KERNEL_GCC_4_6_MIN=y
+FREETZ_KERNEL_GCC_4_7_MIN=y
+FREETZ_KERNEL_GCC_4_8_MIN=y
+FREETZ_KERNEL_GCC_5_MIN=y
+FREETZ_KERNEL_GCC_8_3_MIN=y
+FREETZ_KERNEL_GCC_8_4_MIN=y
+FREETZ_KERNEL_GCC_8_MIN=y
+FREETZ_KERNEL_GCC_8_4_MAX=y
+FREETZ_KERNEL_GCC_8_MAX=y
+FREETZ_KERNEL_GCC_9_MAX=y
+FREETZ_KERNEL_BINUTILS_VERSION="2.31.1"
+FREETZ_KERNEL_GCC_VERSION="8.4.0"
+
+#
+# Target toolchain options ----------------------------------------
+#
+FREETZ_SEPARATE_AVM_UCLIBC_FORCE=y
+FREETZ_SEPARATE_AVM_UCLIBC=y
+# FREETZ_TARGET_UNSUPPORTED_VERSIONS is not set
+FREETZ_TARGET_UCLIBC_1_0_48=y
+FREETZ_TARGET_UCLIBC_SUPPORTS_inotify=y
+FREETZ_TARGET_UCLIBC_SUPPORTS_libubacktrace=y
+FREETZ_TARGET_UCLIBC_REQUIRES_libubacktrace=y
+FREETZ_TARGET_BINUTILS_2_42_DEFAULT=y
+FREETZ_TARGET_BINUTILS_2_42=y
+FREETZ_TARGET_GCC_13_3=y
+FREETZ_TARGET_GCC_4_6_MIN=y
+FREETZ_TARGET_GCC_4_7_MIN=y
+FREETZ_TARGET_GCC_4_8_MIN=y
+FREETZ_TARGET_GCC_4_9_MIN=y
+FREETZ_TARGET_GCC_5_1_MIN=y
+FREETZ_TARGET_GCC_5_4_MIN=y
+FREETZ_TARGET_GCC_5_5_MIN=y
+FREETZ_TARGET_GCC_8_3_MIN=y
+FREETZ_TARGET_GCC_8_4_MIN=y
+FREETZ_TARGET_GCC_9_3_MIN=y
+FREETZ_TARGET_GCC_13_3_MIN=y
+FREETZ_TARGET_GCC_13=y
+FREETZ_TARGET_GCC_4_MIN=y
+FREETZ_TARGET_GCC_5_MIN=y
+FREETZ_TARGET_GCC_8_MIN=y
+FREETZ_TARGET_GCC_9_MIN=y
+FREETZ_TARGET_GCC_13_MIN=y
+FREETZ_TARGET_GCC_13_3_MAX=y
+FREETZ_TARGET_GCC_13_MAX=y
+FREETZ_TARGET_GCC_DEFAULT_AS_NEEDED=y
+# FREETZ_STDCXXLIB_FORCE_GNULIBSTDCXX is not set
+FREETZ_STDCXXLIB_USE_UCLIBCXX=y
+FREETZ_STDCXXLIB_USE_UCLIBCXX_CHOICE=y
+# FREETZ_STDCXXLIB_USE_GNULIBSTDCXX_CHOICE is not set
+FREETZ_TARGET_UCLIBC_1=y
+FREETZ_TARGET_UCLIBC_VERSION="1.0.48"
+FREETZ_TARGET_UCLIBC_MAJOR_VERSION="1"
+FREETZ_TARGET_BINUTILS_VERSION="2.42"
+FREETZ_TARGET_GCC_VERSION="13.3.0"
+FREETZ_GNULIBATOMIC_VERSION="1.2.0"
+FREETZ_GNULIBSTDCXX_VERSION="6.0.32"
+FREETZ_STDCXXLIB="uclibcxx"
+FREETZ_TARGET_CFLAGS="-Ofast -pipe"
+FREETZ_RPATH="/usr/lib/freetz"
+# FREETZ_TARGET_UCLIBC_DODEBUG is not set
+FREETZ_TARGET_UCLIBC_REDUCED_LOCALE_SET=y
+FREETZ_TARGET_UCLIBC_PROVIDES_SSP=y
+
+#
+# Host-tools options ----------------------------------
+#
+# FREETZ_TOOLS_PATCHELF_VERSION_ABANDON is not set
+FREETZ_TOOLS_PATCHELF_VERSION_CURRENT=y
+# FREETZ_TOOLS_UBOOT_STATIC is not set
+# FREETZ_TOOLS_WGET_STATIC is not set
+# FREETZ_TOOLS_KCONFIG_BUTTONS is not set
+# FREETZ_ROOTEMU_FAKEROOT is not set
+FREETZ_ROOTEMU_PSEUDO=y
+# FREETZ_HOSTTOOLS_DOWNLOAD is not set
+FREETZ_HOSTTOOLS_BUILD=y
+# end of Toolchain options
+
+#
+# Build system options
+#
+# FREETZ_ANCIENT_SYSTEM is not set
+FREETZ_MENUCONFIG_REVISION=y
+# FREETZ_VERBOSITY_FWMOD_0 is not set
+# FREETZ_VERBOSITY_FWMOD_1 is not set
+FREETZ_VERBOSITY_FWMOD_2=y
+FREETZ_VERBOSITY_FWMOD=2
+# FREETZ_VERBOSITY_LEVEL_0 is not set
+# FREETZ_VERBOSITY_LEVEL_1 is not set
+FREETZ_VERBOSITY_LEVEL_2=y
+FREETZ_VERBOSITY_LEVEL=2
+FREETZ_SIZEINFO_COMPRESSED=y
+# FREETZ_SIZEINFO_UNCOMPRESSED is not set
+FREETZ_JLEVEL=0
+FREETZ_CHECK_CHANGED=y
+# end of Build system options
+
+#
+# Firmware packaging (fwmod) options
+#
+# FREETZ_FWMOD_SKIP_UNPACK is not set
+FREETZ_FWMOD_VALIDATE=y
+# FREETZ_FWMOD_SKIP_MODIFY is not set
+# FREETZ_FWMOD_SKIP_PACK is not set
+FREETZ_FWMOD_SIGN=y
+FREETZ_FWMOD_SIGN_PASSWORD="freetz"
+# end of Firmware packaging (fwmod) options
+
+#
+# SquashFS options
+#
+# FREETZ_SQUASHFS_BLOCKSIZE_ORIG is not set
+FREETZ_SQUASHFS_BLOCKSIZE_65536=y
+FREETZ_SQUASHFS_BLOCKSIZE=65536
+# end of SquashFS options
+
+#
+# Strip options
+#
+FREETZ_STRIP_BINARIES=y
+# FREETZ_STRIP_MODULES_NONE is not set
+FREETZ_STRIP_MODULES_FREETZ=y
+# FREETZ_STRIP_MODULES_ALL is not set
+# FREETZ_STRIP_SCRIPTS is not set
+# end of Strip options
+
+#
+# Download options
+#
+FREETZ_DL_SITE_USER=""
+FREETZ_DL_DETECT_IMAGE_NAME=y
+FREETZ_DL_VCS_REPO_FIRST=y
+FREETZ_DL_VCS_FROM_MIRRORS=y
+FREETZ_DL_TOOLCHAIN_SITE=""
+FREETZ_DL_KERNEL_TOOLCHAIN_VERSION="rXXXXX"
+FREETZ_DL_KERNEL_TOOLCHAIN_HASH="1edcb72bfc3fe2a6521083eb3caebdcf6f250c78a709a7e2b28c1045b7a97dbb"
+FREETZ_DL_TARGET_TOOLCHAIN_VERSION="rXXXXX"
+FREETZ_DL_TARGET_TOOLCHAIN_HASH="6502eaaeba4ff820a00e9c7940a93619ad7379e65ec0a68b68cf9baac6ac426f"
+FREETZ_DL_TOOLCHAIN_SUFFIX="shared-glibc"
+# FREETZ_DL_KERNEL_OVERRIDE is not set
+FREETZ_DL_KERNEL_SOURCE_ID="7590_07.56"
+FREETZ_DL_KERNEL_VANILLA_SOURCE="linux-${FREETZ_KERNEL_VANILLA_VERSION}.tar.xz"
+FREETZ_DL_KERNEL_VANILLA_HASH="b48d55e57a55ab9fff2e131a99cf82a49ef726c640ca91e51f69a3063ae8ba12"
+FREETZ_DL_KERNEL_AVMDIFF_VERSION="ADv1"
+FREETZ_DL_KERNEL_AVMDIFF_SOURCE="kernel_${FREETZ_KERNEL_VERSION}-${FREETZ_DL_KERNEL_SOURCE_ID}${FREETZ_SYSTEM_TYPE_CORE_SUFFIX}-${FREETZ_DL_KERNEL_AVMDIFF_VERSION}.patch.xz"
+FREETZ_DL_KERNEL_AVMDIFF_HASH="9ae7eb2c879f0aa557fabde551b5c8e2b1b0e77fe93137c013a0ea0801d38dcb"
+FREETZ_DL_SITE="http://localhost"
+FREETZ_DL_SOURCE="${FREETZ_TYPE_PREFIX}-${FREETZ_TYPE_LANGUAGE}${FREETZ_TYPE_PREFIX_LABOR_FIRMWARE}.detected.image"
+# end of Download options
+
+FREETZ_AVM_HAS_FIRMWARE_06_8X=y
+FREETZ_AVM_HAS_FIRMWARE_06_9X=y
+FREETZ_AVM_HAS_FIRMWARE_07_0X=y
+FREETZ_AVM_HAS_FIRMWARE_07_1X=y
+FREETZ_AVM_HAS_FIRMWARE_07_2X=y
+FREETZ_AVM_HAS_FIRMWARE_07_5X=y
+FREETZ_AVM_HAS_FIRMWARE_08_0X_LABOR=y
+FREETZ_AVM_HAS_LANG_DE=y
+FREETZ_AVM_HAS_LANG_EN=y
+FREETZ_TYPE_DSL=y
+FREETZ_AVM_HAS_TEMPERATURE_SENSOR=y
+FREETZ_AVM_HAS_MULTI_ANNEX=y
+FREETZ_AVM_HAS_IPV6=y
+FREETZ_AVM_HAS_PTY_SUPPORT=y
+FREETZ_AVM_HAS_PRINTK=y
+FREETZ_AVM_HAS_KERNEL_CONFIG_AREA=y
+FREETZ_AVM_HAS_JUIS_SUPPORT=y
+FREETZ_AVM_HAS_MULTID_LEASES_FORMAT_V2=y
+FREETZ_AVM_HAS_LIBC_FILE="libc.so"
+FREETZ_AVM_HAS_AVMMULTID_PRELOAD=y
+FREETZ_AVM_SQUASHFS_VERSION=4
+FREETZ_SQUASHFS_VERSION=4
+FREETZ_AVM_SQUASHFS_ENDIANNESS="be"
+FREETZ_AVM_SQUASHFS_COMPRESSION="xz"
+FREETZ_AVM_IMAGES_SUBDIR="var/tmp"
+FREETZ_AVM_HAS_SEPARATE_FILESYSTEM_IMAGE=y
+FREETZ_AVM_SIGNATURE_KEY="010001x00e2d85346653d3e7f82d89857a300bd0714ca40bd5ef1e8bd2a43f6c42168f1aa1672d3b833eda7fd014460c9e2abc1f5c239f86dc7b18a7433102356e34e8e1a7cab229bdbad03d36a3c8ddd10d51a324f91d2132c7813bbfd07fce3c8b31f3f008eb5fe89dd7f9f5870500da8dbd91a749231ad6b3b4d6abc47545438f07f2b"
+FREETZ_AVM_HAS_BRANDING_avm=y
+FREETZ_AVM_HAS_LEDPAGE=y
+FREETZ_AVM_HAS_BRANDING_avme=y
+FREETZ_AVM_HAS_MULTIPLE_LANGUAGES=y
+FREETZ_AVM_HAS_LANGUAGE_de=y
+FREETZ_AVM_HAS_LANGUAGE_en=y
+FREETZ_AVM_HAS_LANGUAGE_es=y
+FREETZ_AVM_HAS_LANGUAGE_fr=y
+FREETZ_AVM_HAS_LANGUAGE_it=y
+FREETZ_AVM_HAS_LANGUAGE_pl=y
+FREETZ_AVM_HAS_CTLMGR_CTL=y
+FREETZ_AVM_HAS_DMESG_FILE=y
+FREETZ_AVM_HAS_INETD=y
+FREETZ_AVM_HAS_OPENSSL=y
+FREETZ_AVM_HAS_OPENSSL_VERSION_1=y
+FREETZ_AVM_HAS_SHOWDSLDSTAT=y
+FREETZ_AVM_HAS_SIGNATURE=y
+FREETZ_AVM_HAS_TR064=y
+FREETZ_AVM_HAS_TR069=y
+FREETZ_AVM_HAS_TR069_FWUPDATE=y
+FREETZ_AVM_HAS_UDEV=y
+FREETZ_AVM_HAS_WLAN=y
+FREETZ_AVM_PROP_ARCH_BE=y
+FREETZ_AVM_PROP_ARCH_MIPS=y
+FREETZ_AVM_PROP_HWREV="226"
+FREETZ_AVM_PROP_MAJOR="154"
+FREETZ_AVM_PROP_NAME="FRITZ!Box 7590"
+FREETZ_AVM_PROP_SQUASHFS_ENDIANN_BE=y
+FREETZ_AVM_SERIAL_CONSOLE_DEVICE="/dev/ttyLTQ0"
+FREETZ_AVM_HAS_TC=y
+FREETZ_AVM_HAS_NEXUS=y
+FREETZ_AVM_HAS_REBOOT_SCRIPT=y
+FREETZ_AVM_HAS_IP_BINARY=y
+FREETZ_AVM_HAS_MESHD=y
+FREETZ_AVM_PROP_SQUASHFS_VERSION_4=y
+FREETZ_AVM_PROP_SQUASHFS_COMPRESSION_XZ=y
+FREETZ_AVM_HAS_ETCSERVICES=y
+FREETZ_AVM_HAS_MULTIPLE_BRANDINGS=y
+FREETZ_AVM_PROP_ALL_REGIONS=y
+FREETZ_AVM_HAS_PLCD=y
+FREETZ_AVM_HAS_AHA=y
+FREETZ_AVM_HAS_SVCTL=y
+FREETZ_AVM_PROP_UCLIBC_SEPARATE=y
+FREETZ_AVM_HAS_KMOD=y
+FREETZ_AVM_HAS_FWLAYOUT_2=y
+FREETZ_AVM_HAS_LANGUAGE_nl=y
+FREETZ_AVM_PROP_KERNEL_CONFIG_AREA_SIZE_256=y
+FREETZ_AVM_PROP_SEPARATE_FILESYSTEM_IMAGE=y
+FREETZ_AVM_PROP_LIBC_MUSL=y
+FREETZ_AVM_HAS_NOEXEC=y
+FREETZ_AVM_HAS_AURA_USB=y
+FREETZ_AVM_HAS_USB_HOST=y
+FREETZ_AVM_HAS_DSLD=y
+FREETZ_AVM_HAS_VPN=y
+FREETZ_AVM_HAS_PRINTSERV=y
+FREETZ_AVM_HAS_MEDIASRV=y
+FREETZ_AVM_HAS_KIDS=y
+FREETZ_AVM_HAS_FAT_MODULE=y
+FREETZ_AVM_HAS_NLS_MODULE=y
+FREETZ_AVM_HAS_BRANDING_1und1=y
+FREETZ_AVM_HAS_ANNEX_SELECTION=y
+FREETZ_AVM_HAS_MYFRITZ=y
+FREETZ_AVM_HAS_NAS=y
+FREETZ_AVM_HAS_NTFS=y
+FREETZ_AVM_HAS_WEBDAV=y
+FREETZ_AVM_HAS_CHRONYD=y
+FREETZ_AVM_HAS_TAM=y
+FREETZ_AVM_HAS_PHONE=y
+FREETZ_AVM_HAS_DDNSD=y
+FREETZ_AVM_HAS_UMTS=y
+FREETZ_AVM_HAS_DTRACE=y
+FREETZ_AVM_HAS_E2FSPROGS=y
+FREETZ_AVM_HAS_DSL_CONTROL=y
+FREETZ_AVM_HAS_PCPD=y
+FREETZ_AVM_HAS_SAMBA_NQCS=y
+FREETZ_AVM_HAS_UNTRUSTEDD=y
+FREETZ_AVM_HAS_WIREGUARD=y
+FREETZ_AVM_HAS_AVMCOUNTERD=y
+FREETZ_AVM_HAS_LIBFUSE=y
+FREETZ_AVM_HAS_DECT=y
+FREETZ_AVM_HAS_FAX=y
+FREETZ_AVM_HAS_RRDTOOL=y
+FREETZ_AVM_PROP_GCC_8_4=y
+FREETZ_AVM_PROP_KERNEL_4_9_325=y
+FREETZ_AVM_HAS_CRC16_BUILTIN=y
+FREETZ_AVM_HAS_EXT3_FS_BUILTIN=y
+FREETZ_AVM_HAS_EXT4_FS_BUILTIN=y
+FREETZ_AVM_HAS_FS_MBCACHE_BUILTIN=y
+FREETZ_AVM_HAS_FUSE_FS_BUILTIN=y
+FREETZ_AVM_HAS_JBD2_BUILTIN=y
+FREETZ_AVM_HAS_MTD_NAND_BUILTIN=y
+FREETZ_AVM_HAS_SWAP_BUILTIN=y
+FREETZ_AVM_HAS_CRYPTO_HMAC_BUILTIN=y
+FREETZ_AVM_HAS_CRYPTO_AES_BUILTIN=y
+FREETZ_AVM_HAS_CRYPTO_ALGAPI_BUILTIN=y
+FREETZ_AVM_HAS_FW_LOADER_BUILTIN=y
+FREETZ_AVM_HAS_LZO_COMPRESS_BUILTIN=y
+FREETZ_AVM_HAS_LZO_DECOMPRESS_BUILTIN=y
+FREETZ_AVM_HAS_SCSI_MOD_BUILTIN=y
+FREETZ_AVM_HAS_BLK_DEV_SD_BUILTIN=y
+FREETZ_AVM_HAS_CRYPTO_BLKCIPHER_BUILTIN=y
+FREETZ_AVM_HAS_CRYPTO_CBC_BUILTIN=y
+FREETZ_AVM_HAS_CRYPTO_DES_BUILTIN=y
+FREETZ_AVM_HAS_CRYPTO_HASH_BUILTIN=y
+FREETZ_AVM_HAS_CRYPTO_MANAGER_BUILTIN=y
+FREETZ_AVM_HAS_CRYPTO_MD5_BUILTIN=y
+FREETZ_AVM_HAS_CRYPTO_RNG_BUILTIN=y
+FREETZ_AVM_HAS_CRYPTO_SHA1_BUILTIN=y
+FREETZ_AVM_HAS_CRYPTO_SHA256_BUILTIN=y
+FREETZ_AVM_HAS_CRYPTO_WORKQUEUE_BUILTIN=y
+FREETZ_AVM_HAS_USB_BUILTIN=y
+FREETZ_AVM_HAS_JFFS2_FS_BUILTIN=y
+FREETZ_AVM_HAS_ANTFS_FS_BUILTIN=y
+FREETZ_AVM_HAS_CRYPTO_AEAD_BUILTIN=y
+FREETZ_AVM_HAS_NET_CLS_U32_BUILTIN=y
+FREETZ_AVM_HAS_NET_SCH_CBQ_BUILTIN=y
+FREETZ_AVM_HAS_NET_SCH_HTB_BUILTIN=y
+FREETZ_AVM_HAS_CRYPTO_ARC4_BUILTIN=y
+FREETZ_AVM_HAS_CRYPTO_CMAC_BUILTIN=y
+FREETZ_AVM_HAS_CRYPTO_ECB_BUILTIN=y
+FREETZ_AVM_HAS_EXPORTFS_BUILTIN=y
+FREETZ_AVM_VERSION_07_5X=y
+FREETZ_AVM_VERSION_04_XX_MIN=y
+FREETZ_AVM_VERSION_05_2X_MIN=y
+FREETZ_AVM_VERSION_05_5X_MIN=y
+FREETZ_AVM_VERSION_06_0X_MIN=y
+FREETZ_AVM_VERSION_06_2X_MIN=y
+FREETZ_AVM_VERSION_06_5X_MIN=y
+FREETZ_AVM_VERSION_06_8X_MIN=y
+FREETZ_AVM_VERSION_06_9X_MIN=y
+FREETZ_AVM_VERSION_07_0X_MIN=y
+FREETZ_AVM_VERSION_07_1X_MIN=y
+FREETZ_AVM_VERSION_07_2X_MIN=y
+FREETZ_AVM_VERSION_07_5X_MIN=y
+FREETZ_AVM_VERSION_07_5X_MAX=y
+FREETZ_AVM_VERSION_07_8X_MAX=y
+FREETZ_AVM_VERSION_08_0X_MAX=y
+FREETZ_SYSTEM_TYPE_GRX5=y
+FREETZ_SYSTEM_TYPE="grx5"
+FREETZ_CPU_MODEL_MIPS_interAptiv=y
+FREETZ_TARGET_ARCH_BE=y
+FREETZ_TARGET_ARCH_MIPS=y
+FREETZ_KERNEL_ARCH="mips"
+FREETZ_TARGET_ARCH="mips"
+FREETZ_TARGET_ARCH_ENDIANNESS_DEPENDENT="mips"
+FREETZ_TARGET_TRIPLET_VENDOR="unknown"
+FREETZ_TARGET_GNU_TRIPLET="${FREETZ_TARGET_ARCH_ENDIANNESS_DEPENDENT}-${FREETZ_TARGET_TRIPLET_VENDOR}-linux-gnu${FREETZ_TARGET_TRIPLET_GNU_ABI}"
+FREETZ_TARGET_UCLIBC_TRIPLET="${FREETZ_TARGET_ARCH_ENDIANNESS_DEPENDENT}-linux-uclibc${FREETZ_TARGET_TRIPLET_UCLIBC_ABI}"
+FREETZ_TARGET_CROSS="${FREETZ_TARGET_UCLIBC_TRIPLET}-"
+FREETZ_TARGET_MAKE_PATH="toolchain/target/bin"
+FREETZ_KERNEL_CROSS="${FREETZ_TARGET_GNU_TRIPLET}-"
+FREETZ_KERNEL_MAKE_PATH="toolchain/kernel/bin"
+FREETZ_AVM_GCC_8_4=y
+FREETZ_AVM_GCC_8=y
+FREETZ_AVM_GCC_3_4_MIN=y
+FREETZ_AVM_GCC_4_6_MIN=y
+FREETZ_AVM_GCC_4_7_MIN=y
+FREETZ_AVM_GCC_4_8_MIN=y
+FREETZ_AVM_GCC_4_9_MIN=y
+FREETZ_AVM_GCC_5_1_MIN=y
+FREETZ_AVM_GCC_5_4_MIN=y
+FREETZ_AVM_GCC_5_5_MIN=y
+FREETZ_AVM_GCC_8_3_MIN=y
+FREETZ_AVM_GCC_8_4_MIN=y
+FREETZ_AVM_GCC_4_MIN=y
+FREETZ_AVM_GCC_5_MIN=y
+FREETZ_AVM_GCC_8_MIN=y
+FREETZ_AVM_GCC_8_4_MAX=y
+FREETZ_AVM_GCC_9_3_MAX=y
+FREETZ_AVM_GCC_13_3_MAX=y
+FREETZ_AVM_GCC_8_MAX=y
+FREETZ_AVM_GCC_9_MAX=y
+FREETZ_AVM_GCC_13_MAX=y
+FREETZ_GCC_ABI="32"
+FREETZ_GCC_ARCH="mips32r2"
+FREETZ_GCC_CPU="34kc"
+FREETZ_GCC_FLOAT_ABI="soft"
+FREETZ_KERNEL_VERSION_4_9=y
+FREETZ_KERNEL_VERSION="4.9.325"
+FREETZ_KERNEL_VERSION_MAJOR="4.9"
+FREETZ_KERNEL_VANILLA_DLDIR="4.x"
+FREETZ_KERNEL_VANILLA_VERSION="${FREETZ_KERNEL_VERSION}"
+FREETZ_KERNEL_VERSION_MODULES_SUBDIR="4.9.325"
+FREETZ_KERNEL_VERSION_2_6_13_MIN=y
+FREETZ_KERNEL_VERSION_2_6_19_MIN=y
+FREETZ_KERNEL_VERSION_2_6_28_MIN=y
+FREETZ_KERNEL_VERSION_2_6_32_MIN=y
+FREETZ_KERNEL_VERSION_2_6_39_MIN=y
+FREETZ_KERNEL_VERSION_3_MIN=y
+FREETZ_KERNEL_VERSION_3_10_MIN=y
+FREETZ_KERNEL_VERSION_3_12_MIN=y
+FREETZ_KERNEL_VERSION_4_MIN=y
+FREETZ_KERNEL_VERSION_4_1_MIN=y
+FREETZ_KERNEL_VERSION_4_4_MIN=y
+FREETZ_KERNEL_VERSION_4_9_MIN=y
+FREETZ_KERNEL_VERSION_4_9_MAX=y
+FREETZ_KERNEL_VERSION_4_19_MAX=y
+FREETZ_KERNEL_VERSION_4_MAX=y
+FREETZ_KERNEL_VERSION_5_4_MAX=y
+FREETZ_KERNEL_VERSION_5_15_MAX=y
+FREETZ_KERNEL_VERSION_5_MAX=y
+FREETZ_KERNEL_VERSION_4=y
+FREETZ_AVM_KERNEL_CONFIG_AREA_SIZE=256
+FREETZ_AVM_UCLIBC_NPTL_ENABLED=y
+FREETZ_AVM_UCLIBC_XLOCALE_ENABLED=y
+FREETZ_AVM_SOURCE_7590_07_56=y
+FREETZ_AVM_SOURCE_ID="7590_07.56"
+FREETZ_AVM_SOURCE_FOR_SYSTEM_TYPE_GRX5=y
+FREETZ_DL_JUIS_BUILDTYPE="1"
+FREETZ_DL_JUIS_COUNTRY="049"
+FREETZ_DL_JUIS_LANG="de"
+FREETZ_DL_JUIS_OEM="avm"
+FREETZ_DL_JUIS_FLAG="empty"
+FREETZ_DL_JUIS_ANNEX="B"
+FREETZ_DL_JUIS_FOS="07.50-100%REV%"
+FREETZ_DL_JUIS_OID="3CA62F"
+FREETZ_DL_JUIS_STRING="Version=${FREETZ_AVM_PROP_MAJOR}.${FREETZ_DL_JUIS_FOS} Serial=${FREETZ_DL_JUIS_OID}%SER% Name=${FREETZ_AVM_PROP_NAME} HW=${FREETZ_AVM_PROP_HWREV} OEM=${FREETZ_DL_JUIS_OEM} Lang=${FREETZ_DL_JUIS_LANG} Annex=${FREETZ_DL_JUIS_ANNEX} Country=${FREETZ_DL_JUIS_COUNTRY} Flag=${FREETZ_DL_JUIS_FLAG} Buildtype=${FREETZ_DL_JUIS_BUILDTYPE} Nonce=%NNC%"
+FREETZ_REPLACE_MODULE_AVAILABLE=y
+FREETZ_KERNEL_AVMDIFF_AVAILABLE=y
+FREETZ_TYPE_PREFIX="7590"
+FREETZ_TYPE_PREFIX_SERIES_SUBDIR="07_5X"
+FREETZ_TARGET_MESON_FAMILY="mips"
+FREETZ_TARGET_MESON_CPU="mips"
+FREETZ_TARGET_MESON_ENDIAN="big"
+FREETZ_INSTALL_BASE=y
+FREETZ_REPLACE_BUSYBOX=y

--- a/make/pkgs/vlmcsd/Config.in
+++ b/make/pkgs/vlmcsd/Config.in
@@ -1,0 +1,11 @@
+config FREETZ_PACKAGE_VLMCSD
+	bool "VLMCSD 1113 (binary only)"
+        select FREETZ_PACKAGE_VLMCSDSETUP
+	default n
+	help
+		vlmcsd is a fully Microsoft compatible KMS server hat provides
+		product activation services to clients.
+		It is designed to run on POSIX compatible operating systens.
+		Only requirements are a basic C library with a BSD-style
+		sockets API and either fork(2) or pthreads(7). That allows it
+		to run on most embedded systems like routers, NASes, etc.

--- a/make/pkgs/vlmcsd/external.files
+++ b/make/pkgs/vlmcsd/external.files
@@ -1,0 +1,1 @@
+[ "$EXTERNAL_FREETZ_PACKAGE_VLMCSD" == "y" ] && EXTERNAL_FILES+=" /usr/bin/vlmcsd"

--- a/make/pkgs/vlmcsd/external.in
+++ b/make/pkgs/vlmcsd/external.in
@@ -1,0 +1,8 @@
+config EXTERNAL_FREETZ_PACKAGE_VLMCSD
+	depends on EXTERNAL_ENABLED && FREETZ_PACKAGE_VLMCSD
+	bool "vlmcsd"
+	default n
+	help
+		externals the following file(s):
+		 /usr/bin/vlmcsd
+

--- a/make/pkgs/vlmcsd/external.services
+++ b/make/pkgs/vlmcsd/external.services
@@ -1,0 +1,1 @@
+[ "$EXTERNAL_FREETZ_PACKAGE_VLMCSD" == "y" ] && EXTERNAL_SERVICES+=" vlmcsd"

--- a/make/pkgs/vlmcsd/files/.language
+++ b/make/pkgs/vlmcsd/files/.language
@@ -1,0 +1,10 @@
+languages
+{ de en }
+default
+{ en }
+files
+{
+	etc/default.vlmcsd/vlmcsd.cfg
+	etc/init.d/rc.vlmcsd
+	usr/lib/cgi-bin/vlmcsd.cgi
+}

--- a/make/pkgs/vlmcsd/files/README
+++ b/make/pkgs/vlmcsd/files/README
@@ -1,0 +1,9 @@
+Vlmcsd Freetz package
+   __  _   __  __ ___ __
+  |__ |_) |__ |__  |   /
+  |   |\  |__ |__  |  /_
+
+This is a package for Freetz: https://freetz.github.io/
+
+Vlmcsd sources are available here:
+https://github.com/Wind4/vlmcsd.git

--- a/make/pkgs/vlmcsd/files/root/etc/default.vlmcsd/vlmcsd.cfg
+++ b/make/pkgs/vlmcsd/files/root/etc/default.vlmcsd/vlmcsd.cfg
@@ -1,0 +1,6 @@
+export VLMCSD_ENABLED="no"
+export VLMCSD_AUTOSTART="yes"
+export VLMCSD_IP="0.0.0.0"
+export VLMCSD_PORT="1688"
+export VLMCSD_RENEW="7d"
+export VLMCSD_RETRY="1d"

--- a/make/pkgs/vlmcsd/files/root/etc/init.d/rc.vlmcsd
+++ b/make/pkgs/vlmcsd/files/root/etc/init.d/rc.vlmcsd
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+DAEMON=vlmcsd
+. /etc/init.d/modlibrc
+if [ -r ../default.$DAEMON/$DAEMON.cfg ]; then
+     . ../default.$DAEMON/$DAEMON.cfg
+fi
+
+start() {
+	modlib_startdaemon $DAEMON -L $VLMCSD_IP -P $VLMCSD_PORT -R $VLMCSD_RENEW -A $VLMCSD_RETRY
+}
+
+case $1 in
+	""|load)
+		modreg cgi 'vlmcsd' 'Microsoft KMS-Server'
+		modreg daemon $DAEMON
+		modlib_start
+		;;
+	start)
+		modlib_start
+		;;
+
+	stop)
+		modlib_stop
+		;;
+	unload)
+		modunreg daemon $DAEMON
+		modunreg cgi $DAEMON
+		modlib_stop
+		;;
+	restart)
+		modlib_stop
+		modlib_start
+		;;
+	status)
+		modlib_status
+		;;
+	*)
+		echo "Usage: $0 [load|unload|start|stop|restart|status]" 1>&2
+		exit 1
+		;;
+esac
+
+exit 0

--- a/make/pkgs/vlmcsd/files/root/usr/lib/cgi-bin/vlmcsd.cgi
+++ b/make/pkgs/vlmcsd/files/root/usr/lib/cgi-bin/vlmcsd.cgi
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+. /usr/lib/libmodcgi.sh
+
+sec_begin "$(lang de:"Netzwerkeinstellungen" en:"Network settings")"
+
+cat << EOF
+<p>$(lang de:"Autostart" en:"Autostart"): <input id="autostart" type="text" name="autostart" value="$(html "$VLMCSD_AUTOSTART")">
+<br />$(lang de:"Lausche an IP-Adresse" en:"Listen at IP-Adress"): <input id="ip" type="text" name="ip" value="$(html "$VLMCSD_IP")">
+<br />$(lang de:"Port" en:"Port"): <input id="port" type="text" name="port" value="$(html "$VLMCSD_PORT")">
+<br />$(lang de:"Aktivierung erneuern nach" en:"Renew activation after"): <input id="renew" type="text" name="renew" value="$(html "$VLMCSD_RENEW")"></p>
+<br />$(lang de:"Neuer Versuch nach" en:"Retry after"): <input id="retry" type="text" name="retry" value="$(html "$VLMCSD_RETRY")"></p>
+EOF
+
+sec_end

--- a/make/pkgs/vlmcsd/vlmcsd.mk
+++ b/make/pkgs/vlmcsd/vlmcsd.mk
@@ -1,0 +1,31 @@
+$(call PKG_INIT_BIN, svn1113)
+$(PKG)_SOURCE:=$($(PKG)_VERSION).tar.gz
+$(PKG)_HASH:=f73b801d56ec7f5e06a306bfb0a6e22b531617ca
+$(PKG)_SITE:=https://github.com/Wind4/vlmcsd/archive/refs/tags/
+$(PKG)_BINARY:=$($(PKG)_DIR)/bin/vlmcsd
+$(PKG)_TARGET_BINARY:=$($(PKG)_DEST_DIR)/usr/bin/vlmcsd
+
+$(PKG_SOURCE_DOWNLOAD)
+$(PKG_UNPACKED)
+$(PKG_CONFIGURED_NOP)
+
+$($(PKG)_BINARY): $($(PKG)_DIR)/.configured
+	$(SUBMAKE) -C $(VLMCSD_DIR) \
+		CC="$(TARGET_CC)" \
+		CFLAGS="$(TARGET_CFLAGS)"
+
+$($(PKG)_TARGET_BINARY): $($(PKG)_BINARY)
+	$(INSTALL_BINARY_STRIP)
+
+$(pkg):
+
+$(pkg)-precompiled: $($(PKG)_TARGET_BINARY)
+
+$(pkg)-clean:
+	-$(SUBMAKE) -C $(VLMCSD_DIR) clean
+	$(RM) $(VLMCSD_DIR)/.configured
+
+$(pkg)-uninstall:
+	$(RM) $(VLMCSD_TARGET_BINARY)
+
+$(PKG_FINISH)

--- a/make/pkgs/vlmcsdsetup/Config.in
+++ b/make/pkgs/vlmcsdsetup/Config.in
@@ -1,0 +1,8 @@
+config FREETZ_PACKAGE_VLMCSDSETUP
+	bool "VLMCSD-Setup 0.0.1 (binary only)"
+	depends on FREETZ_PACKAGE_VLMCSD
+	select FREETZ_LIB_libutil if FREETZ_TARGET_UCLIBC_HAS_multiple_libs
+	default y
+	help
+		A utility to make the setup of vlmcsd easier.
+

--- a/make/pkgs/vlmcsdsetup/vlmcsdsetup.mk
+++ b/make/pkgs/vlmcsdsetup/vlmcsdsetup.mk
@@ -1,0 +1,31 @@
+$(call PKG_INIT_BIN, 0.0.1)
+$(PKG)_SOURCE:=$($(PKG)_VERSION).tar.gz
+$(PKG)_HASH:=c8443079b7ecbcd36629213f3d49d8b24269fbaeb895639d058e07a44594232a
+$(PKG)_SITE:=https://github.com/manfred-mueller/vlmcsdsetup/archive/refs/tags/
+$(PKG)_BINARY:=$($(PKG)_DIR)/vlmcsdsetup
+$(PKG)_TARGET_BINARY:=$($(PKG)_DEST_DIR)/usr/bin/vlmcsdsetup
+
+$(PKG_SOURCE_DOWNLOAD)
+$(PKG_UNPACKED)
+$(PKG_CONFIGURED_NOP)
+
+$($(PKG)_BINARY): $($(PKG)_DIR)/.configured
+	$(SUBMAKE) -C $(VLMCSDSETUP_DIR) \
+		CC="$(TARGET_CC)" \
+		CFLAGS="$(TARGET_CFLAGS)"
+
+$($(PKG)_TARGET_BINARY): $($(PKG)_BINARY)
+	$(INSTALL_BINARY_STRIP)
+
+$(pkg):
+
+$(pkg)-precompiled: $($(PKG)_TARGET_BINARY)
+
+$(pkg)-clean:
+	-$(SUBMAKE) -C $(VLMCSDSETUP_DIR) clean
+	$(RM) $(VLMCSDSETUP_DIR)/.configured
+
+$(pkg)-uninstall:
+	$(RM) $(VLMCSDSETUP_TARGET_BINARY)
+
+$(PKG_FINISH)


### PR DESCRIPTION
vlmcsd is a fully Microsoft compatible KMS server

Created because a KMS is no longer available by default in the MS VLSC and is only created on request.
Tested with firmware 7.59 on a Fritz!Box 7490 and firmware 7.59/8.0 on a Fritz!Box 7590.