### PR TITLE
docs(readme): fix little bit of typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ See [https://freetz-ng.github.io/](https://freetz-ng.github.io/) (or [docs/](doc
 
 
 <details>
-  <summary>Testing your Documentation changes localy</summary
+  <summary>Testing your Documentation changes localy</summary>
 
 When working on this repo, it is advised that you review your changes locally before committing them. The `mkdocs serve` command can be used to live preview your changes (as you type) on your local machine.
 


### PR DESCRIPTION
Dies behebt einen kleinen Tippfehler den ich bei https://github.com/Freetz-NG/freetz-ng/pull/1195 in der [readme.md](https://github.com/Freetz-NG/freetz-ng/blob/066337b00510d2df6ae332a39fa288ef9ab49edd/README.md?plain=1#L92) eingefügt hatte.

```diff
 <details>
-  <summary>Testing your Documentation changes localy</summary
+  <summary>Testing your Documentation changes localy</summary>
```