### PR TITLE
modlibrc: STOP_RETRY_COUNT renamed to SIGTERM_WAIT_SECS

### DIFF
--- a/make/pkgs/collectd/files/root/etc/init.d/rc.collectd
+++ b/make/pkgs/collectd/files/root/etc/init.d/rc.collectd
@@ -6,7 +6,7 @@ DAEMON_LONG_NAME="Collectd daemon"
 # On long cache timeouts, the flush operation may take longer than 10 seconds.
 # To accommodate this, we increase the STOP_RETRY_COUNT to avoid premature termination.
 # see https://github.com/Freetz-NG/freetz-ng/pull/1108
-STOP_RETRY_COUNT=24
+STOP_RETRY_COUNT=25
 . /etc/init.d/modlibrc
 
 config() {

--- a/make/pkgs/collectd/files/root/etc/init.d/rc.collectd
+++ b/make/pkgs/collectd/files/root/etc/init.d/rc.collectd
@@ -6,7 +6,7 @@ DAEMON_LONG_NAME="Collectd daemon"
 # On long cache timeouts, the flush operation may take longer than 10 seconds.
 # To accommodate this, we increase the STOP_RETRY_COUNT to avoid premature termination.
 # see https://github.com/Freetz-NG/freetz-ng/pull/1108
-STOP_RETRY_COUNT=25
+SIGTERM_WAIT_SECS=25
 . /etc/init.d/modlibrc
 
 config() {

--- a/make/pkgs/mod/files/root/etc/init.d/modlibrc
+++ b/make/pkgs/mod/files/root/etc/init.d/modlibrc
@@ -18,7 +18,7 @@
 # DAEMON_CHECK          <empty>                                daemon(s) to check with pidof for running-status
 # PID_FILE              /var/run/${DAEMON_BIN}.pid             pid-file for DAEMON
 # DAEMON_CFGFILE        /tmp/flash/${DAEMON}/${DAEMON}.cfg     config file for the daemon (typically used by startdaemon)
-# STOP_RETRY_COUNT      10                                     seconds to maximum wait during stop() until SIGKILL is used
+# SIGTERM_WAIT_SECS     10                                     seconds to maximum wait during stop() until SIGKILL is used
 
 . /var/env.mod.daemon
 . /etc/init.d/loglibrc
@@ -31,7 +31,7 @@
 : ${DAEMON_SVC:=$DAEMON}
 : ${PID_FILE:=/var/run/${DAEMON_BIN}.pid}
 : ${DAEMON_CFGFILE:=/tmp/flash/${DAEMON}/${DAEMON}.cfg}
-: ${STOP_RETRY_COUNT:=10}
+: ${SIGTERM_WAIT_SECS:=10}
 
 # config:
 #   dummy function if "config" is not defined in parent-script
@@ -278,7 +278,7 @@ stop() {
 	case "$1" in
 		0)
 			local id=$(cat "$PID_FILE" 2>/dev/null)
-			local cnt="${STOP_RETRY_COUNT}"
+			local cnt="${SIGTERM_WAIT_SECS}"
 			while [ $cnt -gt 0 ] && kill -0 $id 2>/dev/null; do
 				kill $id 2>/dev/null
 				local retval=$?


### PR DESCRIPTION
Danke für  0e774e9c0decb4aa23f5a8ef5d1be399b2450826, ich wollte diese Änderungen nicht vornehmen, da ich meine Änderung minimal invasiv halten wollte. So ist es jetzt aber sauberer und dokumentiert. 

Ich habe der Variablen noch einen besseren Namen gegeben, da es eigentlich um die Zeit (SECS) und nicht die Anzahl (COUNT) geht. 
