### PR TITLE
actions: Update Actions bot user & email [skip ci]

### DIFF
--- a/.github/workflows/avm_ftp.yml
+++ b/.github/workflows/avm_ftp.yml
@@ -57,8 +57,8 @@ jobs:
           git pull
           git add .
           git status
-          git config --local user.name github-actions
-          git config --local user.email github-actions@github.com
+          git config --local user.name github-actions[bot]
+          git config --local user.email github-actions[bot]@users.noreply.github.com
           git diff --cached --quiet && exit 0 || git commit -m "ftp: automatic update"
           git config --local credential.helper '!x() { echo "password=$GITHUB_TOKEN"; };x'
           git push origin $GITHUB_REF_NAME

--- a/.github/workflows/avm_juis-recache.yml
+++ b/.github/workflows/avm_juis-recache.yml
@@ -73,8 +73,8 @@ jobs:
           git pull
           git add .
           git status
-          git config --local user.name github-actions
-          git config --local user.email github-actions@github.com
+          git config --local user.name github-actions[bot]
+          git config --local user.email github-actions[bot]@users.noreply.github.com
           git diff --cached --quiet && exit 0 || git commit -m "juis: automatic update"
           git config --local credential.helper '!x() { echo "password=$GITHUB_TOKEN"; };x'
           git push origin $GITHUB_REF_NAME

--- a/.github/workflows/avm_juis.yml
+++ b/.github/workflows/avm_juis.yml
@@ -73,8 +73,8 @@ jobs:
           git pull
           git add .
           git status
-          git config --local user.name github-actions
-          git config --local user.email github-actions@github.com
+          git config --local user.name github-actions[bot]
+          git config --local user.email github-actions[bot]@users.noreply.github.com
           git diff --cached --quiet && exit 0 || git commit -m "juis: automatic update"
           git config --local credential.helper '!x() { echo "password=$GITHUB_TOKEN"; };x'
           git push origin $GITHUB_REF_NAME

--- a/.github/workflows/avm_osp.yml
+++ b/.github/workflows/avm_osp.yml
@@ -57,8 +57,8 @@ jobs:
           git pull
           git add .
           git status
-          git config --local user.name github-actions
-          git config --local user.email github-actions@github.com
+          git config --local user.name github-actions[bot]
+          git config --local user.email github-actions[bot]@users.noreply.github.com
           git diff --cached --quiet && exit 0 || git commit -m "osp: automatic update"
           git config --local credential.helper '!x() { echo "password=$GITHUB_TOKEN"; };x'
           git push origin $GITHUB_REF_NAME

--- a/.github/workflows/dl-hosttools.yml
+++ b/.github/workflows/dl-hosttools.yml
@@ -112,8 +112,8 @@ jobs:
 #         git pull
 #         git add .
 #         git status
-#         git config --local user.name github-actions
-#         git config --local user.email github-actions@github.com
+#         git config --local user.name github-actions[bot]
+#         git config --local user.email github-actions[bot]@users.noreply.github.com
 #         git diff --cached --quiet && exit 0 || git commit -m "dl-hosttools: automatic update"
 #         git config --local credential.helper '!x() { echo "password=$GITHUB_TOKEN"; };x'
 #         git push origin $GITHUB_REF_NAME

--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -69,8 +69,8 @@ jobs:
           git pull || exit
           git add .
           git status
-          git config --local user.name github-actions
-          git config --local user.email github-actions@github.com
+          git config --local user.name github-actions[bot]
+          git config --local user.email github-actions[bot]@users.noreply.github.com
           git diff --cached --quiet && exit 0 || git commit -m "docs: automatic update"
           git config --local credential.helper '!x() { echo "password=$GITHUB_TOKEN"; };x'
           git push origin $GITHUB_REF_NAME

--- a/.github/workflows/postcommit_diffs.yml
+++ b/.github/workflows/postcommit_diffs.yml
@@ -57,8 +57,8 @@ jobs:
           git pull
           git add .
           git status
-          git config --local user.name github-actions
-          git config --local user.email github-actions@github.com
+          git config --local user.name github-actions[bot]
+          git config --local user.email github-actions[bot]@users.noreply.github.com
           git diff --cached --quiet && exit 0 || git commit -m "diffs: automatic update"
           git config --local credential.helper '!x() { echo "password=$GITHUB_TOKEN"; };x'
           git push origin $GITHUB_REF_NAME

--- a/.github/workflows/postcommit_img.yml
+++ b/.github/workflows/postcommit_img.yml
@@ -77,8 +77,8 @@ jobs:
           git pull
           git add config/.img/
           git status
-          git config --local user.name github-actions
-          git config --local user.email github-actions@github.com
+          git config --local user.name github-actions[bot]
+          git config --local user.email github-actions[bot]@users.noreply.github.com
           git diff --cached --quiet && exit 0 || git commit -m "img: automatic update"
           git config --local credential.helper '!x() { echo "password=$GITHUB_TOKEN"; };x'
           git push origin $GITHUB_REF_NAME

--- a/.github/workflows/postcommit_kos.yml
+++ b/.github/workflows/postcommit_kos.yml
@@ -56,8 +56,8 @@ jobs:
           git pull
           git add .
           git status
-          git config --local user.name github-actions
-          git config --local user.email github-actions@github.com
+          git config --local user.name github-actions[bot]
+          git config --local user.email github-actions[bot]@users.noreply.github.com
           git diff --cached --quiet && exit 0 || git commit -m "kos: automatic update"
           git config --local credential.helper '!x() { echo "password=$GITHUB_TOKEN"; };x'
           git push origin $GITHUB_REF_NAME


### PR DESCRIPTION
Dies ändert die älteren GitHub Actions bot Identifikationen (Name und E-Mail) in die korrekten GitHub Actions bot Identifikationen.
Dies hat zu folge das bei commits mit den neuen Bot Identifikationen nun ein passendes Profil Icon zu sehen ist und wenn man auf das Profil Icon klickt, landet man auf die Informationsseite für Github Actions.

| Vorher | Nachher |
|:----------:|:----------:|
| ![Screenshot 2025-06-24 at 14-41-39 Commits · LizenzFass78851_fbscripts](https://github.com/user-attachments/assets/bdc01037-03f9-46e4-95a8-7941eee5d0de) | ![Screenshot 2025-06-24 at 14-41-21 Commits · LizenzFass78851_fbscripts](https://github.com/user-attachments/assets/c114a202-5e7c-4599-a950-d92930458ef7) |

> [!NOTE]
> [skip ci] steht für die Anweisung das, wenn ein Commit Workflows verändert und es steht am Ende des Commit Messages [skip ci] dann verhindert man damit des Workflows nach einer Änderung durch diesen Commit einmalig getriggert werden.
https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/skipping-workflow-runs







