### PR TITLE
mkdocs(footer): add copyright notice & link to github

### DIFF
--- a/.github/mkdocs/mkdocs.yml
+++ b/.github/mkdocs/mkdocs.yml
@@ -46,6 +46,10 @@ theme:
 
 extra:
   generator: false
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/freetz-ng
+      name: GitHub
 
 extra_css:
   - 'extra.css'

--- a/.github/mkdocs/mkdocs.yml
+++ b/.github/mkdocs/mkdocs.yml
@@ -2,7 +2,8 @@ site_name: 'Freetz-NG Documentation'
 site_url: 'https://freetz-ng.github.io/'
 repo_url: 'https://github.com/freetz-ng/freetz-ng'
 edit_uri: '../freetz-ng/blob/master/docs/'
-copyright:
+copyright: |
+  Copyright Freetz-NG. Licensed under <a href="https://github.com/Freetz-NG/freetz-ng/raw/refs/heads/master/COPYING" target="_blank" rel="noopener noreferrer">GPL-2.0</a>
 remote_branch: gh-pages
 validation:
   links:


### PR DESCRIPTION
Dies fügt bei der Fußzeile die (vergessenen) Urheberrechtshinweise und einen Link zu `github.com/freetz-ng` hinzu.

| Vorher | Nachher |
|:-:|:-:|
| <img width="1663" height="330" alt="Screenshot 2025-08-02 at 16-59-59 Freetz-NG Documentation" src="https://github.com/user-attachments/assets/f5734099-26b6-452f-9fe8-324e234368db" /> | <img width="1663" height="334" alt="Screenshot 2025-08-02 at 17-00-04 Freetz-NG Documentation" src="https://github.com/user-attachments/assets/2b52154d-8c1b-4952-a602-ead9f80c7c87" /> |