### PR TITLE
Fix patchelf cross-compiling

### DIFF
--- a/make/pkgs/patchelf/patchelf.mk
+++ b/make/pkgs/patchelf/patchelf.mk
@@ -20,6 +20,12 @@ ifneq ($($(PKG)_SOURCE),$(PATCHELF_HOST_SOURCE))
 $(PKG_SOURCE_DOWNLOAD)
 endif
 $(PKG_UNPACKED)
+
+# Force CXX to real compiler to bypass ccache wrapper issues during cross-compilation
+$(PKG)_CONFIGURE_ENV += CXX="$(TARGET_CROSS)g++"
+# Fix i686 uClibc linking issue with pthread symbols (6591, 6660 devices)
+$(PKG)_CONFIGURE_ENV += $(if $(FREETZ_TARGET_ARCH_X86),CXXFLAGS="$(TARGET_CFLAGS) -fPIC")
+
 $(PKG_CONFIGURED_CONFIGURE)
 
 $($(PKG)_BINARY_BUILD): $($(PKG)_DIR)/.configured


### PR DESCRIPTION
**Fix patchelf cross-compiling**

(after a whole day of revisions and tests)

- [7530AX_08.20](https://github.com/Ircama/freetz-ng/actions/runs/19019953639/artifacts/4443992825) firmware (ARM): https://github.com/Ircama/freetz-ng/actions/runs/19019953639/job/54313383058
- [7590AX_08.20](https://github.com/Ircama/freetz-ng/actions/runs/19019916522/artifacts/4443979358) firmware MIPS: https://github.com/Ircama/freetz-ng/actions/runs/19019916522/job/54313293236
- Matrix: https://github.com/Ircama/freetz-ng/actions/runs/19018295885

Available executables:
```
1200_W5 - 07_2X
1700 - 08_0X
1750 - 07_2X
5590 - 08_0X
6590 - 07_2X
6591 - 07_0X
6660 - 07_1X
6660 - 07_2X
6670 - 07_5X
6670 - 08_0X
6690 - 07_5X
7490 - 07_2X
7530_W6_V1 - 07_2X
7530_W6_V1 - 07_5X
7530_W6_V1 - 08_2X_LABOR
7581 - 07_1X
7590_W5 - 07_2X
7590_W5 - 07_5X
7690 - 07_5X
```

Disabled for missing dependencies:

```
1750 - 07_0X
4040 - 07_0X
6360 - 06_5X
6490 - 06_8X
6590 - 07_0X
7270_V1 - 04_XX
7270_V3 - 06_0X
7390 - 05_2X
7390 - 06_0X
7390 - 06_2X
7490 - 06_5X
7580 - 06_8X
7590_W5 - 07_0X
WLAN - 04_XX

Package dependencies:
	depends on FREETZ_TARGET_GCC_13_MIN  # in fact min gcc11 for C++17
	select FREETZ_STDCXXLIB_FORCE_GNULIBSTDCXX
	select FREETZ_LIB_STDCXXLIB
```

Details:

```
$ readelf -a ./build/modified/external/usr/bin/patchelf|grep NEEDED
 0x00000001 (NEEDED)                     Shared library: [libstdc++.so.6]
 0x00000001 (NEEDED)                     Shared library: [libgcc_s.so.1]
 0x00000001 (NEEDED)                     Shared library: [libc.so.0]

$ file ./build/modified/external/usr/bin/patchelf
./build/modified/external/usr/bin/patchelf: ELF 32-bit MSB executable, MIPS, MIPS32 rel2 version 1 (SYSV), dynamically linked, interpreter /usr/lib/freetz/ld-uClibc.so.1, stripped

$ ls -l ./build/modified/external/usr/bin/patchelf
-rwxr-xr-x 1 myuser myuser 246136 Nov  3 00:50 ./build/modified/external/usr/bin/patchelf
```