### PR TITLE
dependabot: remove scanning for pip dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,16 +6,3 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-
-  - package-ecosystem: pip
-    directories: 
-      - "/.github/mkdocs/"
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-type: direct
-      - dependency-type: indirect
-    groups:
-      mkdocs-pip-dependencies:
-        patterns:
-          - "/.github/mkdocs/*"


### PR DESCRIPTION
Durch https://github.com/Freetz-NG/freetz-ng/commit/017e97c06def7658a5e8da11472579039accea9b ist die durch https://github.com/Freetz-NG/freetz-ng/pull/1195 hinzugefügte änderung für dependabot nicht mehr notwendig.