### PR TITLE
action(mkdocs): remove `fetch-depth` flag on `checkout` action

### DIFF
--- a/.github/workflows/generate_mkdocs.yml
+++ b/.github/workflows/generate_mkdocs.yml
@@ -31,8 +31,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-        with:
-          fetch-depth: 1
       - name: Install dependencies
         run: pip install -r .github/mkdocs/requirements.txt
       - name: Setup Pages


### PR DESCRIPTION
Dies entfernt die eingestellte `fetch-depth` angebe bei dem `checkout` Action bei den mkdocs Workflow.
Das `fetch-depth` ist [standardgemäß](https://github.com/actions/checkout?tab=readme-ov-file#usage) auf 1 und braucht nicht zusätzlich gesetzt zu werden.