### PR TITLE
actions: increase max-parallel jobs to 10 in make_bump workflow

### DIFF
--- a/.github/workflows/make_bump.yml
+++ b/.github/workflows/make_bump.yml
@@ -25,6 +25,7 @@ jobs:
 #     image: freetzng/firmware
       image: ghcr.io/freetz-ng/firmware
     strategy:
+      max-parallel: 10
       fail-fast: false
       matrix:
         fritz: [ 


### PR DESCRIPTION
Aus: https://github.com/Freetz-NG/freetz-ng/pull/1146

> Die Anzahl der parallelen Jobs einer(!) Action begrenzen, auf zb 10. Die Action make_bump hat 30 Jobs, und während die läuft werden alle anderen Actions blockiert und müssen warten, zb nach einem "bump" dauert es recht lange bis die "docs" automatisch aktualisiert werden und der link-commentar erstellt wird. Es laufen eh nicht alle 30 parallel, Github hat schon bei 20 oder 25 eine Grenze

Dies ist möglich durch `max-parallel` unter `strategy`

> Links die Liste in den Actions (zb https://github.com/Freetz-NG/freetz-ng/actions/runs/13911454287), ist "rot" oder "grün". Ich hätte aber gerne noch manuell ein "gelb". Gibt es das? Es soll für den Fall sein dass für eine Toolchain das Paket gar nicht gebaut werden kann und soll

Warscheinlich nicht. Siehe: https://stackoverflow.com/questions/74907704/is-there-a-github-actions-warning-state