### PR TITLE
Add patch to PSL package to skip Python version check

### DIFF
--- a/make/pkgs/psl/patches/110-skip_python_version_check.patch
+++ b/make/pkgs/psl/patches/110-skip_python_version_check.patch
@@ -1,0 +1,13 @@
+--- a/configure
++++ b/configure
+@@ -13394,7 +13394,9 @@
+ 
+ 
+ 
+-        if test -n "$PYTHON"; then
++        # Skip Python version check in cross-compilation
++        am_cv_python_version=3.12
++        if false; then
+       # If the user set $PYTHON, use it and don't search something else.
+       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether $PYTHON version is >= 2.7" >&5
+ printf %s "checking whether $PYTHON version is >= 2.7... " >&6; }

--- a/make/pkgs/psl/psl.mk
+++ b/make/pkgs/psl/psl.mk
@@ -21,7 +21,7 @@ $(PKG)_LIBRARY_TARGET   := $($(PKG)_TARGET_LIBDIR)/$($(PKG)_LIBNAME)
 
 $(PKG)_DEPENDS_ON += python3-host
 
-$(PKG)_CONFIGURE_ENV += PYTHON=python3
+$(PKG)_CONFIGURE_ENV += PYTHON=$(HOST_TOOLS_DIR)/usr/bin/python3
 
 $(PKG)_CONFIGURE_OPTIONS += --enable-shared
 $(PKG)_CONFIGURE_OPTIONS += --enable-static


### PR DESCRIPTION
This PR updates the Public Suffix List (PSL) package to skip Python version checks during build, improving compatibility with Python 3.13.