### PR TITLE
Add python-pycryptodome

### DIFF
--- a/make/pkgs/python-pycryptodome/Config.in
+++ b/make/pkgs/python-pycryptodome/Config.in
@@ -1,0 +1,8 @@
+config FREETZ_PACKAGE_PYTHON_PYCRYPTODOME
+    bool "PyCryptodome"
+    depends on FREETZ_PACKAGE_PYTHON
+    default n
+    help
+		PyCryptodome is a self-contained Python package of low-level 
+		cryptographic primitives.
+		It's a fork of PyCrypto that has been enhanced for modern systems.

--- a/make/pkgs/python-pycryptodome/python-pycryptodome.mk
+++ b/make/pkgs/python-pycryptodome/python-pycryptodome.mk
@@ -1,0 +1,32 @@
+$(call PKG_INIT_BIN, 3.22.0)
+$(PKG)_SOURCE:=pycryptodome-$($(PKG)_VERSION).tar.gz
+$(PKG)_SITE:=https://files.pythonhosted.org/packages/source/p/pycryptodome
+$(PKG)_HASH:=fd7ab568b3ad7b77c908d7c3f7e167ec5a8f035c64ff74f10d47a4edd043d723
+
+$(PKG)_TARGET_BINARY:=$($(PKG)_DEST_DIR)$(PYTHON_SITE_PKG_DIR)/Crypto/Hash/_SHA256.so
+
+$(PKG)_DEPENDS_ON += python gmp
+
+$(PKG)_REBUILD_SUBOPTS += FREETZ_PACKAGE_PYTHON_STATIC
+
+$(PKG_SOURCE_DOWNLOAD)
+$(PKG_UNPACKED)
+$(PKG_CONFIGURED_NOP)
+
+$($(PKG)_TARGET_BINARY): $($(PKG)_DIR)/.configured
+	$(call Build/PyMod/PKG, PYTHON_PYCRYPTODOME, , PYTHONHOME=$(HOST_TOOLS_DIR)/usr)
+	touch -c $@
+
+$(pkg):
+
+$(pkg)-precompiled: $($(PKG)_TARGET_BINARY)
+
+$(pkg)-clean:
+	$(RM) -r $(PYTHON_PYCRYPTODOME_DIR)/build
+
+$(pkg)-uninstall:
+	$(RM) -r \
+		$(PYTHON_PYCRYPTODOME_DEST_DIR)$(PYTHON_SITE_PKG_DIR)/Crypto \
+		$(PYTHON_PYCRYPTODOME_DEST_DIR)$(PYTHON_SITE_PKG_DIR)/pycryptodome-*.egg-info
+
+$(PKG_FINISH)

--- a/make/pkgs/python/Config.in
+++ b/make/pkgs/python/Config.in
@@ -339,6 +339,7 @@ if FREETZ_PACKAGE_PYTHON
 		source "make/pkgs/python-pyrrd/Config.in"
 		source "make/pkgs/python-pyserial/Config.in"
 		source "make/pkgs/python-yenc/Config.in"
+		source "make/pkgs/python-pycryptodome/Config.in"
 	endmenu
 
 endif # FREETZ_PACKAGE_PYTHON


### PR DESCRIPTION
This library is tested to support AES CCM and AES GCM (that are not available with the older PyCrypto).

Ref https://github.com/Freetz-NG/freetz-ng/discussions/947

-----------------------

This PR is useful to understand how to add a new Python module that requires *wheel* installation. As freetz-NG does not include a compiler in the target environment, a library requiring wheel must be installed and cross-compiled in the development environment and then merged in the package set.

`$(PKG_CONFIGURED_NOP)` means that `./configure` is not necessary and shall not be run (usual case when installing a Python module).

The wheel compilation is done here:

```
$($(PKG)_TARGET_BINARY): $($(PKG)_DIR)/.configured
        $(call Build/PyMod/PKG, PYTHON_PYCRYPTODOME, , PYTHONHOME=$(HOST_TOOLS_DIR)/usr)
        touch -c $@

Arguments of Build/PyMod/PKG:

```

`Build/PyMod/PKG` is described [here](https://github.com/Freetz-NG/freetz-ng/blob/master/make/pkgs/python/python-module-macros.mk.in): it runs `python setup.py install` and performs the cross-compilation of the wheel.

- PYTHON_PYCRYPTODOME (the first argument) is the package name.
- The subsequent (second) argument is left empty because no additional arguments are needed in our case to `setup.py`.
- The third argument sets additional variables. In our case, `PYTHONHOME=$(HOST_TOOLS_DIR)/usr` is crucial to avoid architecture mismatch errors (e.g., "wrong ELF class: ELFCLASS32") during the execution of `setup.py`, like this one:

```
Traceback (most recent call last):
  File "./setup.py", line 37, in <module>
    import shutil
  File "/home/$USER/freetz-ng/toolchain/build/mips_gcc-13.3.0_uClibc-1.0.52-nptl_kernel-4.9/mips-linux-uclibc/usr/lib/python2.7/shutil.py", line 12, in <module>
    import collections
  File "/home/$USER/freetz-ng/toolchain/build/mips_gcc-13.3.0_uClibc-1.0.52-nptl_kernel-4.9/mips-linux-uclibc/usr/lib/python2.7/collections.py", line 20, in <module>
    from _collections import deque, defaultdict
ImportError: /home/$USER/freetz-ng/toolchain/build/mips_gcc-13.3.0_uClibc-1.0.52-nptl_kernel-4.9/mips-linux-uclibc/usr/lib/python2.7/lib-dynload/_collections.so: wrong ELF class: ELFCLASS32
make[1]: *** [make/pkgs/python-pycryptodome/python-pycryptodome.mk:17: packages/target-mips_gcc-13.3.0_uClibc-1.0.52-nptl_kernel-4.9/python-pycryptodome-3.22.0/root/usr/lib/python2.7/site-packages/Crypto/Hash/_SHA256.so] Error 1
make: *** [Makefile:48: envira] Terminated
```

The PYTHONHOME environment variable tells Python where to look for its standard libraries. When building cross-platform packages, it's critical that the build scripts run using the host's Python environment while generating code for the target platform. By setting PYTHONHOME to point to your host tools directory, you force Python to use the compatible host system's Python libraries instead of the cross-compiled libraries (MIPS in this case).

In the case of this pycryptodome module, `setup.py` imports *shutil*, *collections* and in turn *_collections* (`from _collections import deque, defaultdict`) which loads a shared object (*_collections.so*) that nedds to be of the same architecture of the dev/build system.

To test the compilation: `make python-pycryptodome-recompile` (where `python-pycryptodome` is the package name). It automatically downloads the package.

In normal conditions, it always performs the compilation.

To test the package download: `make python-pycryptodome-source`

Notice that `$(PKG)_HASH` (like `$(PKG)_HASH:=fd7ab568b3ad7b77c908d7c3f7e167ec5a8f035c64ff74f10d47a4edd043d723`) is required to get a successful download. Otherwise the correct HASH is printed out (as `SHA256:=`: copy it to `$(PKG)_HASH:=`)

To remove the build directory: `make python-pycryptodome-clean`

The above command is useful for discovering the download directory (the one containing `setup.py`) and the compilation directory (`build`).

To remove the target files: `make python-pycryptodome-uninstall`

Sometimes it is needed to patch the downloaded files before compiling them: `make package-name-unpacked` and `make package-name-autofix` allow to test this.

Use `make help` to get the description of all options.