### PR TITLE
Enable shared library for Berkeley DB

### DIFF
--- a/make/libs/db/db.mk
+++ b/make/libs/db/db.mk
@@ -18,6 +18,7 @@ $(PKG)_MUTEX_i686:=*x86/gcc-assembly
 $(PKG)_MUTEX_mips:=MIPS/gcc-assembly
 
 $(PKG)_CONFIGURE_OPTIONS += --enable-static
+$(PKG)_CONFIGURE_OPTIONS += --enable-shared
 $(PKG)_CONFIGURE_OPTIONS += --with-mutex='$($(PKG)_MUTEX_$(call qstrip,$(FREETZ_TARGET_ARCH)))'
 $(PKG)_CONFIGURE_OPTIONS += --disable-cxx
 $(PKG)_CONFIGURE_OPTIONS += --disable-compat185


### PR DESCRIPTION
This PR enables the shared library build for Berkeley DB (libdb) in addition to the existing static library.

Changes:
- Add --enable-shared to db.mk configuration

This allows packages to link against libdb.so dynamically, which is required by some applications like Python's bsddb module and other database-dependent packages.

Size impact: Creates libdb-4.8.so (~1.5 MB shared library)