### PR TITLE
Enhance Meson cross-compilation configuration files

### DIFF
--- a/include/meson.cross/common-linux-uclibc
+++ b/include/meson.cross/common-linux-uclibc
@@ -18,6 +18,7 @@ cpp_link_args     = [%TARGET_LDFLAGS%]
 [properties]
 needs_exe_wrapper = true
 pkg_config_libdir = '%PKGCONFIG%'
+longdouble_format = 'IEEE_DOUBLE_%FREETZ_TARGET_MESON_ENDIAN_UPPER%'
 
 [binaries]
 ar                = arch + '-ar'

--- a/make/include/600-macros.mk
+++ b/make/include/600-macros.mk
@@ -229,6 +229,7 @@ $($(PKG)_DIR)/.configured: $($(PKG)_DIR)/.build-prereq-checked $($(PKG)_DIR)/.un
 		-e 's!%FREETZ_TARGET_MESON_FAMILY%!$(call qstrip,$(FREETZ_TARGET_MESON_FAMILY))!' \
 		-e 's!%FREETZ_TARGET_MESON_CPU%!$(call qstrip,$(FREETZ_TARGET_MESON_CPU))!' \
 		-e 's!%FREETZ_TARGET_MESON_ENDIAN%!$(call qstrip,$(FREETZ_TARGET_MESON_ENDIAN))!' \
+		-e 's!%FREETZ_TARGET_MESON_ENDIAN_UPPER%!$(shell echo $(FREETZ_TARGET_MESON_ENDIAN) | sed 's/little/LE/;s/big/BE/')!' \
 		\
 		-e "s!%TARGET_CFLAGS%!$(foreach X,$(TARGET_CFLAGS) $($(PKG)_EXTRA_CFLAGS),'$(X)',)!g" \
 		-e "s!%TARGET_LDFLAGS%!$(foreach X,$(TARGET_LDFLAGS) $($(PKG)_EXTRA_LDFLAGS),'$(X)',)!g" \


### PR DESCRIPTION
Add dynamic longdouble_format configuration to meson. Cross files. This is required by Meson build system to correctly detect the floating-point format on the target architecture.

Changes:
- Add longdouble_format placeholder in common-linux-uclibc
- Add FREETZ_TARGET_MESON_ENDIAN_UPPER substitution in 600-macros.mk
- Converts 'little' to 'LE' and 'big' to 'BE' for IEEE format

This ensures proper cross-compilation configuration for packages using Meson build system.