### PR TITLE
Fix progress monitor: exclude meta-packages like IPTABLES_IS_SELECTABLE

### DIFF
--- a/tools/make_progress_monitor.sh
+++ b/tools/make_progress_monitor.sh
@@ -774,7 +774,7 @@ if [ -d "$ROOT_DIR/source/${BUILD_ARCH}" ]; then
                 ((NOT_STARTED++))
                 ((TOTAL++))
             fi
-        done < <(grep "^FREETZ_PACKAGE_[A-Z0-9_]*=y$" "$ROOT_DIR/.config" | grep -v "_WITH_\|_STATIC\|_DISABLE_\|_ENABLE_\|_AUTHORIZED_\|_VERSION_\|_SELECT_\|_MOD_\|_PYC\|_COMPRESS_\|_PORT_\|_BAUD_\|_WEBINTERFACE\|_DAEMON\|_SFTP_\|_OMIT_\|_TINY\|_NORMAL\|_HUGE\|_READELF\|_OBJDUMP\|_OBJCOPY\|_NM\|_STRINGS\|_AR\|_RANLIB\|_STRIP\|_ADDR2LINE\|_SIZE\|_PATCHELF")
+        done < <(grep "^FREETZ_PACKAGE_[A-Z0-9_]*=y$" "$ROOT_DIR/.config" | grep -v "_WITH_\|_STATIC\|_DISABLE_\|_ENABLE_\|_AUTHORIZED_\|_VERSION_\|_SELECT_\|_IS_SELECTABLE\|_MOD_\|_PYC\|_COMPRESS_\|_PORT_\|_BAUD_\|_WEBINTERFACE\|_DAEMON\|_SFTP_\|_OMIT_\|_TINY\|_NORMAL\|_HUGE\|_READELF\|_OBJDUMP\|_OBJCOPY\|_NM\|_STRINGS\|_AR\|_RANLIB\|_STRIP\|_ADDR2LINE\|_SIZE\|_PATCHELF")
     fi
 else
     # Early build stage - toolchain compilation only (no target dir yet)
@@ -858,7 +858,7 @@ else
             PKG_INFO+=("0|$pkg_name|0|0|$complexity")
             ((NOT_STARTED++))
             ((TOTAL++))
-        done < <(grep "^FREETZ_PACKAGE_[A-Z0-9_]*=y$" "$ROOT_DIR/.config" | grep -v "_WITH_\|_STATIC\|_DISABLE_\|_ENABLE_\|_AUTHORIZED_\|_VERSION_\|_SELECT_\|_MOD_\|_PYC\|_COMPRESS_\|_PORT_\|_BAUD_\|_WEBINTERFACE\|_DAEMON\|_SFTP_\|_OMIT_\|_TINY\|_NORMAL\|_HUGE\|_READELF\|_OBJDUMP\|_OBJCOPY\|_NM\|_STRINGS\|_AR\|_RANLIB\|_STRIP\|_ADDR2LINE\|_SIZE\|_PATCHELF")
+        done < <(grep "^FREETZ_PACKAGE_[A-Z0-9_]*=y$" "$ROOT_DIR/.config" | grep -v "_WITH_\|_STATIC\|_DISABLE_\|_ENABLE_\|_AUTHORIZED_\|_VERSION_\|_SELECT_\|_IS_SELECTABLE\|_MOD_\|_PYC\|_COMPRESS_\|_PORT_\|_BAUD_\|_WEBINTERFACE\|_DAEMON\|_SFTP_\|_OMIT_\|_TINY\|_NORMAL\|_HUGE\|_READELF\|_OBJDUMP\|_OBJCOPY\|_NM\|_STRINGS\|_AR\|_RANLIB\|_STRIP\|_ADDR2LINE\|_SIZE\|_PATCHELF")
     fi
 fi
 


### PR DESCRIPTION
Meta-packages (def_bool) like FREETZ_PACKAGE_IPTABLES_IS_SELECTABLE do not have build files and cannot be compiled. They remain at 0% and should be filtered out from the package list.

Added _IS_SELECTABLE pattern to the exclusion filter to prevent these meta-packages from appearing in the progress monitor output, fixing the issue reported in https://github.com/Freetz-NG/freetz-ng/pull/1291.