### PR TITLE
action(make_kernel): make FOS input as choice

### DIFF
--- a/.github/workflows/make_kernel.yml
+++ b/.github/workflows/make_kernel.yml
@@ -10,9 +10,25 @@ on:
   workflow_dispatch:
     inputs:
       fos:
-        description: "FOS: 04_XX,05_2X,05_5X,06_0X,06_2X,06_5X,06_8X,06_9X,07_0X,07_1X,07_2X,07_5X,08_0X,08_2X_LABOR"
+        description: "FOS Version to build"
         required: true
         default: "08_2X_LABOR"
+        type: choice
+        options:
+          - "04_XX"
+          - "05_2X"
+          - "05_5X"
+          - "06_0X"
+          - "06_2X"
+          - "06_5X"
+          - "06_8X"
+          - "06_9X"
+          - "07_0X"
+          - "07_1X"
+          - "07_2X"
+          - "07_5X"
+          - "08_0X"
+          - "08_2X_LABOR"
 
 concurrency:
   group: ${{ github.workflow }}


### PR DESCRIPTION
Dies macht der input bei workflow_dispatch als auswahl, was das eingeben der FOS Version erleichtert.

![Bild1](https://github.com/user-attachments/assets/c5729061-34e3-490e-92dd-4a4ffbb823dc)
