### PR TITLE
Add python-cffi

### DIFF
--- a/make/pkgs/python-cffi/Config.in
+++ b/make/pkgs/python-cffi/Config.in
@@ -1,0 +1,7 @@
+config FREETZ_PACKAGE_PYTHON_CFFI
+    bool "Cffi"
+    depends on FREETZ_PACKAGE_PYTHON
+    default n
+    help
+		A Foreign Function Interface package for calling C libraries from Python.
+		http://cffi.readthedocs.io/

--- a/make/pkgs/python-cffi/python-cffi.mk
+++ b/make/pkgs/python-cffi/python-cffi.mk
@@ -1,0 +1,52 @@
+$(call PKG_INIT_BIN,1.15.1)
+$(PKG)_SOURCE:=cffi-$($(PKG)_VERSION).tar.gz
+$(PKG)_SITE:=https://files.pythonhosted.org/packages/source/c/cffi
+$(PKG)_HASH:=d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9
+
+$(PKG)_TARGET_BINARY:=$($(PKG)_DEST_DIR)$(PYTHON_SITE_PKG_DIR)/_cffi_backend.so
+
+$(PKG)_DEPENDS_ON += python gmp
+
+$(PKG)_REBUILD_SUBOPTS += FREETZ_PACKAGE_PYTHON_STATIC
+
+$(PKG_SOURCE_DOWNLOAD)
+$(PKG_UNPACKED)
+$(PKG_CONFIGURED_NOP)
+
+$($(PKG)_TARGET_BINARY): $($(PKG)_DIR)/.configured
+	$(HOST_TOOLS_DIR)/usr/bin/python2 -m ensurepip || true
+	$(HOST_TOOLS_DIR)/usr/bin/python2 -m pip install --no-cache-dir setuptools
+	$(call Build/PyMod/PKG, PYTHON_CFFI, , CFLAGS="$(TARGET_CFLAGS) -I$(TARGET_TOOLCHAIN_STAGING_DIR)/include/python2.7" CPPFLAGS="$(TARGET_CFLAGS) -I$(TARGET_TOOLCHAIN_STAGING_DIR)/include/python2.7" PYTHON_INCDIR="$(TARGET_TOOLCHAIN_STAGING_DIR)/include/python2.7" TARGET_ARCH_BE="$(TARGET_ARCH_BE)" PYTHONHOME=$(HOST_TOOLS_DIR)/usr)
+	touch -c $@
+
+$(pkg):
+
+$(pkg)-precompiled: $($(PKG)_TARGET_BINARY)
+
+$(pkg)-clean:
+	$(RM) -r $(PYTHON_CFFI_DIR)/build
+
+$(pkg)-uninstall:
+	$(RM) -r \
+		$(PYTHON_CFFI_DEST_DIR)$(PYTHON_SITE_PKG_DIR)/cffi \
+		$(PYTHON_CFFI_DEST_DIR)$(PYTHON_SITE_PKG_DIR)/_cffi_backend.so \
+		$(PYTHON_CFFI_DEST_DIR)$(PYTHON_SITE_PKG_DIR)/cffi-*.egg-info
+
+# Show all used variables for this package
+$(pkg)-variables:
+	@echo "(PKG): PYTHON_CFFI"
+	@echo "(PKG)_VERSION: $(PYTHON_CFFI_VERSION)"
+	@echo "(PKG)_SOURCE: $(PYTHON_CFFI_SOURCE)"
+	@echo "(PKG)_SITE: $(PYTHON_CFFI_SITE)"
+	@echo "(PKG)_HASH: $(PYTHON_CFFI_HASH)"
+	@echo "(PKG)_TARGET_BINARY: $(PYTHON_CFFI_TARGET_BINARY)"
+	@echo "(PKG)_DEST_DIR: $(PYTHON_CFFI_DEST_DIR)"
+	@echo "(PKG)_DIR: $(PYTHON_CFFI_DIR)"
+	@echo "(PKG)_DEPENDS_ON: $(PYTHON_CFFI_DEPENDS_ON)"
+	@echo "(PKG)_REBUILD_SUBOPTS: $(PYTHON_CFFI_REBUILD_SUBOPTS)"
+	@echo "PYTHON_SITE_PKG_DIR: $(PYTHON_SITE_PKG_DIR)"
+	@echo "HOST_TOOLS_DIR: $(HOST_TOOLS_DIR)"
+	@echo "TARGET_TOOLCHAIN_STAGING_DIR: $(TARGET_TOOLCHAIN_STAGING_DIR)"
+	@echo "PYTHON_MAJOR_VERSION: $(PYTHON_MAJOR_VERSION)"
+
+$(PKG_FINISH)

--- a/make/pkgs/python/Config.in
+++ b/make/pkgs/python/Config.in
@@ -340,6 +340,7 @@ if FREETZ_PACKAGE_PYTHON
 		source "make/pkgs/python-pyserial/Config.in"
 		source "make/pkgs/python-yenc/Config.in"
 		source "make/pkgs/python-pycryptodome/Config.in"
+		source "make/pkgs/python-cffi/Config.in"
 	endmenu
 
 endif # FREETZ_PACKAGE_PYTHON


### PR DESCRIPTION
Add **python-cffi**, a Foreign Function Interface package for calling C libraries from Python.

Documentation: http://cffi.readthedocs.io/

Python shall be externalized on Freetz-NG.

After the system build, before using *cffi*, you also need *curl*, *pip*, *pycparser*.

To install *pip* on Freetz-NG:

```
curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
python get-pip.py --user
python -m pip install --user -r requirements.txt
```

To install the *pycparser* Python module:

```
python -m pip install pycparser
```

The `ffibuilder.compile()` method of the *cffi* module will not work because Freetz-NG does not include a compiler. To overcome this issue, in a temporary directory of the build system create a file named `mips-linux-uclibc-gcc.c` including this code.

```c

int main(int argc, char *argv[]) {
    printf("\n------ Executed command:\n");
    for (int i = 0; i < argc; i++) {
      if (i > 0) printf(" ");
        printf("%s", argv[i]);
    }
    printf("\n");
    printf("------ (end)\n\n");
    return 0;
}
```

Cross-compile it (on the build system):

```
/home/$USER/freetz-ng/toolchain/build/mips_gcc-13.3.0_uClibc-1.0.52-nptl_kernel-4.9/mips-linux-uclibc/bin/mips-linux-uclibc-gcc -fno-strict-aliasing -march=34kc -mtune=34kc -msoft-float -Ofast -pipe -Wa,--trap -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -Wl,-I/usr/lib/freetz/ld-uClibc.so.1 -DNDEBUG -fno-inline -fPIC -I/usr/include/python2.7 -I/home/$USER/freetz-ng/toolchain/build/mips_gcc-13.3.0_uClibc-1.0.52-nptl_kernel-4.9/mips-linux-uclibc/include/python2.7 mips-linux-uclibc-gcc.c -o mips-linux-uclibc-gcc
```

Move the obtained executable code to Freetz-NG:

```
mkdir -p /home/$USER/freetz-ng/toolchain/build/mips_gcc-13.3.0_uClibc-1.0.52-nptl_kernel-4.9/mips-linux-uclibc/bin/
mv mips-linux-uclibc-gcc /home/$USER/freetz-ng/toolchain/build/mips_gcc-13.3.0_uClibc-1.0.52-nptl_kernel-4.9/mips-linux-uclibc/bin/mips-linux-uclibc-gcc
```

Then, after running `ffibuilder.compile()`, you need to move the created files to the build system and execute the commands shown by the above program.

To each, command, you shoud add:

```
-I/home/$USER/freetz-ng/toolchain/build/mips_gcc-13.3.0_uClibc-1.0.52-nptl_kernel-4.9/mips-linux-uclibc/include/python2.7
```

The obtained shared object shall be moved back to Freetz-NG and imported in Python.

------------------

Example using [API Mode, calling C sources instead of a compiled library](https://cffi.readthedocs.io/en/stable/overview.html#api-mode-calling-c-sources-instead-of-a-compiled-library)

- create *pi.c* following instructions
- create *pi.h* following instructions
- create *pi_extension_build.py* following instructions
- Build the extension following instructions.

Obtained printout:

```
>>> ffibuilder.compile(verbose=True)
generating ./_pi.c
(already up-to-date)
the current directory is '/var/media/myfreetz'
running build_ext
building '_pi' extension
/home/$USER/freetz-ng/toolchain/build/mips_gcc-13.3.0_uClibc-1.0.52-nptl_kernel-4.9/mips-linux-uclibc/bin/mips-linux-uclibc-gcc -fno-strict-aliasing -march=34kc -mtune=34kc -msoft-float -Ofast -pipe -Wa,--trap -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -Wl,-I/usr/lib/freetz/ld-uClibc.so.1 -DNDEBUG -fno-inline -fPIC -I/usr/include/python2.7 -c _pi.c -o ./_pi.o

------ Executed command:
/home/$USER/freetz-ng/toolchain/build/mips_gcc-13.3.0_uClibc-1.0.52-nptl_kernel-4.9/mips-linux-uclibc/bin/mips-linux-uclibc-gcc -fno-strict-aliasing -march=34kc -mtune=34kc -msoft-float -Ofast -pipe -Wa,--trap -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -Wl,-I/usr/lib/freetz/ld-uClibc.so.1 -DNDEBUG -fno-inline -fPIC -I/usr/include/python2.7 -c _pi.c -o ./_pi.o
------ (end)

/home/$USER/freetz-ng/toolchain/build/mips_gcc-13.3.0_uClibc-1.0.52-nptl_kernel-4.9/mips-linux-uclibc/bin/mips-linux-uclibc-gcc -fno-strict-aliasing -march=34kc -mtune=34kc -msoft-float -Ofast -pipe -Wa,--trap -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -Wl,-I/usr/lib/freetz/ld-uClibc.so.1 -DNDEBUG -fno-inline -fPIC -I/usr/include/python2.7 -c pi.c -o ./pi.o

------ Executed command:
/home/$USER/freetz-ng/toolchain/build/mips_gcc-13.3.0_uClibc-1.0.52-nptl_kernel-4.9/mips-linux-uclibc/bin/mips-linux-uclibc-gcc -fno-strict-aliasing -march=34kc -mtune=34kc -msoft-float -Ofast -pipe -Wa,--trap -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -Wl,-I/usr/lib/freetz/ld-uClibc.so.1 -DNDEBUG -fno-inline -fPIC -I/usr/include/python2.7 -c pi.c -o ./pi.o
------ (end)

/home/$USER/freetz-ng/toolchain/build/mips_gcc-13.3.0_uClibc-1.0.52-nptl_kernel-4.9/mips-linux-uclibc/bin/mips-linux-uclibc-gcc -shared ./_pi.o ./pi.o -L/usr/lib -lm -lpython2.7 -o ./_pi.so

------ Executed command:
/home/$USER/freetz-ng/toolchain/build/mips_gcc-13.3.0_uClibc-1.0.52-nptl_kernel-4.9/mips-linux-uclibc/bin/mips-linux-uclibc-gcc -shared ./_pi.o ./pi.o -L/usr/lib -lm -lpython2.7 -o ./_pi.so
------ (end)

'/var/media/myfreetz/_pi.so'

```

Move `pi.c`, `_pi.c`, `pi.h` to a temporary directory of the build system.

On the build system, run the cross-compiler basing on the above istructions:

```
/home/$USER/freetz-ng/toolchain/build/mips_gcc-13.3.0_uClibc-1.0.52-nptl_kernel-4.9/mips-linux-uclibc/bin/mips-linux-uclibc-gcc -fno-strict-aliasing -march=34kc -mtune=34kc -msoft-float -Ofast -pipe -Wa,--trap -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -Wl,-I/usr/lib/freetz/ld-uClibc.so.1 -DNDEBUG -fno-inline -fPIC -I/usr/include/python2.7 -I/home/$USER/freetz-ng/toolchain/build/mips_gcc-13.3.0_uClibc-1.0.52-nptl_kernel-4.9/mips-linux-uclibc/include/python2.7 -c _pi.c -o ./_pi.o

/home/$USER/freetz-ng/toolchain/build/mips_gcc-13.3.0_uClibc-1.0.52-nptl_kernel-4.9/mips-linux-uclibc/bin/mips-linux-uclibc-gcc -fno-strict-aliasing -march=34kc -mtune=34kc -msoft-float -Ofast -pipe -Wa,--trap -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -Wl,-I/usr/lib/freetz/ld-uClibc.so.1 -DNDEBUG -fno-inline -fPIC -I/usr/include/python2.7 -c pi.c -o ./pi.o

/home/$USER/freetz-ng/toolchain/build/mips_gcc-13.3.0_uClibc-1.0.52-nptl_kernel-4.9/mips-linux-uclibc/bin/mips-linux-uclibc-gcc -fno-strict-aliasing -march=34kc -mtune=34kc -msoft-float -Ofast -pipe -Wa,--trap -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -Wl,-I/usr/lib/freetz/ld-uClibc.so.1 -DNDEBUG -fno-inline -fPIC -I/usr/include/python2.7 -I/home/$USER/freetz-ng/toolchain/build/mips_gcc-13.3.0_uClibc-1.0.52-nptl_kernel-4.9/mips-linux-uclibc/include/python2.7 -c _pi.c -o ./_pi.o
```

Notice the addition of `-I/home/$USER/freetz-ng/toolchain/build/mips_gcc-13.3.0_uClibc-1.0.52-nptl_kernel-4.9/mips-linux-uclibc/include/python2.7`.

Move *_pi.so* to Freetz-NG.

The following program will run without errors.

```
python
from _pi.lib import pi_approx
approx = pi_approx(10)
assert str(approx).startswith("3.")

approx = pi_approx(10000)
assert str(approx).startswith("3.1")
```