### PR TITLE
actions(make_bump): add workflow_dispatch inputs for make_bump

### DIFF
--- a/.github/workflows/make_bump.yml
+++ b/.github/workflows/make_bump.yml
@@ -7,7 +7,12 @@ on:
       - 'docs/CHANGELOG.md'
       - 'make/pkgs/'
       - 'make/libs/'
-# workflow_dispatch:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "FREETZ_PACKAGE - input in lowercase (e.g. dropbear)"
+        required: true
+        default: ""
 
 concurrency:
   group: ${{ github.workflow }}
@@ -146,8 +151,12 @@ jobs:
       - name: generate
         id: generate
         run: |
-          PKG="$(git log --format=%B -n1 ${{ github.sha }} | sed -nr 's/^(add|bump|fix|test) ([^ ,]*).*/\2/p')"
-          [ -z "$PKG" ] && echo "No add, bump, fix or test." && exit
+          if [ -n "${{ github.event.inputs.bump }}" ]; then
+            PKG="${{ github.event.inputs.bump }}"
+          else
+            PKG="$(git log --format=%B -n1 ${{ github.sha }} | sed -nr 's/^(add|bump|fix|test) ([^ ,]*).*/\2/p')"
+            [ -z "$PKG" ] && echo "No add, bump, fix or test." && exit
+          fi
           PKG="$(echo "$PKG" | tr '[:lower:]' '[:upper:]')"
           pkg="$(echo "$PKG" | tr '[:upper:]' '[:lower:]')"
           echo "pkg=$pkg" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Dies fügt ein Input für workflow_dispatch ein mit den die Möglichkeit besteht, das wenn man ein Paket z.b. git testen möchte das das nun auch über workflow_dispatch ohne Test commits funktionieren.

**Edit**:
- Commited man z.b. weitere `bump *` commits, werden diese weiterhin ganz normal gebaut und der workflow_dispatch hat keinen einfluss daran.
- Der Input bei workflow_dispatch greift nur wenn man per workflow_dispatch diesen Workflow ausführt und dort einen Input z.b. `git` oder `unbound` eingibt.