### PR TITLE
action(docker): switch ubuntu from 20 to 22

### DIFF
--- a/.github/docker/dl-packs/Dockerfile
+++ b/.github/docker/dl-packs/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 ARG BUILD_USER=builduser
 
 RUN \

--- a/.github/docker/firmware/Dockerfile
+++ b/.github/docker/firmware/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 ARG BUILD_USER=builduser
 
 RUN \

--- a/.github/docker/generate/Dockerfile
+++ b/.github/docker/generate/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 ARG BUILD_USER=builduser
 
 RUN \

--- a/.github/workflows/avm_ftp.yml
+++ b/.github/workflows/avm_ftp.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   build:
     container:
-#     image: ubuntu:20.04
+#     image: ubuntu:22.04
 #     image: freetzng/generate
       image: ghcr.io/freetz-ng/generate
     runs-on: ubuntu-latest

--- a/.github/workflows/avm_juis-recache.yml
+++ b/.github/workflows/avm_juis-recache.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   build:
     container:
-#     image: ubuntu:20.04
+#     image: ubuntu:22.04
 #     image: freetzng/generate
       image: ghcr.io/freetz-ng/generate
     runs-on: ubuntu-latest

--- a/.github/workflows/avm_juis.yml
+++ b/.github/workflows/avm_juis.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   build:
     container:
-#     image: ubuntu:20.04
+#     image: ubuntu:22.04
 #     image: freetzng/generate
       image: ghcr.io/freetz-ng/generate
     runs-on: ubuntu-latest

--- a/.github/workflows/avm_osp.yml
+++ b/.github/workflows/avm_osp.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   build:
     container:
-#     image: ubuntu:20.04
+#     image: ubuntu:22.04
 #     image: freetzng/generate
       image: ghcr.io/freetz-ng/generate
     runs-on: ubuntu-latest

--- a/.github/workflows/dl-hosttools.yml
+++ b/.github/workflows/dl-hosttools.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   build:
     container:
-#     image: ubuntu:20.04
+#     image: ubuntu:22.04
 #     image: freetzng/dl-packs
       image: ghcr.io/freetz-ng/dl-packs
     runs-on: ubuntu-latest

--- a/.github/workflows/dl-toolchains.yml
+++ b/.github/workflows/dl-toolchains.yml
@@ -18,7 +18,7 @@ jobs:
 
   matrizifizieren:
     container:
-#     image: ubuntu:20.04
+#     image: ubuntu:22.04
 #     image: freetzng/generate
       image: ghcr.io/freetz-ng/generate
     runs-on: ubuntu-latest
@@ -53,7 +53,7 @@ jobs:
 
   build:
     container:
-#     image: ubuntu:20.04
+#     image: ubuntu:22.04
 #     image: freetzng/dl-packs
       image: ghcr.io/freetz-ng/dl-packs
     needs: matrizifizieren

--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   build:
     container:
-#     image: ubuntu:20.04
+#     image: ubuntu:22.04
 #     image: freetzng/generate
       image: ghcr.io/freetz-ng/generate
     runs-on: ubuntu-latest

--- a/.github/workflows/generate_link.yml
+++ b/.github/workflows/generate_link.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   build:
     container:
-#     image: ubuntu:20.04
+#     image: ubuntu:22.04
 #     image: freetzng/generate
       image: ghcr.io/freetz-ng/generate
     runs-on: ubuntu-latest

--- a/.github/workflows/make_bump.yml
+++ b/.github/workflows/make_bump.yml
@@ -22,7 +22,7 @@ jobs:
 
   matrizifizieren:
     container:
-#     image: ubuntu:20.04
+#     image: ubuntu:22.04
 #     image: freetzng/generate
       image: ghcr.io/freetz-ng/generate
     runs-on: ubuntu-latest
@@ -65,7 +65,7 @@ jobs:
 
   build:
     container:
-#     image: ubuntu:20.04
+#     image: ubuntu:22.04
 #     image: freetzng/firmware
       image: ghcr.io/freetz-ng/firmware
     needs: matrizifizieren

--- a/.github/workflows/make_freetz.yml
+++ b/.github/workflows/make_freetz.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   build:
     container:
-#     image: ubuntu:20.04
+#     image: ubuntu:22.04
 #     image: freetzng/firmware
       image: ghcr.io/freetz-ng/firmware
 #   strategy:

--- a/.github/workflows/make_kernel.yml
+++ b/.github/workflows/make_kernel.yml
@@ -45,7 +45,7 @@ jobs:
 
   matrizifizieren:
     container:
-#     image: ubuntu:20.04
+#     image: ubuntu:22.04
 #     image: freetzng/generate
       image: ghcr.io/freetz-ng/generate
     runs-on: ubuntu-latest
@@ -87,7 +87,7 @@ jobs:
 
   build:
     container:
-#     image: ubuntu:20.04
+#     image: ubuntu:22.04
 #     image: freetzng/firmware
       image: ghcr.io/freetz-ng/firmware
     needs: matrizifizieren

--- a/.github/workflows/postcommit_diffs.yml
+++ b/.github/workflows/postcommit_diffs.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   build:
     container:
-#     image: ubuntu:20.04
+#     image: ubuntu:22.04
 #     image: freetzng/generate
       image: ghcr.io/freetz-ng/generate
     runs-on: ubuntu-latest

--- a/.github/workflows/postcommit_img.yml
+++ b/.github/workflows/postcommit_img.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   build:
     container:
-#     image: ubuntu:20.04
+#     image: ubuntu:22.04
 #     image: freetzng/dl-packs
       image: ghcr.io/freetz-ng/dl-packs
     runs-on: ubuntu-latest

--- a/.github/workflows/postcommit_kos.yml
+++ b/.github/workflows/postcommit_kos.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   build:
     container:
-#     image: ubuntu:20.04
+#     image: ubuntu:22.04
 #     image: freetzng/generate
       image: ghcr.io/freetz-ng/generate
     runs-on: ubuntu-latest


### PR DESCRIPTION
Dies aktuallisiert die internen Docker Images von ubuntu 20.04 auf 22.04 
(quasi von bullseye auf bookworm wenn man sich die jeweiligen debian_version'en von ubuntu 20 und 22 vergleicht)

Das hatte ich schonmal auf https://github.com/Freetz-NG/freetz-ng/pull/1001, diesmal aber nicht auf 24.04 sondern auf 22.04.
Vielleicht ist ubuntu 22.04 ausgereift genug damit es genauso intern ohne Probleme verwendet werden kann.

Sowohl das bauen der Docker Container als auch einige actions die ich im meinen Fork dazu getestet habe, funktionieren grundlegend ohne Probleme.

-----

Ob es wegen den in ubuntu über apt's mitgelieferten gcc, es zu Buildfehler kommt, kann ich nicht sagen da ich nicht weiß wie weit man testen muss um ein Buildfehler aufzudecken wenn es an den gcc des (in den falle) ubuntu containers liegt.