### PR TITLE
docs: switch gh_page frontend to mkdocs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,15 @@ updates:
     schedule:
       interval: "daily"
 
+  - package-ecosystem: pip
+    directories: 
+      - "/.github/mkdocs/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: direct
+      - dependency-type: indirect
+    groups:
+      mkdocs-pip-dependencies:
+        patterns:
+          - "/.github/mkdocs/*"

--- a/.github/mkdocs/extra.css
+++ b/.github/mkdocs/extra.css
@@ -1,0 +1,49 @@
+/* Disable secondary navigation */
+.md-nav--secondary {
+    display: none;
+}
+.md-sidebar--secondary.md-sidebar {
+    display: none;
+}
+
+/* General styles for navigation and typeset */
+.md-nav {
+    font-size: 14px;
+    line-height: 1.4;
+}
+
+.md-nav__link {
+    display: inline-flex;
+}
+
+.md-typeset {
+    font-size: .7rem;
+    line-height: 1.5;
+}
+
+.md-typeset code,
+.md-typeset pre {
+    color: var(--code-color);
+}
+
+.text-center {
+    text-align: center !important;
+}
+
+.md-typeset table:not([class]) th {
+    color: var(--table-foreground);
+    background-color: var(--table-background);
+}
+
+[data-md-color-scheme="default"] {
+    --code-color: #532ba8;
+    --table-foreground: var(--md-default-bg-color); /* table header backgrounds */
+    --table-background: var(--md-default-fg-color--light); /* table header (text) */
+}
+
+[data-md-color-scheme="slate"] {
+    --code-color: #a47df8;
+    --md-typeset-a-color: #7c90ff; /* links */
+    --table-foreground: #a3acdf; /* table header (text) */
+    --table-background: #272e53; /* table header backgrounds */
+}

--- a/.github/mkdocs/mkdocs.yml
+++ b/.github/mkdocs/mkdocs.yml
@@ -1,0 +1,52 @@
+site_name: 'Freetz-NG Documentation'
+site_url: 'https://freetz-ng.github.io/'
+repo_url: 'https://github.com/freetz-ng/freetz-ng'
+edit_uri: '../freetz-ng/blob/master/docs/'
+copyright:
+remote_branch: gh-pages
+validation:
+  links:
+    anchors: warn
+theme:
+  name: 'material'
+  favicon: 'screenshots/000-TAG_freetz-ng.png'
+  logo: 'screenshots/000-TAG_freetz-ng.png'
+  language: 'en'
+  font:
+    text: 'Noto Sans Lisu'
+    code: 'Roboto Mono'
+  features:
+    - navigation.top
+    - navigation.instant
+    - navigation.indexes
+    - search.suggest
+    - search.highlight
+    - search.share
+    - content.action.edit
+    - content.code.copy
+  palette:
+
+    # Light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: blue grey
+      accent: blue grey
+      toggle:
+        icon: material/lightbulb-outline
+        name: Switch to dark mode
+
+    # Dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: blue grey
+      accent: blue grey
+      toggle:
+        icon: material/lightbulb
+        name: Switch to light mode
+
+extra_css:
+  - 'extra.css'
+
+plugins:
+  - search
+

--- a/.github/mkdocs/requirements.txt
+++ b/.github/mkdocs/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs==1.6.1
+mkdocs-material==9.6.15

--- a/.github/workflows/generate_pages.yml
+++ b/.github/workflows/generate_pages.yml
@@ -30,15 +30,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r .github/mkdocs/requirements.txt
       - name: Setup Pages
         uses: actions/configure-pages@v5
-      - name: Build with Jekyll
-        uses: actions/jekyll-build-pages@v1
-        with:
-          source: ./docs
-          destination: ./_site
+      - name: Build with MkDocs
+        run: mkdocs build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'site'
 
   deploy:
     environment:

--- a/README.md
+++ b/README.md
@@ -87,3 +87,53 @@ More features - less bugs!
 ### Documentation:
 See [https://freetz-ng.github.io/](https://freetz-ng.github.io/) (or [docs/](docs/README.md)).
 
+
+<details>
+  <summary>Testing your Documentation changes localy</summary
+
+When working on this repo, it is advised that you review your changes locally before committing them. The `mkdocs serve` command can be used to live preview your changes (as you type) on your local machine.
+
+Please make sure you fork the repo and change the clone URL in the example below for your fork:
+
+- Linux Mint / Ubuntu 20.04 LTS / 23.10 and later:
+    - Preparations (only required once):
+
+    ```bash
+    git clone https://github.com/YOUR-USERNAME/freetz-ng
+    cd freetz-ng
+    sudo apt install python3-pip python3-venv
+    python3 -m venv .venv
+    source .venv/bin/activate
+    pip3 install -r .github/mkdocs/requirements.txt
+    ```
+
+    - Enter the virtual environment (if exited):
+
+    ```bash
+    source .venv/bin/activate
+    ```
+
+    - Running the docs server:
+
+    ```bash
+    mkdocs serve --dev-addr 0.0.0.0:8000
+    ```
+
+- Fedora Linux instructions (tested on Fedora Linux 28):
+    - Preparations (only required once):
+
+    ```bash
+    git clone https://github.com/YOUR-USERNAME/freetz-ng
+    cd freetz-ng
+    pip install --user -r .github/mkdocs/requirements.txt
+    ```
+
+    - Running the docs server:
+
+    ```bash
+    mkdocs serve --dev-addr 0.0.0.0:8000
+    ```
+
+After these commands, the current branch is accessible through your favorite browser at <http://localhost:8000>
+
+</details>

--- a/docs/extra.css
+++ b/docs/extra.css
@@ -1,0 +1,1 @@
+../.github/mkdocs/extra.css

--- a/docs/ftp/generate.sh
+++ b/docs/ftp/generate.sh
@@ -32,7 +32,7 @@ echo -e "$CATS" | grep -v ^$ | while read c cat; do
 		new="${line%%/*}"
 		[ "$old" != "$new" ] && echo " * $new/" && old="$new"
 		file="${line#$new/}" ; file="${file//\/fritz.os\//:}" ; file="${file//\/recover\//-recover:}" ; kind="${file%%:*}" ; file="${file##*:}"
-		echo "   - ${kind//%20/ }: [${file//%20/ }](https://$SERVER/$c/$line)"
+		echo "    - ${kind//%20/ }: [${file//%20/ }](https://$SERVER/$c/$line)"
 	done
 done
 ) | sed 's/_-/-/' > $PARENT/docs/ftp/README.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,1 @@
+./.github/mkdocs/mkdocs.yml


### PR DESCRIPTION
Dies stellt die Darstellung der Webseite von dem Standard gh_page zu einem gh_page, was mit mkdocs angepasst werden kann.
Auch designtechnisch ist damit auch viel möglich.

| Vorher | Nachher |
|:-:|:-:|
| <img width="1663" height="1567" alt="Screenshot 2025-07-14 at 17-53-58 Welcome to Freetz-NG Freetz-NG" src="https://github.com/user-attachments/assets/e19d18b1-f845-4161-b77f-17d114536db7" /> | <img width="1663" height="1639" alt="Screenshot 2025-07-15 at 16-56-55 Freetz-NG Documentation" src="https://github.com/user-attachments/assets/4307b9e1-5b14-4df9-825c-ece88c6ceeae" />  |