### PR TITLE
news: Add infos about bo**atrix and its accessibility

### DIFF
--- a/docs/NEWS.md
+++ b/docs/NEWS.md
@@ -1,5 +1,13 @@
 # NEWS
 
+ * __[2025-05-01](#2025-05-01)__<a id='2025-05-01'></a><br>
+   boxmatrix.info ist aktuell nicht erreichbar.<br>
+   Vermutlich ist dies schon seit April 2025 der Fall.<br>
+   Zum Glück gibt es die Wayback Machine, mit der man sich die letzte noch funktionierende Kopie von boxmatrix.info anschauen kann.<br>
+   Siehe<br>
+    - [BoxMatrix - Archivkopie (März 2025)](https://web.archive.org/web/20250310024601/https://boxmatrix.info/wiki/BoxMatrix)<br>
+    - [BoxMatrix - Originallink](https://boxmatrix.info/wiki/BoxMatrix)<br>
+
  * __[2025-04-21](#2025-04-21)__<a id='2025-04-21'></a><br>
    Warnung vor GCC 15! Damit kann momentan nicht alles funktionierend compiliert werden.<br>
    Obwohl diese Version noch nicht veröffentlich wurde ist sie in `Fedora 42` bereits Standard.<br>


### PR DESCRIPTION
Dies fügt Infos zu boxmatrix und der aktuellen erreichbarkeit in die `NEWS.md` ein.

-----

Aktuell wenn man boxmatrix.info aufruft, kommt folgendes (Warscheinlich schon seit April 2025):
![Screenshot 2025-05-01 at 09-44-02 ](https://github.com/user-attachments/assets/d470f1f4-919c-49a8-8051-3f605e24af8e)

Mit einer Archivkopie aus der Wayback Maschine kommt man noch an die zuletzt funktionierende Kopie und kann sich dies anschauen.
web.archive.org/web/20250310024601/boxmatrix.info/wiki/BoxMatrix

[EDIT: BM Links umgewandelt]