### PR TITLE
fixes https://github.com/Freetz-NG/freetz-ng/discussions/1136

### DIFF
--- a/make/pkgs/dropbear/patches/004-pointer-to-array-fix.patch
+++ b/make/pkgs/dropbear/patches/004-pointer-to-array-fix.patch
@@ -1,0 +1,20 @@
+--- src/compat.c
++++ src/compat.c
+@@ -288,7 +288,7 @@
+ 		uint64_t v;
+ 		uint8_t bytes[8];
+ 	} out;
+-	STORE64L(inp, &out.bytes);
++	STORE64L(inp, out.bytes);
+ 	return out.v;
+ }
+ 
+@@ -301,7 +301,7 @@
+ 		uint32_t v;
+ 		uint8_t bytes[4];
+ 	} out;
+-	STORE32L(inp, &out.bytes);
++	STORE32L(inp, out.bytes);
+ 	return out.v;
+ }
+ 


### PR DESCRIPTION
Beim Kompilieren mit GCC 4.6.4 tritt ein Typinkompatibilitätsfehler in `htole64` auf. Der Grund ist, dass `&out.bytes` an `STORE64L` übergeben wird, wodurch ein `uint8_t (*)[8]` (Zeiger auf ein Array) statt des erwarteten `uint8_t*` entsteht. "Neuere" GCC-Versionen wie 4.8.5 tolerieren dies, ältere nicht. 

Die Übergabe von `&out.bytes` wurde durch `out.bytes` ersetzt, um die automatische Umwandlung des Arrays in einen Zeiger zu nutzen. Dadurch sollte der Code sowohl mit älteren als auch mit neueren GCC-Versionen kompatibel sein.  

Getestet mit 
- 7570/W920V (gcc-4.6.4, hier trat der Fehler auf, kompiliert nur mit dem Patch) und 
- 7390 (gcc-4.8.5, hier trat der Fehler **nicht** auf, kompiliert mit und ohne dem Patch)

Behebt das in https://github.com/Freetz-NG/freetz-ng/discussions/1136 beschriebene Problem