### PR TITLE
Library porting for PHP - zlib Dropbear compatibility warning

### DIFF
--- a/make/libs/zlib/external.in
+++ b/make/libs/zlib/external.in
@@ -1,6 +1,6 @@
 config EXTERNAL_FREETZ_LIB_libz
 	depends on EXTERNAL_ENABLED && FREETZ_LIB_libz
-	bool "libz"
+	bool "libz (required internal by Dropbear SSH)"
 	default n
 	help
 		externals the following file(s):


### PR DESCRIPTION
This PR adds a compatibility warning for zlib externalization when using Dropbear SSH server.

## Changes
- Add external.in with warning about potential Dropbear conflicts
- Document issues when externalizing zlib with Dropbear

## Rationale
Externalizing zlib can cause conflicts with Dropbear SSH server because Dropbear has specific zlib requirements. This warning helps users avoid potential runtime issues.

## Warning Message
Alerts users to potential compatibility problems and advises caution when selecting zlib externalization if Dropbear is enabled.

## Testing
- [ ] Warning displays correctly in menuconfig
- [ ] Documentation clearly explains the conflict

## Related
Part of PHP 8.4.1 porting effort that requires proper compression library handling.