### PR TITLE
icon in freetz menu entry

### DIFF
--- a/patches/scripts/191-add_responsive_webmenu.sh
+++ b/patches/scripts/191-add_responsive_webmenu.sh
@@ -2,7 +2,7 @@
 echo1 "adding responsive webmenu link"
 
 modsed \
-  '/liveTv/{N;N;N;N;s/^ *\([^\[]*\).*\n.*\n.*\n *\["pos"\] = -65\n *} or nil\(.*\)/&\n\1\["freetz"\] = {\n\["txt"\] = "Freetz",\n\["lnk"\] = "\/cgi-bin\/freetz_status",\n\["pos"\] = -69,\n\["img"\] = "fritzbox"\n} or nil\2/}' \
+  '/liveTv/{N;N;N;N;s/^ *\([^\[]*\).*\n.*\n.*\n *\["pos"\] = -65\n *} or nil\(.*\)/&\n\1\["freetz"\] = {\n\["txt"\] = "Freetz",\n\["lnk"\] = "\/cgi-bin\/freetz_status",\n\["pos"\] = -69,\n\["icon"\] = "fritzbox"\n} or nil\2/}' \
   "${MENU_DATA_LUA}" \
   "freetz_status"
 

--- a/patches/scripts/191-add_responsive_webmenu.sh
+++ b/patches/scripts/191-add_responsive_webmenu.sh
@@ -1,8 +1,16 @@
 [ "$FREETZ_WEBIF_LINK" == "y" ] || return 0
 echo1 "adding responsive webmenu link"
 
-modsed \
+if [ "$FREETZ_AVM_VERSION_07_2X" == "y" ]; then
+  modsed \
+  '/liveTv/{N;N;N;N;s/^ *\([^\[]*\).*\n.*\n.*\n *\["pos"\] = -65\n *} or nil\(.*\)/&\n\1\["freetz"\] = {\n\["txt"\] = "Freetz",\n\["lnk"\] = "\/cgi-bin\/freetz_status",\n\["pos"\] = -69\n} or nil\2/}' \
+  "${MENU_DATA_LUA}" \
+  "freetz_status"
+fi
+
+if [ "$FREETZ_AVM_VERSION_07_5X_MIN" == "y" ]; then
+  modsed \
   '/liveTv/{N;N;N;N;s/^ *\([^\[]*\).*\n.*\n.*\n *\["pos"\] = -65\n *} or nil\(.*\)/&\n\1\["freetz"\] = {\n\["txt"\] = "Freetz",\n\["lnk"\] = "\/cgi-bin\/freetz_status",\n\["pos"\] = -69,\n\["icon"\] = "fritzbox"\n} or nil\2/}' \
   "${MENU_DATA_LUA}" \
   "freetz_status"
-
+fi

--- a/patches/scripts/191-add_responsive_webmenu.sh
+++ b/patches/scripts/191-add_responsive_webmenu.sh
@@ -1,7 +1,7 @@
 [ "$FREETZ_WEBIF_LINK" == "y" ] || return 0
 echo1 "adding responsive webmenu link"
 
-if [ "$FREETZ_AVM_VERSION_07_2X" == "y" ]; then
+if [ "$FREETZ_AVM_VERSION_07_2X_MAX" == "y" ]; then
   modsed \
   '/liveTv/{N;N;N;N;s/^ *\([^\[]*\).*\n.*\n.*\n *\["pos"\] = -65\n *} or nil\(.*\)/&\n\1\["freetz"\] = {\n\["txt"\] = "Freetz",\n\["lnk"\] = "\/cgi-bin\/freetz_status",\n\["pos"\] = -69\n} or nil\2/}' \
   "${MENU_DATA_LUA}" \

--- a/patches/scripts/191-add_responsive_webmenu.sh
+++ b/patches/scripts/191-add_responsive_webmenu.sh
@@ -2,7 +2,7 @@
 echo1 "adding responsive webmenu link"
 
 modsed \
-  '/liveTv/{N;N;N;N;s/^ *\([^\[]*\).*\n.*\n.*\n *\["pos"\] = -65\n *} or nil\(.*\)/&\n\1\["freetz"\] = {\n\["txt"\] = "Freetz",\n\["lnk"\] = "\/cgi-bin\/freetz_status",\n\["pos"\] = -69\n} or nil\2/}' \
+  '/liveTv/{N;N;N;N;s/^ *\([^\[]*\).*\n.*\n.*\n *\["pos"\] = -65\n *} or nil\(.*\)/&\n\1\["freetz"\] = {\n\["txt"\] = "Freetz",\n\["lnk"\] = "\/cgi-bin\/freetz_status",\n\["pos"\] = -69,\n\["img"\] = "fritzbox"\n} or nil\2/}' \
   "${MENU_DATA_LUA}" \
   "freetz_status"
 


### PR DESCRIPTION
Dies fügt ein Icon hinzu mit den der Menüeintrag "Freetz" ebenfalls ein Icon erhält.
Wie man da ein freetz-ng spezifisches Logo da einbetten kann, weiß ich aktuell nicht.

Ergebnis mit "fritzbox"-Icon:

| Vorher | Nachher |
|:---:|:---:|
| ![Screenshot (2)](https://github.com/user-attachments/assets/411a0b1e-0d37-42b0-a23b-c2571484e9fb) | ![Screenshot (1)](https://github.com/user-attachments/assets/8d2c8c15-ddc6-4b47-b745-21083be75665) |

> [!NOTE]
> Es gibt eine Datei die `icons.config.js`. Darin stehen einige Icons die zur auswahl stehen könnten.