### PR TITLE
actions: update job name in make_bump workflow to include bump input

### DIFF
--- a/.github/workflows/make_bump.yml
+++ b/.github/workflows/make_bump.yml
@@ -60,7 +60,7 @@ jobs:
           "_6690        _FIRMWARE_07_5X",
           "_6670        _FIRMWARE_08_0X",
          ]
-    name: ${{ matrix.fritz }}${{ github.event.inputs.bump == '' && '' || ' - ${ github.event.inputs.bump }' }}
+    name: ${{ matrix.fritz }}${{ github.event.inputs.bump != '' && ' - ' }}${{ github.event.inputs.bump }}
     runs-on: ubuntu-latest
 #   if: github.repository == 'freetz-ng/freetz-ng'
 

--- a/.github/workflows/make_bump.yml
+++ b/.github/workflows/make_bump.yml
@@ -60,6 +60,7 @@ jobs:
           "_6690        _FIRMWARE_07_5X",
           "_6670        _FIRMWARE_08_0X",
          ]
+    name: ${{ matrix.fritz }}${{ github.event.inputs.bump == '' && '' || ' - ${{ github.event.inputs.bump }}' }}
     runs-on: ubuntu-latest
 #   if: github.repository == 'freetz-ng/freetz-ng'
 

--- a/.github/workflows/make_bump.yml
+++ b/.github/workflows/make_bump.yml
@@ -60,7 +60,7 @@ jobs:
           "_6690        _FIRMWARE_07_5X",
           "_6670        _FIRMWARE_08_0X",
          ]
-    name: ${{ matrix.fritz }}${{ github.event.inputs.bump != '' && ' - ' }}${{ github.event.inputs.bump }}
+    name: ${{ matrix.fritz }}${{ github.event.inputs.bump != '' && ' - ' || '' }}${{ github.event.inputs.bump }}
     runs-on: ubuntu-latest
 #   if: github.repository == 'freetz-ng/freetz-ng'
 

--- a/.github/workflows/make_bump.yml
+++ b/.github/workflows/make_bump.yml
@@ -60,7 +60,7 @@ jobs:
           "_6690        _FIRMWARE_07_5X",
           "_6670        _FIRMWARE_08_0X",
          ]
-    name: ${{ matrix.fritz }}${{ github.event.inputs.bump == '' && '' || ' - ${{ github.event.inputs.bump }}' }}
+    name: ${{ matrix.fritz }}${{ github.event.inputs.bump == '' && '' || ' - ${ github.event.inputs.bump }' }}
     runs-on: ubuntu-latest
 #   if: github.repository == 'freetz-ng/freetz-ng'
 


### PR DESCRIPTION
Dies fügt einen namen für die Build Jobs hinzu mit der möglichkeit das `github.event.inputs.bump` als teil des Namens ausgegeben wird.
refs: https://github.com/Freetz-NG/freetz-ng/pull/1146#issuecomment-2734301443