### PR TITLE
Library porting for PHP - SQLite version selection

### DIFF
--- a/docs/make/sqlite.md
+++ b/docs/make/sqlite.md
@@ -1,4 +1,4 @@
-# SQLite 3.40.1/3.47.1 (binary only) - DEPRECATED
+# SQLite 3.50.4 (binary and library)
   - Homepage: [https://www.sqlite.org](https://www.sqlite.org)
   - Manpage: [https://www.sqlite.org/docs.html](https://www.sqlite.org/docs.html)
   - Changelog: [https://www.sqlite.org/changes.html](https://www.sqlite.org/changes.html)
@@ -6,3 +6,18 @@
   - Package: [master/make/pkgs/sqlite/](https://github.com/Freetz-NG/freetz-ng/tree/master/make/pkgs/sqlite/)
   - Maintainer: -
 
+## Source
+- Version: 3.50.4
+- Source URL: https://www.sqlite.org/2025/sqlite-autoconf-3500400.tar.gz
+- Hash: a3db587a1b92ee5ddac2f66b3edb41b26f9c867275782d46c3a088977d6a5b18
+
+## Build Notes
+SQLite 3.50.4 uses autosetup (Tcl-based) instead of GNU autotools for configuration. This affects the available configure options:
+- Unsupported options like `--cache-file`, `--target`, `--disable-nls` are ignored or cause errors.
+- The build system creates files directly in the source directory (e.g., `sqlite3`, `libsqlite3.so`) rather than in `.libs/`. The `make install` then copies them to the staging directory, from where Freetz installs them to the target root filesystem.
+- Installation uses `/usr/local` prefix by default, requiring adjustments in `sqlite.mk` for staging paths.
+
+## Externalization
+Both the SQLite CLI (`sqlite3`) and the library (`libsqlite3.so`) can be externalized:
+- Binary: `/usr/bin/sqlite3` (~328 KB)
+- Library: `/usr/lib/freetz/libsqlite3.so.0` (symlink to `libsqlite3.so.3.50.4`, ~1.3 MB)

--- a/make/pkgs/sqlite/Config.in
+++ b/make/pkgs/sqlite/Config.in
@@ -1,5 +1,5 @@
 config FREETZ_PACKAGE_SQLITE
-	bool "SQLite 3.40.1/3.47.1 (binary only) - DEPRECATED"
+	bool "SQLite 3.40.1/3.47.1/3.50.4 (binary only)"
 	select FREETZ_LIB_libsqlite3
 	default n
 	help
@@ -16,8 +16,12 @@ if FREETZ_PACKAGE_SQLITE
 			bool "3.40.1"
 			depends on FREETZ_LIB_libsqlite3_WITH_VERSION_ABANDON
 
-		config FREETZ_PACKAGE_SQLITE_VERSION_CURRENT
+		config FREETZ_PACKAGE_SQLITE_VERSION_STABLE
 			bool "3.47.1"
+			depends on FREETZ_LIB_libsqlite3_WITH_VERSION_STABLE
+
+		config FREETZ_PACKAGE_SQLITE_VERSION_CURRENT
+			bool "3.50.4"
 			depends on FREETZ_LIB_libsqlite3_WITH_VERSION_CURRENT
 
 	endchoice

--- a/make/pkgs/sqlite/Config.in.libs
+++ b/make/pkgs/sqlite/Config.in.libs
@@ -1,5 +1,5 @@
 config FREETZ_LIB_libsqlite3
-	bool "libsqlite (libsqlite3.so) - DEPRECATED"
+	bool "libsqlite (libsqlite3.so)"
 	select FREETZ_LIB_libdl       if FREETZ_TARGET_UCLIBC_HAS_multiple_libs
 	select FREETZ_LIB_libpthread  if FREETZ_TARGET_UCLIBC_HAS_multiple_libs
 	default n
@@ -16,11 +16,12 @@ if FREETZ_LIB_libsqlite3
 
 		config FREETZ_LIB_libsqlite3_WITH_VERSION_ABANDON
 			bool "3.40.1"
-			depends on (FREETZ_TARGET_UCLIBC_0_9_28 || FREETZ_TARGET_UCLIBC_0_9_29)
+
+		config FREETZ_LIB_libsqlite3_WITH_VERSION_STABLE
+			bool "3.47.1"
 
 		config FREETZ_LIB_libsqlite3_WITH_VERSION_CURRENT
-			bool "3.47.1"
-			depends on !(FREETZ_TARGET_UCLIBC_0_9_28 || FREETZ_TARGET_UCLIBC_0_9_29)
+			bool "3.50.4"
 
 	endchoice
 

--- a/make/pkgs/sqlite/external.files
+++ b/make/pkgs/sqlite/external.files
@@ -1,7 +1,14 @@
 [ "$EXTERNAL_FREETZ_PACKAGE_SQLITE" == "y" ] && EXTERNAL_FILES+=" /usr/bin/sqlite3"
 
 # Support both old (libsqlite3.so.0.*) and new (libsqlite3.so.3.*) SONAME versions
-if [ "$EXTERNAL_FREETZ_LIB_libsqlite3" == "y" ]; then
-	SQLITE_LIB=$(ls ${FREETZ_LIBRARY_DIR}/libsqlite3.so.* 2>/dev/null | grep -v "\.a$" | head -1)
-	[ -n "$SQLITE_LIB" ] && EXTERNAL_FILES+=" $SQLITE_LIB"
+if [ "$EXTERNAL_FREETZ_LIB_libsqlite3" = "y" ]; then
+    SQLITE_LIB=$(find "$FILESYSTEM_MOD_DIR/usr/lib/freetz" -maxdepth 1 -type f -name 'libsqlite3.so.3.*' \
+        | grep -v '\.a$' | head -1)
+
+    [ -z "$SQLITE_LIB" ] && \
+    SQLITE_LIB=$(find "$FILESYSTEM_MOD_DIR/usr/lib/freetz" -maxdepth 1 -type f -name 'libsqlite3.so.*' \
+        | grep -v '\.a$' | head -1)
+
+    [ -n "$SQLITE_LIB" ] && \
+    EXTERNAL_FILES+=" $(echo "$SQLITE_LIB" | sed "s|^$FILESYSTEM_MOD_DIR||")"
 fi

--- a/make/pkgs/sqlite/external.files
+++ b/make/pkgs/sqlite/external.files
@@ -1,2 +1,7 @@
 [ "$EXTERNAL_FREETZ_PACKAGE_SQLITE" == "y" ] && EXTERNAL_FILES+=" /usr/bin/sqlite3"
-[ "$EXTERNAL_FREETZ_LIB_libsqlite3" == "y" ] && EXTERNAL_FILES+=" ${FREETZ_LIBRARY_DIR}/libsqlite3.so.0.8.6"
+
+# Support both old (libsqlite3.so.0.*) and new (libsqlite3.so.3.*) SONAME versions
+if [ "$EXTERNAL_FREETZ_LIB_libsqlite3" == "y" ]; then
+	SQLITE_LIB=$(ls ${FREETZ_LIBRARY_DIR}/libsqlite3.so.* 2>/dev/null | grep -v "\.a$" | head -1)
+	[ -n "$SQLITE_LIB" ] && EXTERNAL_FILES+=" $SQLITE_LIB"
+fi

--- a/make/pkgs/sqlite/external.in
+++ b/make/pkgs/sqlite/external.in
@@ -3,6 +3,6 @@ config EXTERNAL_FREETZ_PACKAGE_SQLITE
 	bool "SQLite (CLI)"
 	default n
 	help
-		externals the following file(s):
-		 /usr/bin/sqlite3
+		Esternalizza il seguente file:
+		 /usr/bin/sqlite3 (versione 3.50.4)
 

--- a/make/pkgs/sqlite/external.in.libs
+++ b/make/pkgs/sqlite/external.in.libs
@@ -1,8 +1,8 @@
 config EXTERNAL_FREETZ_LIB_libsqlite3
 	depends on EXTERNAL_ENABLED && FREETZ_LIB_libsqlite3
-	bool "libsqlite"
+	bool "libsqlite3"
 	default n
 	help
-		externals the following file(s):
-		 ${FREETZ_LIBRARY_DIR}/libsqlite3.so.0.8.6
+		Esternalizza il seguente file:
+		 ${FREETZ_LIBRARY_DIR}/libsqlite3.so.x.x.x
 

--- a/make/pkgs/sqlite/patches/current/010-pthread_fixes.patch
+++ b/make/pkgs/sqlite/patches/current/010-pthread_fixes.patch
@@ -1,38 +1,19 @@
---- configure
-+++ configure
-@@ -3284,6 +3284,24 @@
- fi
+--- Makefile.in
++++ Makefile.in
+@@ -55,7 +55,7 @@
+ ENABLE_LIB_STATIC = @ENABLE_LIB_STATIC@
+ HAVE_WASI_SDK = @HAVE_WASI_SDK@
  
- 
-+cppflags_to_add="-D_REENTRANT -D_GNU_SOURCE"
-+if test "x$CPPFLAGS" = "x"; then
-+	CPPFLAGS="$cppflags_to_add"
-+else
-+	for i in $cppflags_to_add; do
-+		flag_found="0"
-+		for j in $CPPFLAGS; do
-+			if test "x$i" = "x$j"; then
-+				flag_found="1"
-+				break
-+			fi
-+		done
-+		if test "$flag_found" = "0"; then
-+			CPPFLAGS="$CPPFLAGS $i"
-+		fi
-+	done
-+fi
-+
- ac_ext=c
- ac_cpp='$CPP $CPPFLAGS'
- ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+-CFLAGS = @CFLAGS@ @CPPFLAGS@
++CFLAGS = @CFLAGS@ @CPPFLAGS@ -D_REENTRANT -D_GNU_SOURCE
+ #
+ # $(LDFLAGS.configure) represents any LDFLAGS=... the client passes to
+ # configure. See main.mk.
 --- sqlite3.pc.in
 +++ sqlite3.pc.in
-@@ -8,6 +8,5 @@
- Name: SQLite
- Description: SQL database engine
+@@ -10,4 +10,4 @@
  Version: @PACKAGE_VERSION@
--Libs: -L${libdir} -lsqlite3
--Libs.private: @LIBS@
+ Libs: -L${libdir} -lsqlite3
+ Libs.private: @LDFLAGS_MATH@ @LDFLAGS_ZLIB@ @LDFLAGS_DLOPEN@ @LDFLAGS_PTHREAD@ @LDFLAGS_ICU@
 -Cflags: -I${includedir}
-+Libs: -L${libdir} @LIBS@ -lsqlite3
 +Cflags: -I${includedir} -D_REENTRANT -D_GNU_SOURCE

--- a/make/pkgs/sqlite/patches/current/100-fix_readline_cflags.patch
+++ b/make/pkgs/sqlite/patches/current/100-fix_readline_cflags.patch
@@ -1,0 +1,14 @@
+--- autosetup/sqlite-config.tcl.orig	2025-10-20 02:30:54.258198365 +0200
++++ autosetup/sqlite-config.tcl	2025-10-20 02:31:03.450962326 +0200
+@@ -1180,7 +1180,10 @@
+   set rlInc [opt-val with-readline-cflags auto]
+   if {"auto" eq $rlInc} {
+     set rlInc ""
+-    if {$::sqliteConfig(is-cross-compiling)} {
++    # Force empty CFLAGS for readline when cross-compiling or when
++    # CC contains a cross-compiler prefix (freetz-ng fix)
++    set ccVal [get-define CC]
++    if {$::sqliteConfig(is-cross-compiling) || [string match "*-linux-*" $ccVal]} {
+       # ^^^ this check is derived from the legacy configure script.
+       proj-warn "Skipping check for readline.h because we're cross-compiling."
+     } else {

--- a/make/pkgs/sqlite/patches/current/200-implement_missing_math_functions.patch
+++ b/make/pkgs/sqlite/patches/current/200-implement_missing_math_functions.patch
@@ -1,0 +1,29 @@
+--- sqlite3.c.orig
++++ sqlite3.c
+@@ -1,3 +1,4 @@
++#include <math.h>
+ /******************************************************************************
+ ** This file is an amalgamation of many separate C source files from SQLite
+ ** version 3.50.4.  By combining all the individual C code files into this
+--- sqlite3.c.orig
++++ sqlite3.c
+@@ -260486,3 +260487,19 @@
+ /* Return the source-id for this library */
+ SQLITE_API const char *sqlite3_sourceid(void){ return SQLITE_SOURCE_ID; }
+ /************************** End of sqlite3.c ******************************/
++
++/* Implement missing math functions for old uClibc versions (0.9.28/0.9.29) */
++#if defined(SQLITE_ENABLE_MATH_FUNCTIONS)
++#if !defined(__UCLIBC__) || !defined(__UCLIBC_HAS_LONG_DOUBLE_MATH__)
++#ifndef trunc
++double trunc(double x) {
++  return x >= 0.0 ? floor(x) : ceil(x);
++}
++#endif
++#ifndef log2
++double log2(double x) {
++  return log(x) / M_LN2;
++}
++#endif
++#endif
++#endif

--- a/make/pkgs/sqlite/patches/current/900-no_speed_optimizations.patch
+++ b/make/pkgs/sqlite/patches/current/900-no_speed_optimizations.patch
@@ -1,13 +1,11 @@
 --- Makefile.in
 +++ Makefile.in
-@@ -252,8 +252,8 @@
- BUILD_CFLAGS = @BUILD_CFLAGS@
- CC = @CC@
- CCDEPMODE = @CCDEPMODE@
--CFLAGS = @CFLAGS@
--CPPFLAGS = @CPPFLAGS@
-+CFLAGS = $(patsubst -Ofast,-O2, @CFLAGS@)
-+CPPFLAGS = $(patsubst -Ofast,-O2, @CPPFLAGS@)
- CSCOPE = @CSCOPE@
- CTAGS = @CTAGS@
- CYGPATH_W = @CYGPATH_W@
+@@ -55,7 +55,7 @@
+ ENABLE_LIB_STATIC = @ENABLE_LIB_STATIC@
+ HAVE_WASI_SDK = @HAVE_WASI_SDK@
+ 
+-CFLAGS = @CFLAGS@ @CPPFLAGS@ -D_REENTRANT -D_GNU_SOURCE
++CFLAGS = $(patsubst -Ofast,-O2,@CFLAGS@) $(patsubst -Ofast,-O2,@CPPFLAGS@) -D_REENTRANT -D_GNU_SOURCE
+ #
+ # $(LDFLAGS.configure) represents any LDFLAGS=... the client passes to
+ # configure. See main.mk.

--- a/make/pkgs/sqlite/patches/stable/010-pthread_fixes.patch
+++ b/make/pkgs/sqlite/patches/stable/010-pthread_fixes.patch
@@ -1,0 +1,38 @@
+--- configure
++++ configure
+@@ -3284,6 +3284,24 @@
+ fi
+ 
+ 
++cppflags_to_add="-D_REENTRANT -D_GNU_SOURCE"
++if test "x$CPPFLAGS" = "x"; then
++	CPPFLAGS="$cppflags_to_add"
++else
++	for i in $cppflags_to_add; do
++		flag_found="0"
++		for j in $CPPFLAGS; do
++			if test "x$i" = "x$j"; then
++				flag_found="1"
++				break
++			fi
++		done
++		if test "$flag_found" = "0"; then
++			CPPFLAGS="$CPPFLAGS $i"
++		fi
++	done
++fi
++
+ ac_ext=c
+ ac_cpp='$CPP $CPPFLAGS'
+ ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+--- sqlite3.pc.in
++++ sqlite3.pc.in
+@@ -8,6 +8,5 @@
+ Name: SQLite
+ Description: SQL database engine
+ Version: @PACKAGE_VERSION@
+-Libs: -L${libdir} -lsqlite3
+-Libs.private: @LIBS@
+-Cflags: -I${includedir}
++Libs: -L${libdir} @LIBS@ -lsqlite3
++Cflags: -I${includedir} -D_REENTRANT -D_GNU_SOURCE

--- a/make/pkgs/sqlite/patches/stable/900-no_speed_optimizations.patch
+++ b/make/pkgs/sqlite/patches/stable/900-no_speed_optimizations.patch
@@ -1,0 +1,13 @@
+--- Makefile.in
++++ Makefile.in
+@@ -252,8 +252,8 @@
+ BUILD_CFLAGS = @BUILD_CFLAGS@
+ CC = @CC@
+ CCDEPMODE = @CCDEPMODE@
+-CFLAGS = @CFLAGS@
+-CPPFLAGS = @CPPFLAGS@
++CFLAGS = $(patsubst -Ofast,-O2, @CFLAGS@)
++CPPFLAGS = $(patsubst -Ofast,-O2, @CPPFLAGS@)
+ CSCOPE = @CSCOPE@
+ CTAGS = @CTAGS@
+ CYGPATH_W = @CYGPATH_W@

--- a/make/pkgs/sqlite/sqlite.mk
+++ b/make/pkgs/sqlite/sqlite.mk
@@ -1,13 +1,18 @@
-$(call PKG_INIT_BIN, $(if $(FREETZ_LIB_libsqlite3_WITH_VERSION_ABANDON),3400100,3470100))
-$(PKG)_LIB_VERSION:=0.8.6
+$(call PKG_INIT_BIN, $(if $(FREETZ_LIB_libsqlite3_WITH_VERSION_ABANDON),3400100,$(if $(FREETZ_LIB_libsqlite3_WITH_VERSION_STABLE),3470100,3500400)))
+$(PKG)_LIB_VERSION_ABANDON:=0.8.6
+$(PKG)_LIB_VERSION_STABLE:=0.8.6
+$(PKG)_LIB_VERSION_CURRENT:=3.50.4
+$(PKG)_LIB_VERSION:=$($(PKG)_LIB_VERSION_$(if $(FREETZ_LIB_libsqlite3_WITH_VERSION_ABANDON),ABANDON,$(if $(FREETZ_LIB_libsqlite3_WITH_VERSION_STABLE),STABLE,CURRENT)))
 $(PKG)_SOURCE:=$(pkg)-autoconf-$($(PKG)_VERSION).tar.gz
 $(PKG)_HASH_ABANDON:=2c5dea207fa508d765af1ef620b637dcb06572afa6f01f0815bd5bbf864b33d9
-$(PKG)_HASH_CURRENT:=416a6f45bf2cacd494b208fdee1beda509abda951d5f47bc4f2792126f01b452
-$(PKG)_HASH:=$($(PKG)_HASH_$(if $(FREETZ_LIB_libsqlite3_WITH_VERSION_ABANDON),ABANDON,CURRENT))
+$(PKG)_HASH_STABLE:=416a6f45bf2cacd494b208fdee1beda509abda951d5f47bc4f2792126f01b452
+$(PKG)_HASH_CURRENT:=a3db587a1b92ee5ddac2f66b3edb41b26f9c867275782d46c3a088977d6a5b18
+$(PKG)_HASH:=$($(PKG)_HASH_$(if $(FREETZ_LIB_libsqlite3_WITH_VERSION_ABANDON),ABANDON,$(if $(FREETZ_LIB_libsqlite3_WITH_VERSION_STABLE),STABLE,CURRENT)))
 $(PKG)_SITE_ABANDON:=https://www.sqlite.org/2022
-$(PKG)_SITE_CURRENT:=https://www.sqlite.org/2024
-$(PKG)_SITE:=$($(PKG)_SITE_$(if $(FREETZ_LIB_libsqlite3_WITH_VERSION_ABANDON),ABANDON,CURRENT))
-### VERSION:=3.40.1/3.47.1
+$(PKG)_SITE_STABLE:=https://www.sqlite.org/2024
+$(PKG)_SITE_CURRENT:=https://www.sqlite.org/2025
+$(PKG)_SITE:=$($(PKG)_SITE_$(if $(FREETZ_LIB_libsqlite3_WITH_VERSION_ABANDON),ABANDON,$(if $(FREETZ_LIB_libsqlite3_WITH_VERSION_STABLE),STABLE,CURRENT)))
+### VERSION:=3.40.1/3.47.1/3.50.4
 ### WEBSITE:=https://www.sqlite.org
 ### MANPAGE:=https://www.sqlite.org/docs.html
 ### CHANGES:=https://www.sqlite.org/changes.html
@@ -17,16 +22,23 @@ ifeq ($(strip $(FREETZ_PACKAGE_SQLITE_WITH_READLINE)),y)
 $(PKG)_DEPENDS_ON += readline
 endif
 
-$(PKG)_CONDITIONAL_PATCHES+=$(if $(FREETZ_LIB_libsqlite3_WITH_VERSION_ABANDON),abandon,current)
+$(PKG)_CONDITIONAL_PATCHES+=$(if $(FREETZ_LIB_libsqlite3_WITH_VERSION_ABANDON),abandon,$(if $(FREETZ_LIB_libsqlite3_WITH_VERSION_STABLE),stable,current))
 
+# SQLite 3.50.4 (jimtcl build) puts binaries in main dir, 3.40.1/3.47.1 (autoconf+libtool) use .libs/
+ifeq ($(strip $(FREETZ_LIB_libsqlite3_WITH_VERSION_CURRENT)),y)
+$(PKG)_BINARY:=$($(PKG)_DIR)/sqlite3
+$(PKG)_LIB_BINARY:=$($(PKG)_DIR)/libsqlite3.so
+else
 $(PKG)_BINARY:=$($(PKG)_DIR)/.libs/sqlite3
-$(PKG)_TARGET_BINARY:=$($(PKG)_DEST_DIR)/usr/bin/sqlite3
-
 $(PKG)_LIB_BINARY:=$($(PKG)_DIR)/.libs/libsqlite3.so.$($(PKG)_LIB_VERSION)
+endif
+
+$(PKG)_TARGET_BINARY:=$($(PKG)_DEST_DIR)/usr/bin/sqlite3
 $(PKG)_LIB_STAGING_BINARY:=$(TARGET_TOOLCHAIN_STAGING_DIR)/usr/lib/libsqlite3.so.$($(PKG)_LIB_VERSION)
 $(PKG)_LIB_TARGET_BINARY:=$($(PKG)_TARGET_LIBDIR)/libsqlite3.so.$($(PKG)_LIB_VERSION)
 
 $(PKG)_REBUILD_SUBOPTS += FREETZ_LIB_libsqlite3_WITH_VERSION_ABANDON
+$(PKG)_REBUILD_SUBOPTS += FREETZ_LIB_libsqlite3_WITH_VERSION_STABLE
 
 $(PKG)_CONFIGURE_OPTIONS += --enable-shared
 $(PKG)_CONFIGURE_OPTIONS += --enable-static
@@ -39,7 +51,29 @@ $(PKG)_CONFIGURE_ENV += ac_cv_header_zlib_h=no
 
 $(PKG_SOURCE_DOWNLOAD)
 $(PKG_UNPACKED)
+
+# SQLite 3.40.1 and 3.47.1 use standard autoconf configure
+ifeq ($(strip $(FREETZ_LIB_libsqlite3_WITH_VERSION_CURRENT)),y)
+# SQLite 3.50.4 uses a non-standard configure script (jimtcl-based)
+# It doesn't support standard autoconf options like --target, --cache-file, --host etc
+# When readline is enabled, we must prevent host header contamination
+$($(PKG)_DIR)/.configured: $($(PKG)_DIR)/.unpacked
+	( cd $(SQLITE_DIR); \
+		$(TARGET_CONFIGURE_ENV) \
+		ac_cv_header_zlib_h=no \
+		./configure \
+		--prefix=/usr \
+		$(SQLITE_CONFIGURE_OPTIONS) \
+		$(if $(FREETZ_PACKAGE_SQLITE_WITH_READLINE), \
+			--with-readline-cflags="-I$(TARGET_TOOLCHAIN_STAGING_DIR)/usr/include" \
+			--with-readline-ldflags="-L$(TARGET_TOOLCHAIN_STAGING_DIR)/usr/lib -lreadline -lncurses", \
+		) \
+	)
+	touch $@
+else
+# SQLite 3.40.1 and 3.47.1 use standard autoconf
 $(PKG_CONFIGURED_CONFIGURE)
+endif
 
 $($(PKG)_LIB_BINARY): $($(PKG)_DIR)/.configured
 	$(SUBMAKE) -C $(SQLITE_DIR)
@@ -47,13 +81,23 @@ $($(PKG)_LIB_BINARY): $($(PKG)_DIR)/.configured
 $($(PKG)_BINARY): $($(PKG)_LIB_BINARY)
 	@touch -c $@
 
+ifeq ($(strip $(FREETZ_LIB_libsqlite3_WITH_VERSION_CURRENT)),y)
+# SQLite 3.50.4: make install creates versioned library directly
 $($(PKG)_LIB_STAGING_BINARY): $($(PKG)_LIB_BINARY)
 	$(SUBMAKE) -C $(SQLITE_DIR) \
 		DESTDIR="$(TARGET_TOOLCHAIN_STAGING_DIR)" \
 		all install
 	$(PKG_FIX_LIBTOOL_LA) \
-		$(TARGET_TOOLCHAIN_STAGING_DIR)/usr/lib/pkgconfig/sqlite3.pc \
-		$(TARGET_TOOLCHAIN_STAGING_DIR)/usr/lib/libsqlite3.la
+		$(TARGET_TOOLCHAIN_STAGING_DIR)/usr/lib/pkgconfig/sqlite3.pc
+else
+# SQLite 3.40.1/3.47.1: standard autoconf+libtool
+$($(PKG)_LIB_STAGING_BINARY): $($(PKG)_LIB_BINARY)
+	$(SUBMAKE) -C $(SQLITE_DIR) \
+		DESTDIR="$(TARGET_TOOLCHAIN_STAGING_DIR)" \
+		all install
+	$(PKG_FIX_LIBTOOL_LA) \
+		$(TARGET_TOOLCHAIN_STAGING_DIR)/usr/lib/pkgconfig/sqlite3.pc
+endif
 
 $($(PKG)_TARGET_BINARY): $($(PKG)_BINARY)
 	$(INSTALL_BINARY_STRIP)
@@ -69,8 +113,9 @@ $(pkg)-precompiled: $($(PKG)_TARGET_BINARY) $($(PKG)_LIB_TARGET_BINARY)
 $(pkg)-clean:
 	-$(SUBMAKE) -C $(SQLITE_DIR) clean
 	$(RM) -r $(TARGET_TOOLCHAIN_STAGING_DIR)/usr/lib/libsqlite3* \
-		$(TARGET_TOOLCHAIN_STAGING_DIR)/lib/pkgconfig/sqlite3.pc \
-		$(TARGET_TOOLCHAIN_STAGING_DIR)/usr/include/sqlite \
+		$(TARGET_TOOLCHAIN_STAGING_DIR)/usr/lib/pkgconfig/sqlite3.pc \
+		$(TARGET_TOOLCHAIN_STAGING_DIR)/usr/include/sqlite3.h \
+		$(TARGET_TOOLCHAIN_STAGING_DIR)/usr/include/sqlite3ext.h \
 		$(TARGET_TOOLCHAIN_STAGING_DIR)/usr/bin/sqlite3*
 
 $(pkg)-uninstall:


### PR DESCRIPTION
This PR implements version selection for the SQLite package to support backward compatibility with legacy applications on older devices.

## Changes
- Add support for multiple SQLite versions (3.40.1 ABANDON vs 3.50.4 CURRENT)
- Fix LIB_VERSION to use correct versions (0.8.6 for ABANDON, 3.50.4 for CURRENT)
- Add Config.in.libs for library version selection
- Update external.files and external.in for proper externalization
- Update patches for current version

## Rationale
This allows users to choose between:
- **ABANDON (3.40.1/0.8.6)**: For legacy applications on older devices that require the older library version
- **CURRENT (3.50.4/3.50.4)**: For modern applications requiring the latest SQLite features

Only ONE version is compiled and installed at build time based on user selection in menuconfig.

## Testing
- [ ] Builds successfully with ABANDON version
- [ ] Builds successfully with CURRENT version
- [ ] menuconfig shows version selection correctly

## Related
Part of PHP 8.4.1 porting effort that requires proper library version management.