### PR TITLE
collectd: flush cache on shutdown

### DIFF
--- a/make/pkgs/collectd/files/root/etc/init.d/rc.collectd
+++ b/make/pkgs/collectd/files/root/etc/init.d/rc.collectd
@@ -3,6 +3,10 @@
 DAEMON=collectd
 DAEMON_CONFIG="/tmp/flash/collectd/collectd.conf"
 DAEMON_LONG_NAME="Collectd daemon"
+# On long cache timeouts, the flush operation may take longer than 10 seconds.
+# To accommodate this, we increase the STOP_RETRY_COUNT to avoid premature termination.
+# see https://github.com/Freetz-NG/freetz-ng/pull/1108
+STOP_RETRY_COUNT=24
 . /etc/init.d/modlibrc
 
 config() {

--- a/make/pkgs/mod/files/root/etc/init.d/modlibrc
+++ b/make/pkgs/mod/files/root/etc/init.d/modlibrc
@@ -276,7 +276,7 @@ stop() {
 	case "$1" in
 		0)
 			local id=$(cat "$PID_FILE" 2>/dev/null)
-			local cnt=9
+			local cnt=${STOP_RETRY_COUNT:-9}
 			while [ $cnt -ge 0 ] && kill -0 $id 2>/dev/null; do
 				kill $id 2>/dev/null
 				local retval=$?


### PR DESCRIPTION
collectd seems **not** to flush its cache on SIGINT, SIGTERM, so send signal SIGUSR1 in `stop_post` before. 

https://www.collectd.org/documentation/manpages/collectd.html
```
SIGNALS
collectd accepts the following signals:

    SIGINT, SIGTERM

    These signals cause collectd to shut down all plugins and terminate.

    SIGUSR1

    This signal causes collectd to signal all plugins to flush data from internal caches. E. g. the rrdtool plugin will write all pending data to the RRD files. This is the same as using the FLUSH -1 command of the unixsock plugin.
```