### PR TITLE
action(stalled_task): add `exempt-pr-labels` value

### DIFF
--- a/.github/workflows/task_stalled.yml
+++ b/.github/workflows/task_stalled.yml
@@ -31,6 +31,7 @@ jobs:
           stale-pr-label: 'stalled'
           labels-to-remove-when-unstale: 'stalled'
           exempt-issue-labels: 'task'
+          exempt-pr-labels: 'task'
           days-before-stale: 7
           remove-stale-when-updated: true
           enable-statistics: true


### PR DESCRIPTION
Dies fügt einen Wert für `exempt-pr-labels` hinzu um Pull Requests die mit dem Label "task" gekennzeichnet sind, von der Schließung des Pull requests durch den "stalled_task" zu verhindern.