### PR TITLE
github-actions: `cache_clear` env

### DIFF
--- a/.github/workflows/generate_juis-recache.yml
+++ b/.github/workflows/generate_juis-recache.yml
@@ -78,10 +78,11 @@ jobs:
       - name: cache_clear
         env:
           ACTIONS_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+          CACHE_KEY: ${{ steps.key.outputs.key }}
         run: |
           ASSETS="$(curl -s  -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches")"
-          ASSID="$(echo "$ASSETS" | grep -B7 "\"key\": *\"${{ steps.key.outputs.key }}\"" | sed -rn 's/ *"id": *([^,]*),*/\1/p')"
-          curl -sL -X DELETE -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches/$ASSID" && echo "Deleted ASSID=$ASSID ..." || true
+          ASSID="$(echo "$ASSETS" | grep -B7 "\"key\": *\"${CACHE_KEY}\"" | sed -rn 's/ *"id": *([^,]*),*/\1/p')"
+          curl -sL -X DELETE -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches/$ASSID" && echo "Deleted ASSID=${ASSID:-null} ..." || true
       - name: cache_save
         uses: actions/cache/save@v4
         if: always()

--- a/.github/workflows/generate_juis.yml
+++ b/.github/workflows/generate_juis.yml
@@ -78,10 +78,11 @@ jobs:
       - name: cache_clear
         env:
           ACTIONS_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+          CACHE_KEY: ${{ steps.key.outputs.key }}
         run: |
           ASSETS="$(curl -s  -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches")"
-          ASSID="$(echo "$ASSETS" | grep -B7 "\"key\": *\"${{ steps.key.outputs.key }}\"" | sed -rn 's/ *"id": *([^,]*),*/\1/p')"
-          curl -sL -X DELETE -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches/$ASSID" && echo "Deleted ASSID=$ASSID ..." || true
+          ASSID="$(echo "$ASSETS" | grep -B7 "\"key\": *\"${CACHE_KEY}\"" | sed -rn 's/ *"id": *([^,]*),*/\1/p')"
+          curl -sL -X DELETE -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches/$ASSID" && echo "Deleted ASSID=${ASSID:-null} ..." || true
       - name: cache_save
         uses: actions/cache/save@v4
         if: always()

--- a/.github/workflows/make_freetz.yml
+++ b/.github/workflows/make_freetz.yml
@@ -164,9 +164,10 @@ jobs:
         if: github.repository == 'freetz-ng/freetz-ng'
         env:
           ACTIONS_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+          CACHE_KEY: ${{ env.CACHE_KEY }}
         run: |
           ASSETS="$(curl -s  -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches")"
-          ASSID="$(echo "$ASSETS" | grep -B7 "\"key\": *\"${{ env.CACHE_KEY }}\"" | sed -rn 's/ *"id": *([^,]*),*/\1/p')"
+          ASSID="$(echo "$ASSETS" | grep -B7 "\"key\": *\"${CACHE_KEY}\"" | sed -rn 's/ *"id": *([^,]*),*/\1/p')"
           curl -sL -X DELETE -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches/$ASSID" && echo "Deleted ASSID=${ASSID:-null} ..." || true
       - name: cache_save
         uses: actions/cache/save@v4

--- a/.github/workflows/make_matrix52.yml
+++ b/.github/workflows/make_matrix52.yml
@@ -164,9 +164,10 @@ jobs:
         if: github.repository == 'freetz-ng/freetz-ng'
         env:
           ACTIONS_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+          CACHE_KEY: ${{ env.CACHE_KEY }}
         run: |
           ASSETS="$(curl -s  -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches")"
-          ASSID="$(echo "$ASSETS" | grep -B7 "\"key\": *\"${{ env.CACHE_KEY }}\"" | sed -rn 's/ *"id": *([^,]*),*/\1/p')"
+          ASSID="$(echo "$ASSETS" | grep -B7 "\"key\": *\"${CACHE_KEY}\"" | sed -rn 's/ *"id": *([^,]*),*/\1/p')"
           curl -sL -X DELETE -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches/$ASSID" && echo "Deleted ASSID=${ASSID:-null} ..." || true
       - name: cache_save
         uses: actions/cache/save@v4

--- a/.github/workflows/make_matrix55.yml
+++ b/.github/workflows/make_matrix55.yml
@@ -164,9 +164,10 @@ jobs:
         if: github.repository == 'freetz-ng/freetz-ng'
         env:
           ACTIONS_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+          CACHE_KEY: ${{ env.CACHE_KEY }}
         run: |
           ASSETS="$(curl -s  -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches")"
-          ASSID="$(echo "$ASSETS" | grep -B7 "\"key\": *\"${{ env.CACHE_KEY }}\"" | sed -rn 's/ *"id": *([^,]*),*/\1/p')"
+          ASSID="$(echo "$ASSETS" | grep -B7 "\"key\": *\"${CACHE_KEY}\"" | sed -rn 's/ *"id": *([^,]*),*/\1/p')"
           curl -sL -X DELETE -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches/$ASSID" && echo "Deleted ASSID=${ASSID:-null} ..." || true
       - name: cache_save
         uses: actions/cache/save@v4

--- a/.github/workflows/make_matrix60.yml
+++ b/.github/workflows/make_matrix60.yml
@@ -164,9 +164,10 @@ jobs:
         if: github.repository == 'freetz-ng/freetz-ng'
         env:
           ACTIONS_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+          CACHE_KEY: ${{ env.CACHE_KEY }}
         run: |
           ASSETS="$(curl -s  -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches")"
-          ASSID="$(echo "$ASSETS" | grep -B7 "\"key\": *\"${{ env.CACHE_KEY }}\"" | sed -rn 's/ *"id": *([^,]*),*/\1/p')"
+          ASSID="$(echo "$ASSETS" | grep -B7 "\"key\": *\"${CACHE_KEY}\"" | sed -rn 's/ *"id": *([^,]*),*/\1/p')"
           curl -sL -X DELETE -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches/$ASSID" && echo "Deleted ASSID=${ASSID:-null} ..." || true
       - name: cache_save
         uses: actions/cache/save@v4

--- a/.github/workflows/make_matrix62.yml
+++ b/.github/workflows/make_matrix62.yml
@@ -164,9 +164,10 @@ jobs:
         if: github.repository == 'freetz-ng/freetz-ng'
         env:
           ACTIONS_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+          CACHE_KEY: ${{ env.CACHE_KEY }}
         run: |
           ASSETS="$(curl -s  -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches")"
-          ASSID="$(echo "$ASSETS" | grep -B7 "\"key\": *\"${{ env.CACHE_KEY }}\"" | sed -rn 's/ *"id": *([^,]*),*/\1/p')"
+          ASSID="$(echo "$ASSETS" | grep -B7 "\"key\": *\"${CACHE_KEY}\"" | sed -rn 's/ *"id": *([^,]*),*/\1/p')"
           curl -sL -X DELETE -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches/$ASSID" && echo "Deleted ASSID=${ASSID:-null} ..." || true
       - name: cache_save
         uses: actions/cache/save@v4

--- a/.github/workflows/make_matrix65.yml
+++ b/.github/workflows/make_matrix65.yml
@@ -164,9 +164,10 @@ jobs:
         if: github.repository == 'freetz-ng/freetz-ng'
         env:
           ACTIONS_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+          CACHE_KEY: ${{ env.CACHE_KEY }}
         run: |
           ASSETS="$(curl -s  -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches")"
-          ASSID="$(echo "$ASSETS" | grep -B7 "\"key\": *\"${{ env.CACHE_KEY }}\"" | sed -rn 's/ *"id": *([^,]*),*/\1/p')"
+          ASSID="$(echo "$ASSETS" | grep -B7 "\"key\": *\"${CACHE_KEY}\"" | sed -rn 's/ *"id": *([^,]*),*/\1/p')"
           curl -sL -X DELETE -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches/$ASSID" && echo "Deleted ASSID=${ASSID:-null} ..." || true
       - name: cache_save
         uses: actions/cache/save@v4

--- a/.github/workflows/make_matrix68.yml
+++ b/.github/workflows/make_matrix68.yml
@@ -164,9 +164,10 @@ jobs:
         if: github.repository == 'freetz-ng/freetz-ng'
         env:
           ACTIONS_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+          CACHE_KEY: ${{ env.CACHE_KEY }}
         run: |
           ASSETS="$(curl -s  -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches")"
-          ASSID="$(echo "$ASSETS" | grep -B7 "\"key\": *\"${{ env.CACHE_KEY }}\"" | sed -rn 's/ *"id": *([^,]*),*/\1/p')"
+          ASSID="$(echo "$ASSETS" | grep -B7 "\"key\": *\"${CACHE_KEY}\"" | sed -rn 's/ *"id": *([^,]*),*/\1/p')"
           curl -sL -X DELETE -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches/$ASSID" && echo "Deleted ASSID=${ASSID:-null} ..." || true
       - name: cache_save
         uses: actions/cache/save@v4

--- a/.github/workflows/make_matrix69.yml
+++ b/.github/workflows/make_matrix69.yml
@@ -164,9 +164,10 @@ jobs:
         if: github.repository == 'freetz-ng/freetz-ng'
         env:
           ACTIONS_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+          CACHE_KEY: ${{ env.CACHE_KEY }}
         run: |
           ASSETS="$(curl -s  -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches")"
-          ASSID="$(echo "$ASSETS" | grep -B7 "\"key\": *\"${{ env.CACHE_KEY }}\"" | sed -rn 's/ *"id": *([^,]*),*/\1/p')"
+          ASSID="$(echo "$ASSETS" | grep -B7 "\"key\": *\"${CACHE_KEY}\"" | sed -rn 's/ *"id": *([^,]*),*/\1/p')"
           curl -sL -X DELETE -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches/$ASSID" && echo "Deleted ASSID=${ASSID:-null} ..." || true
       - name: cache_save
         uses: actions/cache/save@v4

--- a/.github/workflows/make_matrix70.yml
+++ b/.github/workflows/make_matrix70.yml
@@ -164,9 +164,10 @@ jobs:
         if: github.repository == 'freetz-ng/freetz-ng'
         env:
           ACTIONS_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+          CACHE_KEY: ${{ env.CACHE_KEY }}
         run: |
           ASSETS="$(curl -s  -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches")"
-          ASSID="$(echo "$ASSETS" | grep -B7 "\"key\": *\"${{ env.CACHE_KEY }}\"" | sed -rn 's/ *"id": *([^,]*),*/\1/p')"
+          ASSID="$(echo "$ASSETS" | grep -B7 "\"key\": *\"${CACHE_KEY}\"" | sed -rn 's/ *"id": *([^,]*),*/\1/p')"
           curl -sL -X DELETE -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches/$ASSID" && echo "Deleted ASSID=${ASSID:-null} ..." || true
       - name: cache_save
         uses: actions/cache/save@v4

--- a/.github/workflows/make_matrix71.yml
+++ b/.github/workflows/make_matrix71.yml
@@ -164,9 +164,10 @@ jobs:
         if: github.repository == 'freetz-ng/freetz-ng'
         env:
           ACTIONS_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+          CACHE_KEY: ${{ env.CACHE_KEY }}
         run: |
           ASSETS="$(curl -s  -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches")"
-          ASSID="$(echo "$ASSETS" | grep -B7 "\"key\": *\"${{ env.CACHE_KEY }}\"" | sed -rn 's/ *"id": *([^,]*),*/\1/p')"
+          ASSID="$(echo "$ASSETS" | grep -B7 "\"key\": *\"${CACHE_KEY}\"" | sed -rn 's/ *"id": *([^,]*),*/\1/p')"
           curl -sL -X DELETE -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches/$ASSID" && echo "Deleted ASSID=${ASSID:-null} ..." || true
       - name: cache_save
         uses: actions/cache/save@v4

--- a/.github/workflows/make_matrix72.yml
+++ b/.github/workflows/make_matrix72.yml
@@ -164,9 +164,10 @@ jobs:
         if: github.repository == 'freetz-ng/freetz-ng'
         env:
           ACTIONS_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+          CACHE_KEY: ${{ env.CACHE_KEY }}
         run: |
           ASSETS="$(curl -s  -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches")"
-          ASSID="$(echo "$ASSETS" | grep -B7 "\"key\": *\"${{ env.CACHE_KEY }}\"" | sed -rn 's/ *"id": *([^,]*),*/\1/p')"
+          ASSID="$(echo "$ASSETS" | grep -B7 "\"key\": *\"${CACHE_KEY}\"" | sed -rn 's/ *"id": *([^,]*),*/\1/p')"
           curl -sL -X DELETE -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches/$ASSID" && echo "Deleted ASSID=${ASSID:-null} ..." || true
       - name: cache_save
         uses: actions/cache/save@v4

--- a/.github/workflows/make_matrix75.yml
+++ b/.github/workflows/make_matrix75.yml
@@ -164,9 +164,10 @@ jobs:
         if: github.repository == 'freetz-ng/freetz-ng'
         env:
           ACTIONS_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+          CACHE_KEY: ${{ env.CACHE_KEY }}
         run: |
           ASSETS="$(curl -s  -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches")"
-          ASSID="$(echo "$ASSETS" | grep -B7 "\"key\": *\"${{ env.CACHE_KEY }}\"" | sed -rn 's/ *"id": *([^,]*),*/\1/p')"
+          ASSID="$(echo "$ASSETS" | grep -B7 "\"key\": *\"${CACHE_KEY}\"" | sed -rn 's/ *"id": *([^,]*),*/\1/p')"
           curl -sL -X DELETE -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches/$ASSID" && echo "Deleted ASSID=${ASSID:-null} ..." || true
       - name: cache_save
         uses: actions/cache/save@v4

--- a/.github/workflows/make_matrix80.yml
+++ b/.github/workflows/make_matrix80.yml
@@ -164,9 +164,10 @@ jobs:
         if: github.repository == 'freetz-ng/freetz-ng'
         env:
           ACTIONS_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+          CACHE_KEY: ${{ env.CACHE_KEY }}
         run: |
           ASSETS="$(curl -s  -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches")"
-          ASSID="$(echo "$ASSETS" | grep -B7 "\"key\": *\"${{ env.CACHE_KEY }}\"" | sed -rn 's/ *"id": *([^,]*),*/\1/p')"
+          ASSID="$(echo "$ASSETS" | grep -B7 "\"key\": *\"${CACHE_KEY}\"" | sed -rn 's/ *"id": *([^,]*),*/\1/p')"
           curl -sL -X DELETE -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches/$ASSID" && echo "Deleted ASSID=${ASSID:-null} ..." || true
       - name: cache_save
         uses: actions/cache/save@v4


### PR DESCRIPTION
Dies fügt unter `cache_clear` `CACHE_KEY` als seperate env hinzu.
Dadurch lässt sich bei den abschnitt `cache_clear` den Teil mit den `CACHE_KEY` als lokale env angenehmer bearbeiten ohne an der `bash`-Zeile direkt die parameter anpassen zu müssen. (genauso wie bereits auch `ACTIONS_TOKEN`)