### PR TITLE
Patch ch341 driver \n\n Ensure that the driver is in 8N1 + enable RX/…

### DIFF
--- a/make/kernel/patches/2.6.32.61/899-ch341.patch
+++ b/make/kernel/patches/2.6.32.61/899-ch341.patch
@@ -1,0 +1,12 @@
+--- a/linux-2.6.32/drivers/usb/serial/ch341.c
++++ b/linux-2.6.32/drivers/usb/serial/ch341.c
+@@ -218,7 +218,8 @@
+ 	if (r < 0)
+ 		goto out;
+ 
+-	r = ch341_control_out(dev, 0x9a, 0x2518, 0x0050);
++	/* Set 8N1 + enable RX/TX: LCR = 0xC3 (see upstream CH341_LCR_* bits) */
++        r = ch341_control_out(dev, 0x9a, 0x2518, 0x00C3);
+ 	if (r < 0)
+ 		goto out;
+ 

--- a/make/kernel/patches/3.10.107/7490_07.56/899-ch341.patch
+++ b/make/kernel/patches/3.10.107/7490_07.56/899-ch341.patch
@@ -1,0 +1,12 @@
+--- a/linux-3.10/drivers/usb/serial/ch341.c
++++ b/linux-3.10/drivers/usb/serial/ch341.c
+@@ -223,7 +223,8 @@
+ 	if (r < 0)
+ 		goto out;
+ 
+-	r = ch341_control_out(dev, 0x9a, 0x2518, 0x0050);
++	/* Set 8N1 + enable RX/TX: LCR = 0xC3 (see upstream CH341_LCR_* bits) */
++        r = ch341_control_out(dev, 0x9a, 0x2518, 0x00C3);
+ 	if (r < 0)
+ 		goto out;
+ 


### PR DESCRIPTION
Der Wemos D1 Mini enthält einen ch341 chip zur Kommunikation über USB. Seit einiger Zeit ist der zugehörige Treiber (ch341) im Linux Kernel. Unter einem aktuellen Ubuntu funktioniert das auch prima.
In der Fritzbox ist der Treiber (ch341.c) z.B. unter
```
./source/kernel/*/ref-*/linux-*/drivers/usb/serial/ch341.c
```
zu finden. Leider enthalten zumindest die hier gepatchten Versionen - und vermutlich auch weitere - einen Bug, der dazu führt, dass das Timing und die Datenkommunikation mit dem ch341 Chip auf dem Wemos nicht funktioniert. Der Treiber auf der Box setzt den UART in einen 5-bit mode (CS5), so dass die hohen Bits abgeschnitten werden.

Das passiert in der init Routine, in der LCR zu 0x0050 gesetzt wird. Laut Dokumentation ist das "TX enable + even-parity, but CS5 (bits 0..1 = 0). " Zur richtigen Kommunikation wird jedoch "8N1 mit RX+TX benötigt, d.h.: LCR = 0xC3 (0x80 RX enable | 0x40 TX enable | 0x03 CS8). Die Register werden als 0x2518 (LCR2<<8 | LCR) geschrieben.

Der patch in ch341_configure() korrigiert das.
Siehe #1229 
Implementiert #1229 für FB 3272 und FB 7490