### PR TITLE
Package uvncreceiver added

### DIFF
--- a/make/pkgs/uvncrepeater/Config.in
+++ b/make/pkgs/uvncrepeater/Config.in
@@ -1,0 +1,16 @@
+config FREETZ_PACKAGE_UVNCREPEATER
+	bool "UltraVNC repeater 014 (binary only)"
+	default n
+	help
+		A linux port of the UltraVNC Repeater.
+		The  UltraVNC  Repeater acts like a
+		proxy, sitting in the middle between
+		the UltraVNC Server and Viewer. All
+		data for the session is passed through
+		the UltraVNC Repeater meaning that the
+		UltraVNC Viewer and UltraVNC Server can
+		both be behind a NAT firewall, without
+		having to worry about forwarding ports
+		or anything else (providing the Repeater
+		is visible to both UltraVNC Viewer and
+		UltraVNC Server).

--- a/make/pkgs/uvncrepeater/Config.in
+++ b/make/pkgs/uvncrepeater/Config.in
@@ -1,9 +1,9 @@
 config FREETZ_PACKAGE_UVNCREPEATER
-	bool "UltraVNC repeater 014 (binary only)"
+	bool "UVNC IPv4 repeater 014 (binary only)"
 	default n
 	help
-		A linux port of the UltraVNC Repeater.
-		The  UltraVNC  Repeater acts like a
+		A IPv4 only linux port of the UltraVNC
+		Repeater. The Repeater acts like a
 		proxy, sitting in the middle between
 		the UltraVNC Server and Viewer. All
 		data for the session is passed through

--- a/make/pkgs/uvncrepeater/Makefile.in
+++ b/make/pkgs/uvncrepeater/Makefile.in
@@ -1,0 +1,3 @@
+ifeq ($(strip $(FREETZ_PACKAGE_UVNCREPEATER)),y)
+PACKAGES+=uvncrepeater
+endif

--- a/make/pkgs/uvncrepeater/external.files
+++ b/make/pkgs/uvncrepeater/external.files
@@ -1,0 +1,2 @@
+[ "$EXTERNAL_FREETZ_PACKAGE_UVNCREPEATER" == "y" ] && EXTERNAL_FILES+=" /usr/bin/uvncrepeater"
+

--- a/make/pkgs/uvncrepeater/external.in
+++ b/make/pkgs/uvncrepeater/external.in
@@ -1,0 +1,7 @@
+config EXTERNAL_FREETZ_PACKAGE_UVNCREPEATER
+	depends on EXTERNAL_ENABLED && FREETZ_PACKAGE_UVNCREPEATER
+	bool "uvncrepeater"
+	default n
+	help
+		externals the following file(s):
+		 /usr/bin/uvncrepeater

--- a/make/pkgs/uvncrepeater/external.services
+++ b/make/pkgs/uvncrepeater/external.services
@@ -1,0 +1,1 @@
+[ "$EXTERNAL_FREETZ_PACKAGE_UVNCREPEATER" == "y" ] && EXTERNAL_SERVICES+=" uvncrepeater"

--- a/make/pkgs/uvncrepeater/files/.language
+++ b/make/pkgs/uvncrepeater/files/.language
@@ -1,0 +1,10 @@
+languages
+{ de en }
+default
+{ en }
+files
+{
+	etc/default.vlmcsd/uvncrepeater*.def
+	etc/init.d/rc.uvncrepeater
+	usr/lib/cgi-bin/uvncrepeater.cgi
+}

--- a/make/pkgs/uvncrepeater/files/root/etc/default.uvncrepeater/uvncrepeater.cfg
+++ b/make/pkgs/uvncrepeater/files/root/etc/default.uvncrepeater/uvncrepeater.cfg
@@ -1,0 +1,2 @@
+export UVNCREPEATER_ENABLED="no"
+export UVNCREPEATER_CMDLINE="-d"

--- a/make/pkgs/uvncrepeater/files/root/etc/default.uvncrepeater/uvncrepeater.defaults
+++ b/make/pkgs/uvncrepeater/files/root/etc/default.uvncrepeater/uvncrepeater.defaults
@@ -1,0 +1,103 @@
+[general]
+;Ports
+viewerport = 5900
+serverport = 5500
+
+;Repeater's own ip address in case your server happens to have several
+;ip addresses (for example, one physical machine running several virtual 
+;machines each having their own ip address)
+;default (0.0.0.0 = INADDR_ANY = uses all addresses) is the same that 
+;older repeater versions (before 0.12) did --> listens to all interfaces
+;Notice ! This IS NOT address of server or viewer, but repeater itself !
+ownipaddress = 0.0.0.0
+
+;How many sessions can we have active at the same time ?
+;values can be [1...1000]
+;Notice: If you actually *have* computer(s) capable
+;of 1000 simultaneous sessions, you are probably a *very big company*, 
+;so please invite me to visit and admire your server(s) ;-)
+maxsessions = 10
+
+;If program is started as root (to allow binding ports below 1024), 
+;it changes to this user after ports have been bound in startup
+;You need to create a suitable (normal, non-privileged) user/group and change name here
+runasuser = uvncrep
+
+;Allowed modes for repeater
+;0=None, 1=Only Mode 1, 2=Only Mode 2, 3=Both modes
+;Notice: If you set allowedmodes = 0, repeater will run without listening to any ports, 
+;it will just wait for your ctlr + c ;-)
+;allowedmodes = 3  
+
+;Logging level
+;0 = Very little (fatal() messages, relaying done)
+;1 = 0 + Important messages + Connections opened / closed
+;2 = 1 + Ini values + exceptions in logic flow
+;3 = 2 + Everything else (very detailed and exhaustive logging == BIG log files)
+;logginglevel = 3              
+
+
+[mode1]
+;0=All
+;allowedmode1serverport = 0
+
+;0=Allow connections to all server addressess,
+;1=Require that server address (or range of addresses) is listed in 
+;srvListAllow[0]...srvListAllow[SERVERS_LIST_SIZE-1]
+;requirelistedserver = 0             
+
+;List of allowed server addresses / ranges
+;Ranges can be defined by setting corresponding number to 0, e.g. 10.0.0.0 allows all addresses 10.x.x.x
+;Address 255.255.255.255 (default) does not allow any connections
+;Address 0.0.0.0 allows all connections
+;Only IP addresses can be used here, not DNS names 
+;There can be max SERVERS_LIST_SIZE (default 50) srvListAllow lines
+;srvListAllow0 = 10.0.0.0        ;Allow network 10.x.x.x
+;srvListAllow1 = 192.168.0.0     ;Allow network 192.168.x.x
+
+;List of denied server addresses / ranges
+;Ranges can be defined by setting corresponding number to 0, e.g. 10.0.0.0 denies all addresses 10.x.x.x
+;Address 255.255.255.255 (default) does not deny any connections
+;Address 0.0.0.0 denies all connections
+;Only IP addresses can be used here, not DNS names 
+;If addresss/range is both allowed and denied, it will be denied (deny is stronger)
+;There can be max SERVERS_LIST_SIZE (default 50) srvListDeny lines
+;srvListDeny0 = 10.0.0.0         ;Deny network 10.x.x.x
+;srvListDeny1 = 192.168.2.22     ;Deny host 192.168.2.22
+
+[mode2]
+;0=Allow all IDs, 1=Allow only IDs listed in idList[0]...idList[ID_LIST_SIZE-1]
+;requirelistedid = 0             
+
+;List of allowed ID: numbers
+;Value 0 means "this authenticates negatively"
+;If value is not listed, default is 0
+;Values should be between [1...LONG_MAX-1]
+;There can be max ID_LIST_SIZE (default 100) idList lines
+;idlist0 = 1111                  
+;idlist1 = 2222
+;idlist2 = 0
+;idlist3 = 0
+;idlist4 = 0
+;idlist5 = 0
+;idlist6 = 0
+;idlist7 = 0
+;idlist8 = 0
+;idlist9 = 0
+
+
+[eventinterface]
+;Use event interface (for reporting repeater events to outside world) ?
+;This could be used to send email, write webpage, update database etc.
+;Possible values: true/false
+;useeventinterface = true
+
+;Hostname/Ip address  + port of event listener we send events to
+;eventlistenerhost = localhost
+;eventlistenerport = 2002
+
+;Make HTTP/1.0 GET request to event listener (instead of normal write dump)
+;Somebody wanted this for making a PHP event listener
+;usehttp = true
+
+

--- a/make/pkgs/uvncrepeater/files/root/etc/default.uvncrepeater/uvncrepeater_ini.def
+++ b/make/pkgs/uvncrepeater/files/root/etc/default.uvncrepeater/uvncrepeater_ini.def
@@ -1,0 +1,8 @@
+CAPTION='UVNCREPEATER: uvncrepeater.ini'
+
+CONFIG_FILE='/tmp/flash/uvncrepeater/uvncrepeater.ini'
+CONFIG_SAVE='modsave flash; if pidof uvncrepeater > /dev/null; then /mod/etc/init.d/rc.uvncrepeater restart; fi'
+CONFIG_TYPE='text'
+
+TEXT_ROWS=60
+

--- a/make/pkgs/uvncrepeater/files/root/etc/init.d/rc.uvncrepeater
+++ b/make/pkgs/uvncrepeater/files/root/etc/init.d/rc.uvncrepeater
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+DAEMON=uvncrepeater
+DAEMON_USER=uvncrep
+DAEMON_LONG_NAME="UVNC-Repeater"
+DAEMON_CFGFILE="/tmp/flash/$DAEMON/$DAEMON.ini"
+. /etc/init.d/modlibrc
+
+start() {
+	modlib_startdaemon $DAEMON_BIN -i $DAEMON_CFGFILE -p $PID_FILE $UVNCREPEATER_CMDLINE &
+}
+
+case $1 in
+	""|load)
+		modlib_defaults $DAEMON_CFGFILE
+		modlib_adduser $DAEMON_USER
+		modreg cgi $DAEMON "$DAEMON_LONG_NAME"
+		modreg daemon $DAEMON
+		modreg file $DAEMON uvncrepeater_ini 'uvncrepeater.ini' 0 "uvncrepeater_ini"
+
+		modlib_start $UVNCREPEATER_ENABLED
+		;;
+	unload)
+		modunreg file $DAEMON
+		modunreg daemon $DAEMON
+		modunreg cgi $DAEMON
+		modlib_stop
+		;;
+	start)
+		modlib_start
+		;;
+	stop)
+		modlib_stop
+		;;
+	restart)
+		modlib_restart
+		;;
+	status)
+		modlib_status
+		;;
+	*)
+		echo "Usage: $0 [load|unload|start|stop|restart|status]" 1>&2
+		exit 1
+		;;
+esac
+
+exit 0

--- a/make/pkgs/uvncrepeater/files/root/usr/lib/cgi-bin/uvncrepeater.cgi
+++ b/make/pkgs/uvncrepeater/files/root/usr/lib/cgi-bin/uvncrepeater.cgi
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+. /usr/lib/libmodcgi.sh
+
+sec_begin "$(lang de:"Starttyp" en:"Start type")"
+cgi_print_radiogroup_service_starttype "enabled" "$UVNCREPEATER_ENABLED" "" "" 0
+sec_end
+
+sec_begin "$(lang de:"Konfiguration" en:"Configuration")"
+cgi_print_textline_p "renew" "$UVNCREPEATER_CMDLINE" 55/250 "$(lang de:"Optionale Parameter" en:"Optional parameters"): "
+sec_end
+

--- a/make/pkgs/uvncrepeater/patches/100-cross_compile.patch
+++ b/make/pkgs/uvncrepeater/patches/100-cross_compile.patch
@@ -1,0 +1,39 @@
+--- Makefile.orig	2010-03-02 10:52:48.000000000 +0100
++++ Makefile	2010-03-02 10:53:48.000000000 +0100
+@@ -1,27 +1,28 @@
++CC=g++
+ CFLAGS=-Wall
+ repeater: repeater.o repeaterproc.o openbsd_stringfuncs.o iniparser.o readini.o repeaterutil.o repeaterevents.o
+-	g++ $(CFLAGS) -o repeater repeater.o repeaterproc.o openbsd_stringfuncs.o iniparser.o readini.o repeaterutil.o repeaterevents.o
++	$(CC) $(CFLAGS) -o repeater repeater.o repeaterproc.o openbsd_stringfuncs.o iniparser.o readini.o repeaterutil.o repeaterevents.o
+ 
+ repeater.o: repeater.cpp
+-	g++ $(CFLAGS) -c repeater.cpp
++	$(CC) $(CFLAGS) -c repeater.cpp
+ 
+ repeaterproc.o: repeaterproc.cpp
+-	g++ $(CFLAGS) -c repeaterproc.cpp
++	$(CC) $(CFLAGS) -c repeaterproc.cpp
+ 
+ openbsd_stringfuncs.o: openbsd_stringfuncs.cpp
+-	g++ $(CFLAGS) -c openbsd_stringfuncs.cpp
++	$(CC) $(CFLAGS) -c openbsd_stringfuncs.cpp
+ 
+ iniparser.o: iniparser.cpp
+-	g++ $(CFLAGS) -c iniparser.cpp
++	$(CC) $(CFLAGS) -c iniparser.cpp
+ 
+ readini.o: readini.cpp
+-	g++ $(CFLAGS) -c readini.cpp
++	$(CC) $(CFLAGS) -c readini.cpp
+ 
+ repeaterutil.o: repeaterutil.cpp
+-	g++ $(CFLAGS) -c repeaterutil.cpp
++	$(CC) $(CFLAGS) -c repeaterutil.cpp
+ 
+ repeaterevents.o: repeaterevents.cpp
+-	g++ $(CFLAGS) -c repeaterevents.cpp
++	$(CC) $(CFLAGS) -c repeaterevents.cpp
+ 
+ clean:
+ 	rm -f *.o repeater

--- a/make/pkgs/uvncrepeater/patches/101-freetz_compat.patch
+++ b/make/pkgs/uvncrepeater/patches/101-freetz_compat.patch
@@ -1,0 +1,104 @@
+--- repeater.cpp	2025-02-03 12:16:17.705526421 +0100
++++ repeater.cpp.patched	2025-02-04 01:48:53.846832558 +0100
+@@ -1970,6 +1970,46 @@
+         fatal("dropRootPrivileges(): getpwnam() failed\n");    
+ }
+ 
++// Function to daemonize the process
++void daemonize() {
++    pid_t pid = fork();
++    if (pid < 0) {
++        exit(EXIT_FAILURE); // Fork failed
++    }
++    if (pid > 0) {
++        exit(EXIT_SUCCESS); // Parent exits, child continues
++    }
++
++    // Create a new session and become session leader
++    if (setsid() < 0) {
++        exit(EXIT_FAILURE);
++    }
++
++    // Fork again to ensure it's not a session leader
++    pid = fork();
++    if (pid < 0) {
++        exit(EXIT_FAILURE);
++    }
++    if (pid > 0) {
++        exit(EXIT_SUCCESS); // First child exits, second child continues
++    }
++
++    // Change working directory to root to avoid blocking unmounts
++    chdir("/");
++
++    // Set file permissions mask
++    umask(0);
++
++    // Close standard file descriptors
++    close(STDIN_FILENO);
++    close(STDOUT_FILENO);
++    close(STDERR_FILENO);
++
++    // Redirect standard file descriptors to /dev/null
++    open("/dev/null", O_RDONLY);  // stdin
++    open("/dev/null", O_WRONLY);  // stdout
++    open("/dev/null", O_WRONLY);  // stderr
++}
+ 
+ int main(int argc, char **argv)
+ {
+@@ -1982,9 +2022,9 @@
+     //ctrl+c signal handler
+     struct sigaction saInt;
+ 
+-    //ini file default
+-    char defaultIniFilePathAndName[] = "/etc/uvncrepeater.ini";
+-    char tmpBuf[MAX_PATH];
++    bool runAsDaemon = false;
++    char iniFilePath[MAX_PATH] = "/etc/uvncrepeater.ini";
++    char pidFilePath[MAX_PATH] = "";
+     bool memoryOk;
+ 
+     //Startup event
+@@ -1995,10 +2035,37 @@
+     
+     fprintf(stderr, "UltraVnc Linux Repeater version %s\n", REPEATER_VERSION);
+     
+-    //Read parameters from ini file
+-    strlcpy(tmpBuf, (argc >= 2) ? argv[1] : defaultIniFilePathAndName, MAX_PATH);
+-    if (false == readIniFile(tmpBuf)) {
+-        debug(LEVEL_1, "main(): ini file (%s) read error, using defaults\n", tmpBuf);
++    // Parse command-line arguments
++    for (int i = 1; i < argc; i++) {
++        if (strcmp(argv[i], "-i") == 0 && i + 1 < argc) {
++            strncpy(iniFilePath, argv[++i], MAX_PATH - 1);
++        } else if (strcmp(argv[i], "-p") == 0 && i + 1 < argc) {
++            strncpy(pidFilePath, argv[++i], MAX_PATH - 1);
++        } else if (strcmp(argv[i], "-d") == 0) {
++            runAsDaemon = true;  // Enable daemon mode
++        }
++    }
++
++    // Daemonize if requested
++    if (runAsDaemon) {
++        daemonize();
++    }
++
++    // Write PID to file if specified
++    if (strlen(pidFilePath) > 0) {
++        FILE *pidFile = fopen(pidFilePath, "w");
++        if (pidFile) {
++            fprintf(pidFile, "%d\n", getpid());
++            fclose(pidFile);
++        } else {
++            fprintf(stderr, "Error: Could not write PID file %s\n", pidFilePath);
++            return 1;
++        }
++    }
++
++    // Read parameters from ini file
++    if (false == readIniFile(iniFilePath)) {
++        debug(LEVEL_1, "main(): ini file (%s) read error, using defaults\n", iniFilePath);
+     }
+     listInitializationValues();
+ 

--- a/make/pkgs/uvncrepeater/uvncrepeater.mk
+++ b/make/pkgs/uvncrepeater/uvncrepeater.mk
@@ -1,0 +1,38 @@
+$(call PKG_INIT_BIN, 014)
+$(PKG)_SOURCE:=repeater$($(PKG)_VERSION).zip
+$(PKG)_SITE:=https://web.archive.org/web/20151001044013/http://koti.mbnet.fi/jtko/uvncrepeater
+$(PKG)_DIR=$(SOURCE_DIR)/Ver014
+$(PKG)_BINARY:=$($(PKG)_DIR)/repeater
+$(PKG)_TARGET_BINARY:=$($(PKG)_DEST_DIR)/usr/bin/uvncrepeater
+$(PKG)_HASH:=f22f2c5a283c7ff636a649b4b2e0de7409537eaa
+
+### WEBSITE:=https://uvnc.com/products/ultravnc-repeater.html
+### MANPAGE:=https://uvnc.com/docs/ultravnc-repeater.html
+### SUPPORT:=manfred-mueller
+
+$(PKG)_BINARY:=$($(PKG)_DIR)/repeater
+$(PKG)_TARGET_BINARY:=$($(PKG)_DEST_DIR)/usr/bin/uvncrepeater
+
+$(PKG_SOURCE_DOWNLOAD)
+$(PKG_UNPACKED)
+$(PKG_CONFIGURED_NOP)
+
+$($(PKG)_BINARY): $($(PKG)_DIR)/.configured
+	$(SUBMAKE) -C $(UVNCREPEATER_DIR) \
+                CC="$(TARGET_CC)" \
+                CFLAGS="$(TARGET_CFLAGS)"
+
+
+$($(PKG)_TARGET_BINARY): $($(PKG)_BINARY)
+	$(INSTALL_BINARY_STRIP)
+
+$(pkg)-precompiled: $($(PKG)_TARGET_BINARY)
+
+
+$(pkg)-clean:
+	-$(SUBMAKE) -C $(UVNCREPEATER_DIR) clean
+
+$(pkg)-uninstall:
+	$(RM) $(UVNCREPEATER_TARGET_BINARY)
+
+$(PKG_FINISH)


### PR DESCRIPTION
Der Repeater agiert wie ein Proxy, der zwischen dem Server und dem Betrachter sitzt. Alle Daten für die Sitzung werden durch den Repeater geleitet, was bedeutet, dass der Betrachter und der Server sich beide hinter einer NAT-Firewall befinden können, ohne dass man sich um die Weiterleitung von Ports oder etwas anderes kümmern muss (vorausgesetzt, der Repeater ist sowohl für den Betrachter als auch für den Server sichtbar).

Als Basis diente ein Paketfund im [ip-phone-Forum](https://www.ip-phone-forum.de/threads/ultravnc-repeater.211025/post-1497829)