### PR TITLE
Python/unnecessary/files usr/bin/pydoc3

### DIFF
--- a/make/pkgs/python3/python3-filelists.mk.in
+++ b/make/pkgs/python3/python3-filelists.mk.in
@@ -4,7 +4,7 @@ usr/lib/python$(PYTHON3_MAJOR_VERSION)/lib2to3
 usr/lib/python$(PYTHON3_MAJOR_VERSION)/lib-dynload/future_builtins.so
 usr/bin/idle
 usr/lib/python$(PYTHON3_MAJOR_VERSION)/idlelib
-usr/bin/pydoc
+usr/bin/pydoc3
 usr/bin/smtpd.py
 usr/lib/python$(PYTHON3_MAJOR_VERSION)/config/config.c*
 usr/lib/python$(PYTHON3_MAJOR_VERSION)/config/install-sh


### PR DESCRIPTION
Python/unnecessary/files 
`pydoc3` anstelle von `pydoc`