### PR TITLE
Add Python 3.13 support with extension packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ endif
 # genin: (re)generate .in files if necessary
 ifneq ($(findstring clean,$(MAKECMDGOALS)),clean)
 # Note: the list of the packages to be treated specially (the 3rd argument of get-subdirs-containing) should match that used in genin
-ifneq ($(call genin-get-considered-packages,make/pkgs/Config.in.generated),$(call get-subdirs-containing,make/pkgs,Config.in,asterisk[-].* iptables-cgi nhipt python[-].* ruby-fcgi sg3_utils))
+ifneq ($(call genin-get-considered-packages,make/pkgs/Config.in.generated),$(call get-subdirs-containing,make/pkgs,Config.in,asterisk[-].* iptables-cgi nhipt python[-].* python3[-].* ruby-fcgi sg3_utils))
 ifneq ($(shell $(GENERATE_IN_TOOL) $(if $(findstring legacy,$(MAKECMDGOALS)),legacy) >&2 && echo OK),OK)
 $(error genin failed)
 endif

--- a/docs/make/python-cffi.md
+++ b/docs/make/python-cffi.md
@@ -1,8 +1,4 @@
 # Cffi 1.15.1
-  - Homepage: [https://cffi.readthedocs.io](https://cffi.readthedocs.io)
-  - Manpage: [https://cffi.readthedocs.io/en/stable/overview.html](https://cffi.readthedocs.io/en/stable/overview.html)
-  - Changelog: [https://github.com/python-cffi/cffi/releases](https://github.com/python-cffi/cffi/releases)
-  - Repository: [https://github.com/python-cffi/cffi](https://github.com/python-cffi/cffi)
   - Package: [master/make/pkgs/python-cffi/](https://github.com/Freetz-NG/freetz-ng/tree/master/make/pkgs/python-cffi/)
   - Maintainer: -
 

--- a/docs/make/python-pycrypto.md
+++ b/docs/make/python-pycrypto.md
@@ -1,8 +1,4 @@
 # PyCrypto 2.7a1 - DEPRECATED
-  - Homepage: [https://www.pycrypto.org/](https://www.pycrypto.org/)
-  - Manpage: [https://www.pycrypto.org/doc/](https://www.pycrypto.org/doc/)
-  - Changelog: [https://github.com/pycrypto/pycrypto/tags](https://github.com/pycrypto/pycrypto/tags)
-  - Repository: [https://github.com/pycrypto/pycrypto](https://github.com/pycrypto/pycrypto)
   - Package: [master/make/pkgs/python-pycrypto/](https://github.com/Freetz-NG/freetz-ng/tree/master/make/pkgs/python-pycrypto/)
   - Maintainer: -
 

--- a/docs/make/python-pycryptodome.md
+++ b/docs/make/python-pycryptodome.md
@@ -1,8 +1,4 @@
 # PyCryptodome 3.23.0
-  - Homepage: [https://www.pycryptodome.org/](https://www.pycryptodome.org/)
-  - Manpage: [https://www.pycryptodome.org/src/api](https://www.pycryptodome.org/src/api)
-  - Changelog: [https://www.pycryptodome.org/src/changelog](https://www.pycryptodome.org/src/changelog)
-  - Repository: [https://github.com/Legrandin/pycryptodome/](https://github.com/Legrandin/pycryptodome/)
   - Package: [master/make/pkgs/python-pycryptodome/](https://github.com/Freetz-NG/freetz-ng/tree/master/make/pkgs/python-pycryptodome/)
   - Maintainer: -
 

--- a/docs/make/python-pycurl.md
+++ b/docs/make/python-pycurl.md
@@ -1,8 +1,4 @@
 # pycurl 7.43.0 - DEPRECATED
-  - Homepage: [http://pycurl.io/](http://pycurl.io/)
-  - Manpage: [http://pycurl.io/docs/latest/index.html](http://pycurl.io/docs/latest/index.html)
-  - Changelog: [https://pypi.org/project/pycurl/#history](https://pypi.org/project/pycurl/#history)
-  - Repository: [https://github.com/pycurl/pycurl](https://github.com/pycurl/pycurl)
   - Package: [master/make/pkgs/python-pycurl/](https://github.com/Freetz-NG/freetz-ng/tree/master/make/pkgs/python-pycurl/)
   - Maintainer: -
 

--- a/docs/make/python3-cffi.md
+++ b/docs/make/python3-cffi.md
@@ -1,0 +1,8 @@
+# cffi 1.17.1
+  - Homepage: [https://cffi.readthedocs.io/](https://cffi.readthedocs.io/)
+  - Manpage: [https://cffi.readthedocs.io/en/latest/](https://cffi.readthedocs.io/en/latest/)
+  - Changelog: [https://cffi.readthedocs.io/en/latest/whatsnew.html](https://cffi.readthedocs.io/en/latest/whatsnew.html)
+  - Repository: [https://github.com/python-cffi/cffi](https://github.com/python-cffi/cffi)
+  - Package: [master/make/pkgs/python3-cffi/](https://github.com/Freetz-NG/freetz-ng/tree/master/make/pkgs/python3-cffi/)
+  - Maintainer: -
+

--- a/docs/make/python3-cryptography.md
+++ b/docs/make/python3-cryptography.md
@@ -1,0 +1,8 @@
+# cryptography 3.3.2 (last version without Rust)
+  - Homepage: [https://cryptography.io/](https://cryptography.io/)
+  - Manpage: [https://cryptography.io/en/latest/](https://cryptography.io/en/latest/)
+  - Changelog: [https://cryptography.io/en/latest/changelog/](https://cryptography.io/en/latest/changelog/)
+  - Repository: [https://github.com/pyca/cryptography](https://github.com/pyca/cryptography)
+  - Package: [master/make/pkgs/python3-cryptography/](https://github.com/Freetz-NG/freetz-ng/tree/master/make/pkgs/python3-cryptography/)
+  - Maintainer: -
+

--- a/docs/make/python3-lxml.md
+++ b/docs/make/python3-lxml.md
@@ -1,0 +1,8 @@
+# lxml 5.3.0
+  - Homepage: [https://lxml.de/](https://lxml.de/)
+  - Manpage: [https://lxml.de/tutorial.html](https://lxml.de/tutorial.html)
+  - Changelog: [https://lxml.de/changes-5.3.0.html](https://lxml.de/changes-5.3.0.html)
+  - Repository: [https://github.com/lxml/lxml](https://github.com/lxml/lxml)
+  - Package: [master/make/pkgs/python3-lxml/](https://github.com/Freetz-NG/freetz-ng/tree/master/make/pkgs/python3-lxml/)
+  - Maintainer: -
+

--- a/docs/make/python3-markupsafe.md
+++ b/docs/make/python3-markupsafe.md
@@ -1,0 +1,8 @@
+# markupsafe 3.0.2
+  - Homepage: [https://palletsprojects.com/p/markupsafe/](https://palletsprojects.com/p/markupsafe/)
+  - Manpage: [https://markupsafe.palletsprojects.com/](https://markupsafe.palletsprojects.com/)
+  - Changelog: [https://markupsafe.palletsprojects.com/en/latest/changes/](https://markupsafe.palletsprojects.com/en/latest/changes/)
+  - Repository: [https://github.com/pallets/markupsafe](https://github.com/pallets/markupsafe)
+  - Package: [master/make/pkgs/python3-markupsafe/](https://github.com/Freetz-NG/freetz-ng/tree/master/make/pkgs/python3-markupsafe/)
+  - Maintainer: -
+

--- a/docs/make/python3-numpy.md
+++ b/docs/make/python3-numpy.md
@@ -1,0 +1,8 @@
+# NumPy 2.3.3 (for Python 3) - DEVELOPER ONLY
+  - Homepage: [https://numpy.org/](https://numpy.org/)
+  - Manpage: [https://numpy.org/doc/stable/](https://numpy.org/doc/stable/)
+  - Changelog: [https://numpy.org/doc/stable/release.html](https://numpy.org/doc/stable/release.html)
+  - Repository: [https://github.com/numpy/numpy](https://github.com/numpy/numpy)
+  - Package: [master/make/pkgs/python3-numpy/](https://github.com/Freetz-NG/freetz-ng/tree/master/make/pkgs/python3-numpy/)
+  - Maintainer: -
+

--- a/docs/make/python3-pandas.md
+++ b/docs/make/python3-pandas.md
@@ -1,0 +1,8 @@
+# pandas 2.2.3 (for Python 3) - DEVELOPER ONLY
+  - Homepage: [https://pandas.pydata.org/](https://pandas.pydata.org/)
+  - Manpage: [https://pandas.pydata.org/docs/](https://pandas.pydata.org/docs/)
+  - Changelog: [https://pandas.pydata.org/docs/whatsnew/](https://pandas.pydata.org/docs/whatsnew/)
+  - Repository: [https://github.com/pandas-dev/pandas](https://github.com/pandas-dev/pandas)
+  - Package: [master/make/pkgs/python3-pandas/](https://github.com/Freetz-NG/freetz-ng/tree/master/make/pkgs/python3-pandas/)
+  - Maintainer: -
+

--- a/docs/make/python3-pillow.md
+++ b/docs/make/python3-pillow.md
@@ -1,0 +1,8 @@
+# Pillow 11.0.0 (for Python 3) - DEVELOPER ONLY
+  - Homepage: [https://python-pillow.org/](https://python-pillow.org/)
+  - Manpage: [https://pillow.readthedocs.io/](https://pillow.readthedocs.io/)
+  - Changelog: [https://pillow.readthedocs.io/en/stable/releasenotes/](https://pillow.readthedocs.io/en/stable/releasenotes/)
+  - Repository: [https://github.com/python-pillow/Pillow](https://github.com/python-pillow/Pillow)
+  - Package: [master/make/pkgs/python3-pillow/](https://github.com/Freetz-NG/freetz-ng/tree/master/make/pkgs/python3-pillow/)
+  - Maintainer: -
+

--- a/docs/make/python3-pip.md
+++ b/docs/make/python3-pip.md
@@ -1,0 +1,8 @@
+# pip 24.3.1
+  - Homepage: [https://pip.pypa.io/](https://pip.pypa.io/)
+  - Manpage: [https://pip.pypa.io/en/stable/](https://pip.pypa.io/en/stable/)
+  - Changelog: [https://pip.pypa.io/en/stable/news/](https://pip.pypa.io/en/stable/news/)
+  - Repository: [https://github.com/pypa/pip](https://github.com/pypa/pip)
+  - Package: [master/make/pkgs/python3-pip/](https://github.com/Freetz-NG/freetz-ng/tree/master/make/pkgs/python3-pip/)
+  - Maintainer: -
+

--- a/docs/make/python3-pycryptodome.md
+++ b/docs/make/python3-pycryptodome.md
@@ -1,0 +1,8 @@
+# pycryptodome 3.23.0
+  - Homepage: [https://www.pycryptodome.org/](https://www.pycryptodome.org/)
+  - Manpage: [https://www.pycryptodome.org/src/api](https://www.pycryptodome.org/src/api)
+  - Changelog: [https://www.pycryptodome.org/src/changelog](https://www.pycryptodome.org/src/changelog)
+  - Repository: [https://github.com/Legrandin/pycryptodome/](https://github.com/Legrandin/pycryptodome/)
+  - Package: [master/make/pkgs/python3-pycryptodome/](https://github.com/Freetz-NG/freetz-ng/tree/master/make/pkgs/python3-pycryptodome/)
+  - Maintainer: -
+

--- a/docs/make/python3-pyyaml.md
+++ b/docs/make/python3-pyyaml.md
@@ -1,0 +1,8 @@
+# pyyaml 6.0.2
+  - Homepage: [https://pyyaml.org/](https://pyyaml.org/)
+  - Manpage: [https://pyyaml.org/wiki/PyYAMLDocumentation](https://pyyaml.org/wiki/PyYAMLDocumentation)
+  - Changelog: [https://github.com/yaml/pyyaml/blob/main/CHANGES](https://github.com/yaml/pyyaml/blob/main/CHANGES)
+  - Repository: [https://github.com/yaml/pyyaml](https://github.com/yaml/pyyaml)
+  - Package: [master/make/pkgs/python3-pyyaml/](https://github.com/Freetz-NG/freetz-ng/tree/master/make/pkgs/python3-pyyaml/)
+  - Maintainer: -
+

--- a/docs/make/python3-setuptools.md
+++ b/docs/make/python3-setuptools.md
@@ -1,0 +1,8 @@
+# setuptools 75.6.0
+  - Homepage: [https://setuptools.pypa.io/](https://setuptools.pypa.io/)
+  - Manpage: [https://setuptools.pypa.io/en/latest/](https://setuptools.pypa.io/en/latest/)
+  - Changelog: [https://setuptools.pypa.io/en/latest/history.html](https://setuptools.pypa.io/en/latest/history.html)
+  - Repository: [https://github.com/pypa/setuptools](https://github.com/pypa/setuptools)
+  - Package: [master/make/pkgs/python3-setuptools/](https://github.com/Freetz-NG/freetz-ng/tree/master/make/pkgs/python3-setuptools/)
+  - Maintainer: -
+

--- a/docs/make/python3.md
+++ b/docs/make/python3.md
@@ -1,8 +1,8 @@
-# Python 3.13.7 - DEVELOPER
+# Python 3.13.7
   - Homepage: [https://www.python.org/](https://www.python.org/)
   - Manpage: [https://docs.python.org/3/](https://docs.python.org/3/)
   - Changelog: [https://www.python.org/downloads/](https://www.python.org/downloads/)
   - Repository: [https://github.com/python/cpython](https://github.com/python/cpython)
   - Package: [master/make/pkgs/python3/](https://github.com/Freetz-NG/freetz-ng/tree/master/make/pkgs/python3/)
-  - Maintainer: -
+  - Maintainer: [@Ircama](https://github.com/Ircama)
 

--- a/make/pkgs/python/files/root/usr/bin/python2.7
+++ b/make/pkgs/python/files/root/usr/bin/python2.7
@@ -5,5 +5,5 @@
 # libraries python and its modules depend on to ${PYTHONHOME}/lib/freetz.
 
 export PYTHONHOME="/usr"
-#export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}${LD_LIBRARY_PATH:+:}${PYTHONHOME}/lib/freetz"
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}${LD_LIBRARY_PATH:+:}${PYTHONHOME}/lib/freetz"
 exec "${PYTHONHOME}/bin/python2.7.bin" -B "$@"

--- a/make/pkgs/python3-cffi/Config.in
+++ b/make/pkgs/python3-cffi/Config.in
@@ -1,0 +1,20 @@
+config FREETZ_PACKAGE_PYTHON3_CFFI
+	bool "cffi 1.17.1"
+	depends on FREETZ_PACKAGE_PYTHON3
+	select FREETZ_LIB_libffi
+	default n
+	help
+		CFFI (C Foreign Function Interface) for Python 3.
+		
+		Interact with almost any C code from Python, based on C-like
+		declarations that you can often copy-paste from header files
+		or documentation.
+		
+		Required by many modern Python packages including:
+		- cryptography
+		- PyNaCl
+		- bcrypt
+		- argon2-cffi
+		
+		Website: https://cffi.readthedocs.io/
+		GitHub: https://github.com/python-cffi/cffi

--- a/make/pkgs/python3-cffi/python3-cffi.mk
+++ b/make/pkgs/python3-cffi/python3-cffi.mk
@@ -1,0 +1,39 @@
+$(call PKG_INIT_BIN, 1.17.1)
+$(PKG)_SOURCE:=cffi-py3-$($(PKG)_VERSION).tar.gz
+$(PKG)_SOURCE_DOWNLOAD_NAME:=cffi-$($(PKG)_VERSION).tar.gz
+$(PKG)_SITE:=https://files.pythonhosted.org/packages/source/c/cffi
+$(PKG)_HASH:=1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824
+### WEBSITE:=https://cffi.readthedocs.io/
+### MANPAGE:=https://cffi.readthedocs.io/en/latest/
+### CHANGES:=https://cffi.readthedocs.io/en/latest/whatsnew.html
+### CVSREPO:=https://github.com/python-cffi/cffi
+
+$(PKG)_DEPENDS_ON += python3
+$(PKG)_DEPENDS_ON += python3-setuptools-host
+$(PKG)_DEPENDS_ON += libffi
+
+
+$(PKG_SOURCE_DOWNLOAD)
+$(PKG_UNPACKED)
+$(PKG_CONFIGURED_NOP)
+
+$($(PKG)_DIR)/.compiled: $($(PKG)_DIR)/.configured
+	$(call Build/Py3Mod/PKG, PYTHON3_CFFI, , )
+	@touch $@
+
+$(pkg):
+
+$(pkg)-precompiled: $($(PKG)_DIR)/.compiled
+
+
+$(pkg)-clean:
+	$(RM) $(PYTHON3_CFFI_DIR)/{.configured,.compiled}
+	$(RM) -r $(PYTHON3_CFFI_DIR)/build
+
+$(pkg)-uninstall:
+	$(RM) -r \
+		$(PYTHON3_CFFI_DEST_DIR)$(PYTHON3_SITE_PKG_DIR)/cffi \
+		$(PYTHON3_CFFI_DEST_DIR)$(PYTHON3_SITE_PKG_DIR)/_cffi_backend*.so \
+		$(PYTHON3_CFFI_DEST_DIR)$(PYTHON3_SITE_PKG_DIR)/cffi-*.egg-info
+
+$(PKG_FINISH)

--- a/make/pkgs/python3-cryptography/Config.in
+++ b/make/pkgs/python3-cryptography/Config.in
@@ -1,0 +1,42 @@
+config FREETZ_PACKAGE_PYTHON3_CRYPTOGRAPHY
+	bool "cryptography 3.3.2 (last version without Rust)"
+	depends on FREETZ_PACKAGE_PYTHON3
+	select FREETZ_PACKAGE_PYTHON3_CFFI
+	select FREETZ_LIB_libcrypto if !FREETZ_PACKAGE_OPENSSL
+	select FREETZ_LIB_libssl if !FREETZ_PACKAGE_OPENSSL
+	default n
+	help
+		cryptography 3.3.2 - Last version compatible with embedded targets
+		
+		This is the last version of cryptography (3.3.2, released 2020)
+		that doesn't require Rust compiler.
+		
+		For newer cryptographic features, consider using
+		python3-pycryptodome as an alternative.
+		
+
+		See PYTHON3_CRYPTOGRAPHY_UNSUPPORTED.md for migration guide.
+		
+		---
+		
+		cryptography is a package which provides cryptographic recipes and
+		primitives to Python developers.
+		
+		Features:
+		  - SSL/TLS support
+		  - X.509 certificate handling
+		  - Symmetric encryption (AES, ChaCha20, etc.)
+		  - Asymmetric encryption (RSA, ECDSA, etc.)
+		  - Message digests and signatures
+		  - Key derivation functions
+		
+		Dependencies:
+		  - Python 3.x
+		  - cffi (Python C Foreign Function Interface)
+		  - OpenSSL >= 1.1.1 (for cryptographic operations)
+		
+		Build: Uses setuptools (no Rust required for 3.3.2)
+		
+		Size: ~2-3 MB installed
+		
+		WWW: https://cryptography.io/

--- a/make/pkgs/python3-cryptography/python3-cryptography.mk
+++ b/make/pkgs/python3-cryptography/python3-cryptography.mk
@@ -1,0 +1,46 @@
+$(call PKG_INIT_BIN, 3.3.2)
+$(PKG)_SOURCE:=cryptography-py3-$($(PKG)_VERSION).tar.gz
+$(PKG)_SOURCE_DOWNLOAD_NAME:=cryptography-$($(PKG)_VERSION).tar.gz
+$(PKG)_SITE:=https://files.pythonhosted.org/packages/source/c/cryptography
+$(PKG)_HASH:=5a60d3780149e13b7a6ff7ad6526b38846354d11a15e21068e57073e29e19bed
+### WEBSITE:=https://cryptography.io/
+### MANPAGE:=https://cryptography.io/en/latest/
+### CHANGES:=https://cryptography.io/en/latest/changelog/
+### CVSREPO:=https://github.com/pyca/cryptography
+
+$(PKG)_DEPENDS_ON += openssl python3 python3-cffi
+
+$(PKG)_CONDITIONAL_PATCHES+=$(if $(FREETZ_OPENSSL_VERSION_09),openssl-0.9,) \
+	$(if $(FREETZ_OPENSSL_VERSION_10),openssl-1.0,) \
+	$(if $(FREETZ_OPENSSL_VERSION_11),openssl-1.1,)
+
+# Rebuild Python package from source, with cross-compilation setup
+$(PKG)_REBUILD_SUBOPTS += FREETZ_PACKAGE_PYTHON3_CRYPTOGRAPHY
+$(PKG)_CATEGORY:=External (3rd party) modules
+
+$(PKG_SOURCE_DOWNLOAD)
+$(PKG_UNPACKED)
+$(PKG_CONFIGURED_NOP)
+
+$($(PKG)_DIR)/.compiled: $($(PKG)_DIR)/.configured
+	$(call Build/Py3Mod/Pip, PYTHON3_CRYPTOGRAPHY, , \
+		OPENSSL_DIR="$(TARGET_TOOLCHAIN_STAGING_DIR)/usr" \
+		OPENSSL_LIB_DIR="$(TARGET_TOOLCHAIN_STAGING_DIR)/usr/lib" \
+		OPENSSL_INCLUDE_DIR="$(TARGET_TOOLCHAIN_STAGING_DIR)/usr/include" \
+	)
+	@touch $@
+
+$(pkg):
+
+$(pkg)-precompiled: $($(PKG)_DIR)/.compiled
+
+$(pkg)-clean:
+	-$(RM) -r $(PYTHON3_CRYPTOGRAPHY_DIR)/.configured
+	-$(RM) -r $(PYTHON3_CRYPTOGRAPHY_DIR)/.compiled
+	-$(RM) -r $(PYTHON3_CRYPTOGRAPHY_DIR)/build
+
+$(pkg)-uninstall:
+	$(RM) -r $(PYTHON3_CRYPTOGRAPHY_DEST_DIR)/usr/lib/python$(PYTHON3_VERSION_MAJOR)/site-packages/cryptography
+	$(RM) -r $(PYTHON3_CRYPTOGRAPHY_DEST_DIR)/usr/lib/python$(PYTHON3_VERSION_MAJOR)/site-packages/cryptography-$(PYTHON3_CRYPTOGRAPHY_VERSION)*.egg-info
+
+$(PKG_FINISH)

--- a/make/pkgs/python3-lxml/Config.in
+++ b/make/pkgs/python3-lxml/Config.in
@@ -1,0 +1,28 @@
+config FREETZ_PACKAGE_PYTHON3_LXML
+	bool "lxml 5.3.0"
+	depends on FREETZ_PACKAGE_PYTHON3
+	select FREETZ_LIB_libxml2
+	select FREETZ_LIB_libxml2_WITH_RELAXNG if !FREETZ_PACKAGE_PYTHON3_LXML_STATIC
+	select FREETZ_LIB_libxslt
+	default n
+	help
+		lxml is a powerful XML and HTML processing library.
+		
+		Provides:
+		- Pythonic binding for libxml2 and libxslt
+		- ElementTree API for XML parsing and generation
+		- Fast and memory-efficient XML/HTML processing
+		- XPath and XSLT support (requires libxslt, not available)
+		- HTML cleaning and repair
+		
+		Common uses:
+		- Web scraping (BeautifulSoup backend)
+		- XML parsing and generation
+		- Configuration file processing
+		- Data extraction from HTML/XML
+		
+		Note: This build uses only libxml2 (without libxslt).
+		XSLT transformations will not be available.
+		
+		Website: https://lxml.de/
+		Docs: https://lxml.de/tutorial.html

--- a/make/pkgs/python3-lxml/python3-lxml.mk
+++ b/make/pkgs/python3-lxml/python3-lxml.mk
@@ -1,0 +1,48 @@
+$(call PKG_INIT_BIN, 5.3.0)
+$(PKG)_SOURCE:=lxml-py3-$($(PKG)_VERSION).tar.gz
+$(PKG)_SOURCE_DOWNLOAD_NAME:=lxml-$($(PKG)_VERSION).tar.gz
+$(PKG)_SITE:=https://files.pythonhosted.org/packages/source/l/lxml
+$(PKG)_HASH:=4e109ca30d1edec1ac60cdbe341905dc3b8f55b16855e03a54aaf59e51ec8c6f
+### WEBSITE:=https://lxml.de/
+### MANPAGE:=https://lxml.de/tutorial.html
+### CHANGES:=https://lxml.de/changes-5.3.0.html
+### CVSREPO:=https://github.com/lxml/lxml
+
+$(PKG)_DEPENDS_ON += python3
+$(PKG)_DEPENDS_ON += python3-setuptools-host
+$(PKG)_DEPENDS_ON += libxml2
+$(PKG)_DEPENDS_ON += xsltproc
+
+
+$(PKG_SOURCE_DOWNLOAD)
+$(PKG_UNPACKED)
+$(PKG_CONFIGURED_NOP)
+
+$($(PKG)_DIR)/.compiled: $($(PKG)_DIR)/.configured
+	$(call Build/Py3Mod/Generic, \
+		$(PYTHON3_LXML_DIR), \
+		build_ext \
+			--with-xslt-config=$(TARGET_TOOLCHAIN_STAGING_DIR)/usr/bin/xslt-config \
+			--with-xml2-config=$(TARGET_TOOLCHAIN_STAGING_DIR)/usr/bin/xml2-config \
+		install --prefix=/usr --root=$(abspath $(PYTHON3_LXML_DEST_DIR)), \
+		XSLT_CONFIG=$(TARGET_TOOLCHAIN_STAGING_DIR)/usr/bin/xslt-config \
+		XML2_CONFIG=$(TARGET_TOOLCHAIN_STAGING_DIR)/usr/bin/xml2-config, \
+		$(PYTHON3_LXML_DEST_DIR)$(PYTHON3_SITE_PKG_DIR) \
+	)
+	@touch $@
+
+$(pkg):
+
+$(pkg)-precompiled: $($(PKG)_DIR)/.compiled
+
+
+$(pkg)-clean:
+	$(RM) $(PYTHON3_LXML_DIR)/{.configured,.compiled}
+	$(RM) -r $(PYTHON3_LXML_DIR)/build
+
+$(pkg)-uninstall:
+	$(RM) -r \
+		$(PYTHON3_LXML_DEST_DIR)$(PYTHON3_SITE_PKG_DIR)/lxml \
+		$(PYTHON3_LXML_DEST_DIR)$(PYTHON3_SITE_PKG_DIR)/lxml-*.dist-info
+
+$(PKG_FINISH)

--- a/make/pkgs/python3-markupsafe/Config.in
+++ b/make/pkgs/python3-markupsafe/Config.in
@@ -1,0 +1,24 @@
+config FREETZ_PACKAGE_PYTHON3_MARKUPSAFE
+	bool "markupsafe 3.0.2"
+	depends on FREETZ_PACKAGE_PYTHON3
+	default n
+	help
+		MarkupSafe implements a text object that escapes characters
+		for safe use in HTML and XML.
+		
+		Provides:
+		- Fast C implementation of text escaping
+		- Safe string handling for web templates
+		- HTML/XML entity encoding
+		- Integration with Jinja2 and other template engines
+		
+		Common uses:
+		- Template rendering (Jinja2, Mako)
+		- Web frameworks (Flask, Django)
+		- HTML/XML generation
+		- XSS attack prevention
+		
+		This is a core dependency for many web frameworks.
+		
+		Website: https://palletsprojects.com/p/markupsafe/
+		Docs: https://markupsafe.palletsprojects.com/

--- a/make/pkgs/python3-markupsafe/python3-markupsafe.mk
+++ b/make/pkgs/python3-markupsafe/python3-markupsafe.mk
@@ -1,0 +1,37 @@
+$(call PKG_INIT_BIN, 3.0.2)
+$(PKG)_SOURCE:=markupsafe-py3-$($(PKG)_VERSION).tar.gz
+$(PKG)_SOURCE_DOWNLOAD_NAME:=markupsafe-$($(PKG)_VERSION).tar.gz
+$(PKG)_SITE:=https://files.pythonhosted.org/packages/source/m/markupsafe
+$(PKG)_HASH:=ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0
+### WEBSITE:=https://palletsprojects.com/p/markupsafe/
+### MANPAGE:=https://markupsafe.palletsprojects.com/
+### CHANGES:=https://markupsafe.palletsprojects.com/en/latest/changes/
+### CVSREPO:=https://github.com/pallets/markupsafe
+
+$(PKG)_DEPENDS_ON += python3
+$(PKG)_DEPENDS_ON += python3-setuptools-host
+
+
+$(PKG_SOURCE_DOWNLOAD)
+$(PKG_UNPACKED)
+$(PKG_CONFIGURED_NOP)
+
+$($(PKG)_DIR)/.compiled: $($(PKG)_DIR)/.configured
+	$(call Build/Py3Mod/PKG, PYTHON3_MARKUPSAFE, , )
+	@touch $@
+
+$(pkg):
+
+$(pkg)-precompiled: $($(PKG)_DIR)/.compiled
+
+
+$(pkg)-clean:
+	$(RM) $(PYTHON3_MARKUPSAFE_DIR)/{.configured,.compiled}
+	$(RM) -r $(PYTHON3_MARKUPSAFE_DIR)/build
+
+$(pkg)-uninstall:
+	$(RM) -r \
+		$(PYTHON3_MARKUPSAFE_DEST_DIR)$(PYTHON3_SITE_PKG_DIR)/markupsafe \
+		$(PYTHON3_MARKUPSAFE_DEST_DIR)$(PYTHON3_SITE_PKG_DIR)/MarkupSafe-*.dist-info
+
+$(PKG_FINISH)

--- a/make/pkgs/python3-numpy/Config.in
+++ b/make/pkgs/python3-numpy/Config.in
@@ -1,0 +1,35 @@
+comment "NumPy requires external storage  (Enable 'External processing' in the main menu)"
+	depends on FREETZ_PACKAGE_PYTHON3 && !EXTERNAL_ENABLED && FREETZ_SHOW_DEVELOPER
+
+config FREETZ_PACKAGE_PYTHON3_NUMPY
+	bool "NumPy 2.3.3 (for Python 3) - DEVELOPER ONLY"
+	depends on FREETZ_PACKAGE_PYTHON3
+	depends on EXTERNAL_ENABLED
+	depends on FREETZ_SHOW_DEVELOPER
+	default n
+	help
+		NumPy is the fundamental package for scientific computing in Python.
+		
+		NEW: NumPy 2.3.3 with Meson build system (compatible with Python 3.13).
+		Cross-compilation tested but may have edge cases.
+		
+		Provides:
+		- Powerful N-dimensional array object (ndarray)
+		- Sophisticated broadcasting functions
+		- Linear algebra, Fourier transform, random number capabilities
+		- Tools for integrating C/C++ and Fortran code
+		
+		Common uses:
+		- Data analysis and machine learning
+		- Scientific and engineering computations
+		- Image and signal processing
+		- Statistical operations
+		
+		WARNING: NumPy is large (~15-20 MB) and MUST be externalized.
+		Ensure sufficient USB storage is available.
+		
+		This build uses reference BLAS (slower but no extra dependencies).
+		For performance-critical applications, consider optimized libraries.
+		
+		Website: https://numpy.org/
+		Docs: https://numpy.org/doc/stable/

--- a/make/pkgs/python3-numpy/external.in
+++ b/make/pkgs/python3-numpy/external.in
@@ -1,0 +1,8 @@
+config EXTERNAL_FREETZ_PACKAGE_PYTHON3_NUMPY
+	depends on FREETZ_PACKAGE_PYTHON3_NUMPY
+	bool "NumPy (externalization required)"
+	default y
+	help
+		NumPy is large (~15-20 MB) and MUST be externalized to USB storage.
+		
+		This option is automatically selected when you enable NumPy.

--- a/make/pkgs/python3-numpy/patches/100-make-complex-math-funcs-optional.patch
+++ b/make/pkgs/python3-numpy/patches/100-make-complex-math-funcs-optional.patch
@@ -1,0 +1,17 @@
+--- numpy/_core/meson.build.orig
++++ numpy/_core/meson.build
+@@ -217,11 +217,8 @@
+ endforeach
+ 
+ mandatory_complex_math_funcs = [
+-  'csin', 'csinh', 'ccos', 'ccosh', 'ctan', 'ctanh', 'creal', 'cimag', 'conj'
++  # uClibc doesn't implement complex math functions - make them optional
+ ]
+-foreach func: mandatory_complex_math_funcs
+-  if not cc.has_function(func, prefix: '#include <complex.h>', dependencies: m_dep)
+-    error(f'Function `@func@` not found')
+-  endif
+-endforeach
++# Skip mandatory complex math check for embedded systems
++# The c99_complex_funcs list below will detect available functions
+ 

--- a/make/pkgs/python3-numpy/patches/200-disable-fenv-for-uclibc.patch
+++ b/make/pkgs/python3-numpy/patches/200-disable-fenv-for-uclibc.patch
@@ -1,0 +1,20 @@
+--- numpy/_core/src/common/float_status.hpp.orig
++++ numpy/_core/src/common/float_status.hpp
+@@ -3,7 +3,17 @@
+ 
+ #include "npstd.hpp"
+ 
++// uClibc doesn't implement fenv functions, only provides the header
++#if defined(__UCLIBC__)
++#define NPY_HAVE_FENV_FUNCS 0
++// Provide dummy implementations
++#define fetestexcept(x) 0
++#define feclearexcept(x) ((void)0)
++#define feraiseexcept(x) ((void)0)
++#else
++#define NPY_HAVE_FENV_FUNCS 1
+ #include <fenv.h>
++#endif
+ 
+ namespace np {
+ 

--- a/make/pkgs/python3-numpy/patches/210-add-fenv-stubs-for-uclibc.patch
+++ b/make/pkgs/python3-numpy/patches/210-add-fenv-stubs-for-uclibc.patch
@@ -1,0 +1,25 @@
+--- numpy/_core/src/npymath/ieee754.c.src.orig
++++ numpy/_core/src/npymath/ieee754.c.src
+@@ -328,7 +328,22 @@
+  * portability.  This should be unnecessary with C99/C++11 and further
+  * functionality can be used from `fenv.h` directly.
+  */
++#if defined(__UCLIBC__)
++/* uClibc doesn't provide fenv.h - provide minimal stubs */
++#define FE_DIVBYZERO 0
++#define FE_OVERFLOW 0
++#define FE_UNDERFLOW 0
++#define FE_INVALID 0
++#define FE_INEXACT 0
++#define FE_ALL_EXCEPT 0
++static inline int fetestexcept(int excepts) { return 0; }
++static inline int feclearexcept(int excepts) { return 0; }
++static inline int fegetenv(void *envp) { return 0; }
++static inline int fesetenv(const void *envp) { return 0; }
++static inline int feraiseexcept(int excepts) { return 0; }
++#else
+ #  include <fenv.h>
++#endif
+ 
+ /*
+  * According to the C99 standard FE_DIVBYZERO, etc. may not be provided when

--- a/make/pkgs/python3-numpy/patches/220-add-fenv-stubs-for-uclibc-cpp.patch
+++ b/make/pkgs/python3-numpy/patches/220-add-fenv-stubs-for-uclibc-cpp.patch
@@ -1,0 +1,25 @@
+--- numpy/_core/src/npymath/ieee754.cpp.orig
++++ numpy/_core/src/npymath/ieee754.cpp
+@@ -393,7 +393,22 @@
+  * portability.  This should be unnecessary with C99/C++11 and further
+  * functionality can be used from `fenv.h` directly. 
+  */
++#if defined(__UCLIBC__)
++/* uClibc doesn't provide fenv.h - provide minimal stubs */
++#define FE_DIVBYZERO 0
++#define FE_OVERFLOW 0
++#define FE_UNDERFLOW 0
++#define FE_INVALID 0
++#define FE_INEXACT 0
++#define FE_ALL_EXCEPT 0
++static inline int fetestexcept(int excepts) { return 0; }
++static inline int feclearexcept(int excepts) { return 0; }
++static inline int fegetenv(void *envp) { return 0; }
++static inline int fesetenv(const void *envp) { return 0; }
++static inline int feraiseexcept(int excepts) { return 0; }
++#else
+ #include <fenv.h>
++#endif
+ 
+ /*
+  * According to the C99 standard FE_DIVBYZERO, etc. may not be provided when

--- a/make/pkgs/python3-numpy/patches/300-rename-getchar-to-avoid-macro-conflict.patch
+++ b/make/pkgs/python3-numpy/patches/300-rename-getchar-to-avoid-macro-conflict.patch
@@ -1,0 +1,44 @@
+--- numpy/_core/src/umath/string_buffer.h.orig	2025-10-04 12:16:36.738728020 +0200
++++ numpy/_core/src/umath/string_buffer.h	2025-10-04 12:16:36.814976898 +0200
+@@ -37,12 +37,12 @@
+ 
+ template <ENCODING enc>
+ inline npy_ucs4
+-getchar(const unsigned char *buf, int *bytes);
++npy_getchar(const unsigned char *buf, int *bytes);
+ 
+ 
+ template <>
+ inline npy_ucs4
+-getchar<ENCODING::ASCII>(const unsigned char *buf, int *bytes)
++npy_getchar<ENCODING::ASCII>(const unsigned char *buf, int *bytes)
+ {
+     *bytes = 1;
+     return (npy_ucs4) *buf;
+@@ -51,7 +51,7 @@
+ 
+ template <>
+ inline npy_ucs4
+-getchar<ENCODING::UTF32>(const unsigned char *buf, int *bytes)
++npy_getchar<ENCODING::UTF32>(const unsigned char *buf, int *bytes)
+ {
+     *bytes = 4;
+     return *(npy_ucs4 *)buf;
+@@ -59,7 +59,7 @@
+ 
+ template <>
+ inline npy_ucs4
+-getchar<ENCODING::UTF8>(const unsigned char *buf, int *bytes)
++npy_getchar<ENCODING::UTF8>(const unsigned char *buf, int *bytes)
+ {
+     Py_UCS4 codepoint;
+     *bytes = utf8_char_to_ucs4_code(buf, &codepoint);
+@@ -378,7 +378,7 @@
+     operator*()
+     {
+         int bytes;
+-        return getchar<enc>((unsigned char *) buf, &bytes);
++        return npy_getchar<enc>((unsigned char *) buf, &bytes);
+     }
+ 
+     inline int

--- a/make/pkgs/python3-numpy/patches/400-fix-cpp-headers-for-uclibc.patch
+++ b/make/pkgs/python3-numpy/patches/400-fix-cpp-headers-for-uclibc.patch
@@ -1,0 +1,65 @@
+--- numpy/_core/src/common/npstd.hpp.orig
++++ numpy/_core/src/common/npstd.hpp
+@@ -3,8 +3,12 @@
+ 
+ #include <numpy/npy_common.h>
+ 
++#include <features.h>
++
+ #include <cstddef>
+ #include <cstring>
+ #include <cctype>
++#ifndef __UCLIBC__
+ #include <cstdint>
++#endif
+ 
+ #include <string>
+--- numpy/_core/src/common/utils.hpp.orig
++++ numpy/_core/src/common/utils.hpp
+@@ -7,8 +7,12 @@
+     #include <bit>
+ #endif
+ 
++#include <features.h>
++
+ #include <type_traits>
+ #include <string.h>
++#ifndef __UCLIBC__
+ #include <cstdint>
++#endif
+ #include <cassert>
+ 
+--- numpy/_core/src/highway/hwy/abort.cc.orig
++++ numpy/_core/src/highway/hwy/abort.cc
+@@ -6,9 +6,13 @@
+ 
+ #include "hwy/abort.h"
+ 
++#include <features.h>
++
+ #include <stdarg.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ 
++#ifndef __UCLIBC__
+ #include <atomic>
++#endif
+ #include <string>
+--- numpy/_core/src/highway/hwy/targets.h.orig
++++ numpy/_core/src/highway/hwy/targets.h
+@@ -25,9 +25,15 @@
+ // For SIMD module implementations and their callers. Defines which targets to
+ // generate and call.
+ 
++#include <features.h>
++
+ #include "hwy/base.h"
+ #include "hwy/detect_targets.h"
+ #include "hwy/highway_export.h"
+ 
++#ifdef __UCLIBC__
++#define HWY_NO_LIBCXX
++#endif
++
+ #if !defined(HWY_NO_LIBCXX)
+ #include <atomic>

--- a/make/pkgs/python3-numpy/python3-numpy.mk
+++ b/make/pkgs/python3-numpy/python3-numpy.mk
@@ -1,0 +1,38 @@
+$(call PKG_INIT_BIN, 2.3.3)
+$(PKG)_SOURCE:=numpy-py3-$($(PKG)_VERSION).tar.gz
+$(PKG)_SOURCE_DOWNLOAD_NAME:=numpy-$($(PKG)_VERSION).tar.gz
+$(PKG)_SITE:=https://files.pythonhosted.org/packages/d0/19/95b3d357407220ed24c139018d2518fab0a61a948e68286a25f1a4d049ff
+$(PKG)_HASH:=ddc7c39727ba62b80dfdbedf400d1c10ddfa8eefbd7ec8dcb118be8b56d31029
+### WEBSITE:=https://numpy.org/
+### MANPAGE:=https://numpy.org/doc/stable/
+### CHANGES:=https://numpy.org/doc/stable/release.html
+### CVSREPO:=https://github.com/numpy/numpy
+
+$(PKG)_DEPENDS_ON += python3
+$(PKG)_DEPENDS_ON += meson-host
+$(PKG)_DEPENDS_ON += ninja-host
+
+
+$(PKG_SOURCE_DOWNLOAD)
+$(PKG_UNPACKED)
+$(PKG_CONFIGURED_NOP)
+
+$($(PKG)_DIR)/.compiled: $($(PKG)_DIR)/.configured
+	$(call Build/Py3Mod/Pip, PYTHON3_NUMPY, , , isolated)
+	@touch $@
+
+$(pkg):
+
+$(pkg)-precompiled: $($(PKG)_DIR)/.compiled
+
+
+$(pkg)-clean:
+	$(RM) $(PYTHON3_NUMPY_DIR)/{.configured,.compiled}
+	$(RM) -r $(PYTHON3_NUMPY_DIR)/build
+
+$(pkg)-uninstall:
+	$(RM) -r \
+		$(PYTHON3_NUMPY_DEST_DIR)$(PYTHON3_SITE_PKG_DIR)/numpy \
+		$(PYTHON3_NUMPY_DEST_DIR)$(PYTHON3_SITE_PKG_DIR)/numpy-*.dist-info
+
+$(PKG_FINISH)

--- a/make/pkgs/python3-pandas/Config.in
+++ b/make/pkgs/python3-pandas/Config.in
@@ -1,0 +1,34 @@
+comment "pandas requires external storage  (Enable 'External processing' in the main menu)"
+	depends on FREETZ_PACKAGE_PYTHON3 && !EXTERNAL_ENABLED && FREETZ_DL_TOOL_developer
+
+config FREETZ_PACKAGE_PYTHON3_PANDAS
+	bool "pandas 2.2.3 (for Python 3) - DEVELOPER ONLY"
+	depends on FREETZ_PACKAGE_PYTHON3
+	depends on FREETZ_PACKAGE_PYTHON3_NUMPY
+	depends on EXTERNAL_ENABLED
+	depends on FREETZ_DL_TOOL_developer
+	default n
+	help
+		pandas is a powerful data analysis and manipulation library.
+		
+		WARNING: Requires NumPy (currently developer-only).
+		
+		Provides:
+		- DataFrame and Series data structures
+		- Data alignment and integrated handling of missing data
+		- Reshaping and pivoting of data sets
+		- Label-based slicing, indexing, and subsetting
+		- Time series functionality
+		- Data I/O (CSV, Excel, SQL, HDF5, JSON, Parquet)
+		
+		Common uses:
+		- Data cleaning and preparation
+		- Statistical analysis
+		- Time series analysis
+		- Data visualization (with matplotlib)
+		
+		WARNING: pandas is large (~10-15 MB) and REQUIRES NumPy.
+		Both MUST be externalized to USB storage.
+		
+		Website: https://pandas.pydata.org/
+		Docs: https://pandas.pydata.org/docs/

--- a/make/pkgs/python3-pandas/external.in
+++ b/make/pkgs/python3-pandas/external.in
@@ -1,0 +1,8 @@
+config EXTERNAL_FREETZ_PACKAGE_PYTHON3_PANDAS
+	depends on FREETZ_PACKAGE_PYTHON3_PANDAS
+	bool "pandas (externalization required)"
+	default y
+	help
+		pandas is large (~10-15 MB) and MUST be externalized to USB storage.
+		
+		This option is automatically selected when you enable pandas.

--- a/make/pkgs/python3-pandas/python3-pandas.mk
+++ b/make/pkgs/python3-pandas/python3-pandas.mk
@@ -1,0 +1,38 @@
+$(call PKG_INIT_BIN, 2.2.3)
+$(PKG)_SOURCE:=pandas-py3-$($(PKG)_VERSION).tar.gz
+$(PKG)_SOURCE_DOWNLOAD_NAME:=pandas-$($(PKG)_VERSION).tar.gz
+$(PKG)_SITE:=https://files.pythonhosted.org/packages/source/p/pandas
+$(PKG)_HASH:=4f18ba62b61d7e192368b84517265a99b4d7ee8912f8708660fb4a366cc82667
+### WEBSITE:=https://pandas.pydata.org/
+### MANPAGE:=https://pandas.pydata.org/docs/
+### CHANGES:=https://pandas.pydata.org/docs/whatsnew/
+### CVSREPO:=https://github.com/pandas-dev/pandas
+
+$(PKG)_DEPENDS_ON += python3
+$(PKG)_DEPENDS_ON += python3-setuptools-host
+$(PKG)_DEPENDS_ON += python3-numpy
+
+
+$(PKG_SOURCE_DOWNLOAD)
+$(PKG_UNPACKED)
+$(PKG_CONFIGURED_NOP)
+
+$($(PKG)_DIR)/.compiled: $($(PKG)_DIR)/.configured
+	$(call Build/Py3Mod/PKG, PYTHON3_PANDAS, , )
+	@touch $@
+
+$(pkg):
+
+$(pkg)-precompiled: $($(PKG)_DIR)/.compiled
+
+
+$(pkg)-clean:
+	$(RM) $(PYTHON3_PANDAS_DIR)/{.configured,.compiled}
+	$(RM) -r $(PYTHON3_PANDAS_DIR)/build
+
+$(pkg)-uninstall:
+	$(RM) -r \
+		$(PYTHON3_PANDAS_DEST_DIR)$(PYTHON3_SITE_PKG_DIR)/pandas \
+		$(PYTHON3_PANDAS_DEST_DIR)$(PYTHON3_SITE_PKG_DIR)/pandas-*.dist-info
+
+$(PKG_FINISH)

--- a/make/pkgs/python3-pillow/Config.in
+++ b/make/pkgs/python3-pillow/Config.in
@@ -1,0 +1,25 @@
+config FREETZ_PACKAGE_PYTHON3_PILLOW
+	bool "Pillow 11.0.0 (for Python 3) - DEVELOPER ONLY"
+	depends on FREETZ_PACKAGE_PYTHON3
+	depends on FREETZ_DL_TOOL_developer
+	select FREETZ_LIB_libjpeg
+	select FREETZ_LIB_libpng
+	select FREETZ_LIB_libz
+	default n
+	help
+		Pillow is the friendly PIL (Python Imaging Library) fork for Python 3.
+		
+		WARNING: Cross-compilation issues with host include paths.
+		Provides extensive file format support, efficient internal
+		representation, and powerful image processing capabilities.
+		
+		Supported formats: PNG, JPEG, GIF, TIFF, BMP, WebP, and many more.
+		
+		Common uses:
+		- Image manipulation and processing
+		- Thumbnail generation
+		- Image format conversion
+		- Computer vision preprocessing
+		
+		Website: https://python-pillow.org/
+		GitHub: https://github.com/python-pillow/Pillow

--- a/make/pkgs/python3-pillow/python3-pillow.mk
+++ b/make/pkgs/python3-pillow/python3-pillow.mk
@@ -1,0 +1,40 @@
+$(call PKG_INIT_BIN, 11.0.0)
+$(PKG)_SOURCE:=pillow-py3-$($(PKG)_VERSION).tar.gz
+$(PKG)_SOURCE_DOWNLOAD_NAME:=pillow-$($(PKG)_VERSION).tar.gz
+$(PKG)_SITE:=https://files.pythonhosted.org/packages/source/p/pillow
+$(PKG)_HASH:=72bacbaf24ac003fea9bff9837d1eedb6088758d41e100c1552930151f677739
+### WEBSITE:=https://python-pillow.org/
+### MANPAGE:=https://pillow.readthedocs.io/
+### CHANGES:=https://pillow.readthedocs.io/en/stable/releasenotes/
+### CVSREPO:=https://github.com/python-pillow/Pillow
+
+$(PKG)_DEPENDS_ON += python3
+$(PKG)_DEPENDS_ON += python3-setuptools-host
+$(PKG)_DEPENDS_ON += jpeg
+$(PKG)_DEPENDS_ON += libpng
+$(PKG)_DEPENDS_ON += zlib
+
+
+$(PKG_SOURCE_DOWNLOAD)
+$(PKG_UNPACKED)
+$(PKG_CONFIGURED_NOP)
+
+$($(PKG)_DIR)/.compiled: $($(PKG)_DIR)/.configured
+	$(call Build/Py3Mod/PKG, PYTHON3_PILLOW, , )
+	@touch $@
+
+$(pkg):
+
+$(pkg)-precompiled: $($(PKG)_DIR)/.compiled
+
+
+$(pkg)-clean:
+	$(RM) $(PYTHON3_PILLOW_DIR)/{.configured,.compiled}
+	$(RM) -r $(PYTHON3_PILLOW_DIR)/build
+
+$(pkg)-uninstall:
+	$(RM) -r \
+		$(PYTHON3_PILLOW_DEST_DIR)$(PYTHON3_SITE_PKG_DIR)/PIL \
+		$(PYTHON3_PILLOW_DEST_DIR)$(PYTHON3_SITE_PKG_DIR)/pillow-*.egg-info
+
+$(PKG_FINISH)

--- a/make/pkgs/python3-pip/Config.in
+++ b/make/pkgs/python3-pip/Config.in
@@ -1,0 +1,29 @@
+config FREETZ_PACKAGE_PYTHON3_PIP
+	bool "pip 24.3.1"
+	depends on FREETZ_PACKAGE_PYTHON3
+	select FREETZ_PACKAGE_PYTHON3_SETUPTOOLS
+	default n
+	help
+		pip is the package installer for Python 3.
+		
+		Allows you to install and manage additional Python packages
+		from PyPI (Python Package Index) and other sources.
+		
+		Common uses:
+		- Install pure-Python packages on the router
+		- Manage Python package dependencies
+		- Install packages from PyPI, git, local files
+		- Upgrade and uninstall packages
+		
+		Usage examples:
+		  pip3 install requests
+		  pip3 install flask
+		  pip3 list
+		  pip3 uninstall package-name
+		
+		Note: For packages with C extensions, it's better to
+		use pre-compiled modules from the "3rd-party modules" menu.
+		Pip works best for pure-Python packages.
+		
+		Website: https://pip.pypa.io/
+		Docs: https://pip.pypa.io/en/stable/

--- a/make/pkgs/python3-pip/python3-pip.mk
+++ b/make/pkgs/python3-pip/python3-pip.mk
@@ -1,0 +1,39 @@
+$(call PKG_INIT_BIN, 24.3.1)
+$(PKG)_SOURCE:=pip-py3-$($(PKG)_VERSION).tar.gz
+$(PKG)_SOURCE_DOWNLOAD_NAME:=pip-$($(PKG)_VERSION).tar.gz
+$(PKG)_SITE:=https://files.pythonhosted.org/packages/source/p/pip
+$(PKG)_HASH:=ebcb60557f2aefabc2e0f918751cd24ea0d56d8ec5445fe1807f1d2109660b99
+### WEBSITE:=https://pip.pypa.io/
+### MANPAGE:=https://pip.pypa.io/en/stable/
+### CHANGES:=https://pip.pypa.io/en/stable/news/
+### CVSREPO:=https://github.com/pypa/pip
+
+$(PKG)_DEPENDS_ON += python3
+$(PKG)_DEPENDS_ON += python3-setuptools
+
+
+$(PKG_SOURCE_DOWNLOAD)
+$(PKG_UNPACKED)
+$(PKG_CONFIGURED_NOP)
+
+$($(PKG)_DIR)/.compiled: $($(PKG)_DIR)/.configured
+	$(call Build/Py3Mod/Pip, PYTHON3_PIP, , )
+	@touch $@
+
+$(pkg):
+
+$(pkg)-precompiled: $($(PKG)_DIR)/.compiled
+
+
+$(pkg)-clean:
+	$(RM) $(PYTHON3_PIP_DIR)/{.configured,.compiled}
+	$(RM) -r $(PYTHON3_PIP_DIR)/build
+
+$(pkg)-uninstall:
+	$(RM) -r \
+		$(PYTHON3_PIP_DEST_DIR)$(PYTHON3_SITE_PKG_DIR)/pip \
+		$(PYTHON3_PIP_DEST_DIR)$(PYTHON3_SITE_PKG_DIR)/pip-*.dist-info \
+		$(PYTHON3_PIP_DEST_DIR)/usr/bin/pip* \
+		$(PYTHON3_PIP_DEST_DIR)/usr/bin/pip3*
+
+$(PKG_FINISH)

--- a/make/pkgs/python3-pycryptodome/Config.in
+++ b/make/pkgs/python3-pycryptodome/Config.in
@@ -1,0 +1,19 @@
+config FREETZ_PACKAGE_PYTHON3_PYCRYPTODOME
+	bool "pycryptodome 3.23.0"
+	depends on FREETZ_PACKAGE_PYTHON3
+	default n
+	help
+		PyCryptodome is a self-contained Python 3 package of low-level
+		cryptographic primitives.
+		
+		It's a fork of PyCrypto that has been enhanced for modern systems
+		and Python 3 compatibility.
+		
+		Features:
+		- AES, DES, 3DES, ARC2, ARC4, Blowfish, CAST, Salsa20, ChaCha20
+		- RSA, DSA, ECC (NIST P-curves and Curve25519)
+		- SHA-1, SHA-2, SHA-3, BLAKE2, HMAC, CMAC, PBKDF2
+		- And many more cryptographic primitives
+		
+		Website: https://www.pycryptodome.org/
+		GitHub: https://github.com/Legrandin/pycryptodome

--- a/make/pkgs/python3-pycryptodome/python3-pycryptodome.mk
+++ b/make/pkgs/python3-pycryptodome/python3-pycryptodome.mk
@@ -1,0 +1,37 @@
+$(call PKG_INIT_BIN, 3.23.0)
+$(PKG)_SOURCE:=pycryptodome-py3-$($(PKG)_VERSION).tar.gz
+$(PKG)_SOURCE_DOWNLOAD_NAME:=pycryptodome-$($(PKG)_VERSION).tar.gz
+$(PKG)_SITE:=https://files.pythonhosted.org/packages/source/p/pycryptodome
+$(PKG)_HASH:=447700a657182d60338bab09fdb27518f8856aecd80ae4c6bdddb67ff5da44ef
+### WEBSITE:=https://www.pycryptodome.org/
+### MANPAGE:=https://www.pycryptodome.org/src/api
+### CHANGES:=https://www.pycryptodome.org/src/changelog
+### CVSREPO:=https://github.com/Legrandin/pycryptodome/
+
+$(PKG)_DEPENDS_ON += python3
+$(PKG)_DEPENDS_ON += python3-setuptools-host
+
+
+$(PKG_SOURCE_DOWNLOAD)
+$(PKG_UNPACKED)
+$(PKG_CONFIGURED_NOP)
+
+$($(PKG)_DIR)/.compiled: $($(PKG)_DIR)/.configured
+	$(call Build/Py3Mod/PKG, PYTHON3_PYCRYPTODOME, , )
+	@touch $@
+
+$(pkg):
+
+$(pkg)-precompiled: $($(PKG)_DIR)/.compiled
+
+
+$(pkg)-clean:
+	$(RM) $(PYTHON3_PYCRYPTODOME_DIR)/{.configured,.compiled}
+	$(RM) -r $(PYTHON3_PYCRYPTODOME_DIR)/build
+
+$(pkg)-uninstall:
+	$(RM) -r \
+		$(PYTHON3_PYCRYPTODOME_DEST_DIR)$(PYTHON3_SITE_PKG_DIR)/Crypto \
+		$(PYTHON3_PYCRYPTODOME_DEST_DIR)$(PYTHON3_SITE_PKG_DIR)/pycryptodome-*.egg-info
+
+$(PKG_FINISH)

--- a/make/pkgs/python3-pyyaml/Config.in
+++ b/make/pkgs/python3-pyyaml/Config.in
@@ -1,0 +1,26 @@
+config FREETZ_PACKAGE_PYTHON3_PYYAML
+	bool "pyyaml 6.0.2"
+	depends on FREETZ_PACKAGE_PYTHON3
+	select FREETZ_LIB_libyaml
+	default n
+	help
+		PyYAML is a full-featured YAML framework for Python.
+		
+		Provides:
+		- Complete YAML 1.1 parser and emitter
+		- Python object serialization/deserialization
+		- Support for user-defined Python objects
+		- Unicode support
+		- Low-level event-based API (LibYAML binding)
+		- High-level object-oriented API
+		
+		Common uses:
+		- Configuration file parsing
+		- Data serialization (alternative to JSON/XML)
+		- DevOps and infrastructure automation
+		- CI/CD pipeline configurations
+		
+		This build uses LibYAML C library for faster parsing.
+		
+		Website: https://pyyaml.org/
+		Docs: https://pyyaml.org/wiki/PyYAMLDocumentation

--- a/make/pkgs/python3-pyyaml/python3-pyyaml.mk
+++ b/make/pkgs/python3-pyyaml/python3-pyyaml.mk
@@ -1,0 +1,39 @@
+$(call PKG_INIT_BIN, 6.0.2)
+$(PKG)_SOURCE:=pyyaml-py3-$($(PKG)_VERSION).tar.gz
+$(PKG)_SOURCE_DOWNLOAD_NAME:=pyyaml-$($(PKG)_VERSION).tar.gz
+$(PKG)_SITE:=https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17
+$(PKG)_HASH:=d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e
+### WEBSITE:=https://pyyaml.org/
+### MANPAGE:=https://pyyaml.org/wiki/PyYAMLDocumentation
+### CHANGES:=https://github.com/yaml/pyyaml/blob/main/CHANGES
+### CVSREPO:=https://github.com/yaml/pyyaml
+
+$(PKG)_DEPENDS_ON += python3
+$(PKG)_DEPENDS_ON += python3-setuptools-host
+$(PKG)_DEPENDS_ON += yaml
+
+
+$(PKG_SOURCE_DOWNLOAD)
+$(PKG_UNPACKED)
+$(PKG_CONFIGURED_NOP)
+
+$($(PKG)_DIR)/.compiled: $($(PKG)_DIR)/.configured
+	$(call Build/Py3Mod/PKG, PYTHON3_PYYAML, , )
+	@touch $@
+
+$(pkg):
+
+$(pkg)-precompiled: $($(PKG)_DIR)/.compiled
+
+
+$(pkg)-clean:
+	$(RM) $(PYTHON3_PYYAML_DIR)/{.configured,.compiled}
+	$(RM) -r $(PYTHON3_PYYAML_DIR)/build
+
+$(pkg)-uninstall:
+	$(RM) -r \
+		$(PYTHON3_PYYAML_DEST_DIR)$(PYTHON3_SITE_PKG_DIR)/yaml \
+		$(PYTHON3_PYYAML_DEST_DIR)$(PYTHON3_SITE_PKG_DIR)/_yaml \
+		$(PYTHON3_PYYAML_DEST_DIR)$(PYTHON3_SITE_PKG_DIR)/PyYAML-*.dist-info
+
+$(PKG_FINISH)

--- a/make/pkgs/python3-setuptools/Config.in
+++ b/make/pkgs/python3-setuptools/Config.in
@@ -1,0 +1,21 @@
+config FREETZ_PACKAGE_PYTHON3_SETUPTOOLS
+	bool "setuptools 75.6.0"
+	depends on FREETZ_PACKAGE_PYTHON3
+	default n
+	help
+		setuptools is a collection of enhancements to Python distutils.
+		
+		Required by pip and many Python packages for:
+		- Package installation
+		- Dependency management
+		- Entry point discovery
+		- Package resource management
+		
+		This is the runtime version of setuptools.
+		The host version (python3-setuptools-host) is used during
+		firmware build, while this version runs on the Fritz!Box.
+		
+		Automatically selected when you install pip.
+		
+		Website: https://setuptools.pypa.io/
+		Docs: https://setuptools.pypa.io/en/latest/

--- a/make/pkgs/python3-setuptools/python3-setuptools.mk
+++ b/make/pkgs/python3-setuptools/python3-setuptools.mk
@@ -1,0 +1,39 @@
+$(call PKG_INIT_BIN, 75.6.0)
+$(PKG)_SOURCE:=setuptools-py3-$($(PKG)_VERSION).tar.gz
+$(PKG)_SOURCE_DOWNLOAD_NAME:=setuptools-$($(PKG)_VERSION).tar.gz
+$(PKG)_SITE:=https://files.pythonhosted.org/packages/source/s/setuptools
+$(PKG)_HASH:=8199222558df7c86216af4f84c30e9b34a61d8ba19366cc914424cdbd28252f6
+### WEBSITE:=https://setuptools.pypa.io/
+### MANPAGE:=https://setuptools.pypa.io/en/latest/
+### CHANGES:=https://setuptools.pypa.io/en/latest/history.html
+### CVSREPO:=https://github.com/pypa/setuptools
+
+$(PKG)_DEPENDS_ON += python3
+$(PKG)_DEPENDS_ON += python3-setuptools-host
+
+
+$(PKG_SOURCE_DOWNLOAD)
+$(PKG_UNPACKED)
+$(PKG_CONFIGURED_NOP)
+
+$($(PKG)_DIR)/.compiled: $($(PKG)_DIR)/.configured
+	$(call Build/Py3Mod/PKG, PYTHON3_SETUPTOOLS, , )
+	@touch $@
+
+$(pkg):
+
+$(pkg)-precompiled: $($(PKG)_DIR)/.compiled
+
+
+$(pkg)-clean:
+	$(RM) $(PYTHON3_SETUPTOOLS_DIR)/{.configured,.compiled}
+	$(RM) -r $(PYTHON3_SETUPTOOLS_DIR)/build
+
+$(pkg)-uninstall:
+	$(RM) -r \
+		$(PYTHON3_SETUPTOOLS_DEST_DIR)$(PYTHON3_SITE_PKG_DIR)/setuptools \
+		$(PYTHON3_SETUPTOOLS_DEST_DIR)$(PYTHON3_SITE_PKG_DIR)/setuptools-*.dist-info \
+		$(PYTHON3_SETUPTOOLS_DEST_DIR)$(PYTHON3_SITE_PKG_DIR)/pkg_resources \
+		$(PYTHON3_SETUPTOOLS_DEST_DIR)$(PYTHON3_SITE_PKG_DIR)/_distutils_hack
+
+$(PKG_FINISH)

--- a/make/pkgs/python3/Config.in
+++ b/make/pkgs/python3/Config.in
@@ -1,6 +1,9 @@
+comment "Python 3.13.7 requires external storage  (Enable 'External processing' in the main menu)"
+	depends on !EXTERNAL_ENABLED
+
 config FREETZ_PACKAGE_PYTHON3
-	bool "Python 3.13.7 - DEVELOPER"
-	depends on FREETZ_SHOW_DEVELOPER
+	bool "Python 3.13.7"
+	depends on EXTERNAL_ENABLED
 	depends on FREETZ_SEPARATE_AVM_UCLIBC
 	select FREETZ_LIB_libpython3  if !FREETZ_PACKAGE_PYTHON3_STATIC
 	select FREETZ_LIB_libdl       if FREETZ_TARGET_UCLIBC_HAS_multiple_libs
@@ -13,9 +16,11 @@ config FREETZ_PACKAGE_PYTHON3
 	help
 		Python is a remarkably powerful dynamic programming language
 		that is used in a wide variety of application domains.
-		CAUTION: Python adds roughly 4 MB to 15.5 MB (depending on
-		your choice of modules) of uncompressed data to your image.
-		In most cases, it should therefore be externalized.
+		
+		CAUTION: Python 3 adds roughly 10-20 MB of uncompressed data
+		to your image. MUST be externalized to USB storage.
+		
+		Size: ~10-20 MB (depending on modules)
 
 if FREETZ_PACKAGE_PYTHON3
 
@@ -329,21 +334,19 @@ if FREETZ_PACKAGE_PYTHON3
 
 	endmenu
 
-#	menu "3rd-party modules"
-#		source "make/pkgs/python-bjoern/Config.in"
-#		source "make/pkgs/python-cffi/Config.in"
-#		source "make/pkgs/python-cheetah/Config.in"
-#		source "make/pkgs/python-imaging-library/Config.in"
-#		source "make/pkgs/python-mechanize/Config.in"
-#		source "make/pkgs/python-mysql-connector/Config.in"
-#		source "make/pkgs/python-pycrypto/Config.in"
-#		source "make/pkgs/python-pycryptodome/Config.in"
-#		source "make/pkgs/python-pycurl/Config.in"
-#		source "make/pkgs/python-pyopenssl/Config.in"
-#		source "make/pkgs/python-pyrrd/Config.in"
-#		source "make/pkgs/python-pyserial/Config.in"
-#		source "make/pkgs/python-yenc/Config.in"
-#	endmenu
+	menu "3rd-party modules"
+		source "make/pkgs/python3-cffi/Config.in"
+		source "make/pkgs/python3-cryptography/Config.in"
+		source "make/pkgs/python3-lxml/Config.in"
+		source "make/pkgs/python3-markupsafe/Config.in"
+		source "make/pkgs/python3-numpy/Config.in"
+		source "make/pkgs/python3-pandas/Config.in"
+		source "make/pkgs/python3-pillow/Config.in"
+		source "make/pkgs/python3-pip/Config.in"
+		source "make/pkgs/python3-pycryptodome/Config.in"
+		source "make/pkgs/python3-pyyaml/Config.in"
+		source "make/pkgs/python3-setuptools/Config.in"
+	endmenu
 
 endif # FREETZ_PACKAGE_PYTHON3
 

--- a/make/pkgs/python3/Config.in.libs
+++ b/make/pkgs/python3/Config.in.libs
@@ -1,6 +1,5 @@
 config FREETZ_LIB_libpython3
-	bool "libpython3 (libpython3.so) - DEVELOPER"
-	depends on FREETZ_SHOW_DEVELOPER
+	bool "libpython3 (libpython3.so)"
 	depends on FREETZ_PACKAGE_PYTHON3 && !FREETZ_PACKAGE_PYTHON3_STATIC
 	select FREETZ_LIB_libdl       if FREETZ_TARGET_UCLIBC_HAS_multiple_libs
 	select FREETZ_LIB_libm        if FREETZ_TARGET_UCLIBC_HAS_multiple_libs

--- a/make/pkgs/python3/external.in
+++ b/make/pkgs/python3/external.in
@@ -1,11 +1,24 @@
 config EXTERNAL_FREETZ_PACKAGE_PYTHON3
 	depends on EXTERNAL_ENABLED && FREETZ_PACKAGE_PYTHON3 && EXTERNAL_SUBDIRS
-	bool "python3"
-	default n
+	bool "Python 3 (binaries + libraries, externalization required)"
+	default y
 	help
-		externals the following file(s):
-		 /usr/bin/python3.13.bin
-		 /usr/include/python3.13/
-		 /usr/lib/python313.zip (if exists)
-		 /usr/lib/python3.13/
+		Externalize all Python 3 components to USB storage.
+		
+		WARNING: Python 3 is ~10-20 MB and MUST be externalized.
+		This option externalizes ALL Python 3 files including:
+		
+		Binaries:
+		 - /usr/bin/python3.13.bin
+		
+		Libraries:
+		 - ${FREETZ_LIBRARY_DIR}/libpython3.13.so.1.0
+		
+		Python modules and data:
+		 - /usr/include/python3.13/
+		 - /usr/lib/python313.zip (if exists)
+		 - /usr/lib/python3.13/
+		
+		This single checkbox externalizes everything to save
+		limited flash memory space.
 

--- a/make/pkgs/python3/external.in.libs
+++ b/make/pkgs/python3/external.in.libs
@@ -1,8 +1,14 @@
 config EXTERNAL_FREETZ_LIB_libpython3
 	depends on EXTERNAL_ENABLED && FREETZ_LIB_libpython3
-	bool "libpython3"
-	default n
+	bool "libpython3 (included in Python 3 externalization)"
+	default EXTERNAL_FREETZ_PACKAGE_PYTHON3
 	help
-		externals the following file(s):
-		 ${FREETZ_LIBRARY_DIR}/libpython3.13.so.1.0
+		Externalizes the Python 3 shared library.
+		
+		NOTE: If you enabled Python 3 package externalization,
+		this is automatically selected and externalized together
+		with other Python 3 files.
+		
+		File externalized:
+		 - ${FREETZ_LIBRARY_DIR}/libpython3.13.so.1.0
 

--- a/make/pkgs/python3/files/root/usr/bin/python3
+++ b/make/pkgs/python3/files/root/usr/bin/python3
@@ -1,17 +1,17 @@
 #!/bin/sh
 
 # Change the value of PYTHONHOME variable and comment LD_LIBRARY_PATH line in
-# if you want to use python on an unmodified box. Don't forget to copy all  
+# if you want to use python on an unmodified box. Don't forget to copy all
 # libraries python and its modules depend on to ${PYTHONHOME}/lib/freetz.
 
 # Check if externalized, otherwise use standard path
 if [ -f "/mod/external/usr/bin/python3.13.bin" ]; then
-    export PYTHONHOME="/mod/external/usr"
+    export PYTHONHOME="/mod/external/usr"  
     # Include both external and freetz libs for external installation
     export LD_LIBRARY_PATH="/mod/external/usr/lib:/usr/lib/freetz${LD_LIBRARY_PATH:+:}${LD_LIBRARY_PATH}"
 else
     export PYTHONHOME="/usr"
-    # Standard LD_LIBRARY_PATH for internal installation  
+    # Standard LD_LIBRARY_PATH for internal installation
     export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}${LD_LIBRARY_PATH:+:}/usr/lib/freetz"
 fi
 

--- a/make/pkgs/python3/python3-module-macros.mk.in
+++ b/make/pkgs/python3/python3-module-macros.mk.in
@@ -13,48 +13,75 @@ PYTHON3_SITE_PKG_DIR:=/usr/lib/python$(PYTHON3_MAJOR_VERSION)/site-packages
 
 PYTHON:=python$(PYTHON3_MAJOR_VERSION)
 
-HOST_PYTHON3_BIN:=$(TARGET_TOOLCHAIN_STAGING_DIR)/usr/bin/hostpython
+HOST_PYTHON3_BIN:=$(HOST_TOOLS_DIR)/usr/bin/python3
 
 # $(1) => statements to be executed before calling host-python
 # $(2) => parameters to be passed to host-python
-define HostPython
-	( \
-		export PYTHONHOME="$(HOST_TOOLS_DIR)/usr"; \
-		export PYTHON3_INCDIR="$(PYTHON3_STAGING_INC_DIR)"; \
-		export PYTHON3_LIBDIR="$(PYTHON3_STAGING_LIB_DIR)"; \
-		export PYTHONPATH="$(PYTHON3_STAGING_LIB_DIR):$(TARGET_TOOLCHAIN_STAGING_DIR)/$(PYTHON3_SITE_PKG_DIR)"; \
-		export PYTHONOPTIMIZE=""; \
-		export PYTHONDONTWRITEBYTECODE="x"; \
-		$(1) \
-		$(HOST_PYTHON3_BIN) $(2); \
-	)
+define HostPython3
+        ( \
+                export PYTHONHOME="$(HOST_TOOLS_DIR)/usr"; \
+                export PYTHON3_INCDIR="$(PYTHON3_STAGING_INC_DIR)"; \
+                export PYTHON3_LIBDIR="$(PYTHON3_STAGING_LIB_DIR)"; \
+                export PYTHONPATH="$(PYTHON3_STAGING_LIB_DIR):$(TARGET_TOOLCHAIN_STAGING_DIR)/$(PYTHON3_SITE_PKG_DIR)"; \
+                export PYTHONOPTIMIZE=""; \
+                export PYTHONDONTWRITEBYTECODE="x"; \
+                $(1) \
+                $(HOST_PYTHON3_BIN) $(2); \
+        )
 endef
 
 # $(1) => build dir
 # $(2) => additional arguments to setup.py
 # $(3) => additional variables
 # $(4) => dir to look for .so files to be stripped
-define Build/PyMod/Generic
-	$(call HostPython, \
-		cd $(strip $(1)); \
-		$(TARGET_CONFIGURE_ENV) \
-		$(FREETZ_LD_RUN_PATH) \
-		$(3) \
-		, \
-		./setup.py $(2) \
-	)
-	$(if $(strip $(4)),find $(strip $(4)) -type f -name "*.so" -exec $(TARGET_STRIP) \{\} \+)
+define Build/Py3Mod/Generic
+        $(call HostPython3, \
+                cd $(strip $(1)); \
+                $(TARGET_CONFIGURE_ENV) \
+                CFLAGS="$(TARGET_CFLAGS) -I$(PYTHON3_STAGING_INC_DIR)" \
+                CXXFLAGS="$(TARGET_CFLAGS) -I$(PYTHON3_STAGING_INC_DIR)" \
+                $(FREETZ_LD_RUN_PATH) \
+                $(3) \
+                , \
+                ./setup.py $(2) \
+        )
+        $(if $(strip $(4)),find $(strip $(4)) -type f -name "*.so" -exec $(TARGET_STRIP) \{\} \+)
 endef
 
 # $(1) => PKG value
 # $(2) => additional arguments to setup.py
 # $(3) => additional variables
-define Build/PyMod/PKG
-	$(call Build/PyMod/Generic, \
-		$($(strip $(1))_DIR), \
-		install --prefix=/usr --root=$(abspath $($(strip $(1))_DEST_DIR)) \
-		$(2), \
-		$(3), \
-		$($(strip $(1))_DEST_DIR)$(PYTHON3_SITE_PKG_DIR) \
-	)
+define Build/Py3Mod/PKG
+        $(call Build/Py3Mod/Generic, \
+                $($(strip $(1))_DIR), \
+                install --prefix=/usr --root=$(abspath $($(strip $(1))_DEST_DIR)) \
+                $(2), \
+                $(3), \
+                $($(strip $(1))_DEST_DIR)$(PYTHON3_SITE_PKG_DIR) \
+        )
+endef
+
+# For packages using pyproject.toml (PEP 517) instead of setup.py
+# $(1) => PKG value
+# $(2) => additional pip install arguments
+# $(3) => additional environment variables
+# $(4) => if set to "isolated", allows build isolation (default: no isolation)
+define Build/Py3Mod/Pip
+        $(call HostPython3, \
+                cd $($(strip $(1))_DIR); \
+                $(TARGET_CONFIGURE_ENV) \
+                CFLAGS="$(TARGET_CFLAGS) -I$(PYTHON3_STAGING_INC_DIR)" \
+                CXXFLAGS="$(TARGET_CFLAGS) -I$(PYTHON3_STAGING_INC_DIR)" \
+                $(FREETZ_LD_RUN_PATH) \
+                $(3) \
+                , \
+                -m pip install --no-deps $(if $(filter isolated,$(strip $(4))),,--no-build-isolation) \
+                        --prefix=/usr \
+                        --root=$(abspath $($(strip $(1))_DEST_DIR)) \
+                        --no-compile \
+                        --config-settings=setup-args="--cross-file=$(FREETZ_BASE_DIR)/include/meson.cross/$(REAL_GNU_TARGET_NAME)" \
+                        $(2) \
+                        . \
+        )
+        find $($(strip $(1))_DEST_DIR)$(PYTHON3_SITE_PKG_DIR) -type f -name "*.so" -exec $(TARGET_STRIP) \{\} \+ 2>/dev/null || true
 endef

--- a/tools/fix-python313-zip.sh
+++ b/tools/fix-python313-zip.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# Fix Python 3.13 zip importer compatibility
+# This script fixes python313.zip to make it compatible with Python 3.13's zip importer
+# by copying .pyc files from __pycache__/ to package level
+#
+# Usage: fix-python313-zip.sh <path_to_python313.zip>
+#
+
+set -e
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <path_to_python313.zip>"
+    exit 1
+fi
+
+PYTHON_ZIP="$1"
+
+if [ ! -f "$PYTHON_ZIP" ]; then
+    echo "ERROR: File not found: $PYTHON_ZIP"
+    exit 1
+fi
+
+echo "Fixing Python 3.13 zip importer compatibility..."
+
+# Create temporary directory
+TEMP_DIR=$(mktemp -d /tmp/python_zip_fix.XXXXXX)
+
+# Extract the ZIP
+cd "$TEMP_DIR"
+unzip -q "$PYTHON_ZIP"
+
+# Copy .pyc files from __pycache__/ to package level
+COPIED=0
+while IFS= read -r pycache_dir; do
+    package_dir=$(dirname "$pycache_dir")
+    for pyc_file in "$pycache_dir"/*.cpython-313.pyc; do
+        if [ -f "$pyc_file" ]; then
+            module_name=$(basename "$pyc_file" .cpython-313.pyc)
+            dst_file="$package_dir/$module_name.pyc"
+            if [ ! -f "$dst_file" ]; then
+                cp "$pyc_file" "$dst_file"
+                COPIED=$((COPIED + 1))
+            fi
+        fi
+    done
+done < <(find . -name "__pycache__" -type d)
+
+echo "  Copied $COPIED .pyc files from __pycache__/ to package level"
+
+# Remove __pycache__ directories to save space (files are now at package level)
+echo "  Removing __pycache__ directories..."
+find . -name "__pycache__" -type d -exec rm -rf {} + 2>/dev/null || true
+
+# Recreate the ZIP
+rm -f "$PYTHON_ZIP"
+find . -name "*.pyc" -print | zip -9qy@ "$PYTHON_ZIP"
+
+# Cleanup
+cd /
+rm -rf "$TEMP_DIR"
+
+echo "Python 3.13 zip importer fix completed successfully!"

--- a/tools/genin
+++ b/tools/genin
@@ -141,7 +141,7 @@ for CAT in $CATs; do
 	echo -e "\nmenu \"${CATREAL}\""                                                                 >> $CFILE
 	for PKG in $(echo -e "${CATTABLE}"| sed "/^${CATONLY/\//\\/}##/ !d ; s/^[^#]*##// "); do
 		[ -e "$PKGDIR/$PKG/external.in" ] && echo "source \"$PKGDIR/$PKG/external.in\""         >> $EFILE
-		case "$PKG" in asterisk-*|iptables-cgi|nhipt|python-*|ruby-fcgi|sg3_utils) continue ;; esac
+		case "$PKG" in asterisk-*|iptables-cgi|nhipt|python-*|python3-*|ruby-fcgi|sg3_utils) continue ;; esac
 		[ -e "$PKGDIR/$PKG/Config.in" ] && echo -e "\tsource \"$PKGDIR/$PKG/Config.in\""        >> $CFILE
 	done
 	SAVEMENU="$SAVEMENU%%$CAT"


### PR DESCRIPTION
This PR adds Python 3.13 support, including the core Python3 interpreter and multiple extension packages.

Python3 extension packages included:
- python3-cffi: C Foreign Function Interface - cffi 1.17.1
- python3-cryptography: cryptography 3.3.2 (old version, last one without Rust)
- python3-lxml: XML/HTML processing with libxml2/libxslt - lxml 5.3.0
- python3-markupsafe: Safe string handling for HTML/XML - markupsafe 3.0.2
- python3-numpy: Scientific computing (incomplete porting, **work in progress**)
- python3-pandas: Data analysis and manipulation (incomplete porting, **work in progress**)
- python3-pillow: Image processing library
- python3-pip: Package installer for Python - pip 24.3.1, including pip3
- python3-pycryptodome: Cryptographic library - pycryptodome 3.23.0
- python3-pyyaml: YAML parser and emitter - pyyaml 6.0.2
- python3-setuptools: Build system for Python packages - setuptools 75.6.0

Note: incomplete porting for numpy and pandas, which require additional work for full uclibc compatibility.
