### PR TITLE
[ftdi1] Updated CMakeLists.txt file for compatibility with currently used CMake

### DIFF
--- a/make/pkgs/ftdi1/patches/020-CMakeLists.patch
+++ b/make/pkgs/ftdi1/patches/020-CMakeLists.patch
@@ -5,7 +5,7 @@
  endif("${CMAKE_BUILD_TYPE}" STREQUAL "")
  set(CMAKE_COLOR_MAKEFILE ON)
 -cmake_minimum_required(VERSION 2.6 FATAL_ERROR)
-+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
++cmake_minimum_required(VERSION 2.6...3.10 FATAL_ERROR)
  
  add_definitions(-Wall)
  

--- a/make/pkgs/ftdi1/patches/020-CMakeLists.patch
+++ b/make/pkgs/ftdi1/patches/020-CMakeLists.patch
@@ -1,0 +1,11 @@
+--- CMakeLists.txt_orig	2020-07-07 21:32:55.000000000 +0200
++++ CMakeLists.txt	2025-10-04 12:13:02.943143715 +0200
+@@ -12,7 +12,7 @@
+    set(CMAKE_BUILD_TYPE     RelWithDebInfo)
+ endif("${CMAKE_BUILD_TYPE}" STREQUAL "")
+ set(CMAKE_COLOR_MAKEFILE ON)
+-cmake_minimum_required(VERSION 2.6 FATAL_ERROR)
++cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+ 
+ add_definitions(-Wall)
+ 


### PR DESCRIPTION
Hi @fda77!

ftdi1 doesn't build anymore due to a more recent CMake tool. This patch fixes it. An update of ftdi1 is not available, that's why I created this little patch. Is the format and patch file named OK?

BR,
Sven