### PR TITLE
action(generate_mkdocs): remove symlink to mkdocs.yml and adjust action to still working

### DIFF
--- a/.github/mkdocs/mkdocs.yml
+++ b/.github/mkdocs/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: 'Freetz-NG Documentation'
 site_url: 'https://freetz-ng.github.io/'
 repo_url: 'https://github.com/freetz-ng/freetz-ng'
 edit_uri: '../freetz-ng/blob/master/docs/'
+docs_dir: '../../docs/'
 copyright: |
   Copyright Freetz-NG. Licensed under <a href="https://github.com/Freetz-NG/freetz-ng/raw/refs/heads/master/COPYING" target="_blank" rel="noopener noreferrer">GPL-2.0</a>
 remote_branch: gh-pages

--- a/.github/workflows/generate_mkdocs.yml
+++ b/.github/workflows/generate_mkdocs.yml
@@ -27,16 +27,19 @@ permissions:
 
 jobs:
   build:
+    env:
+      MKDOCS_REQUIREMENTS_FILE: .github/mkdocs/requirements.txt
+      MKDOCS_CONFIG_FILE: .github/mkdocs/mkdocs.yml
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v5
       - name: Install dependencies
-        run: pip install -r .github/mkdocs/requirements.txt
+        run: pip install -r ${{ env.MKDOCS_REQUIREMENTS_FILE }}
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Build with MkDocs
-        run: mkdocs build
+        run: mkdocs build --config-file ${{ env.MKDOCS_CONFIG_FILE }}
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Please make sure you fork the repo and change the clone URL in the example below
     - Running the docs server:
 
     ```bash
-    mkdocs serve --dev-addr 0.0.0.0:8000
+    mkdocs serve --dev-addr 0.0.0.0:8000 --config-file .github/mkdocs/mkdocs.yml
     ```
 
 - Fedora Linux instructions (tested on Fedora Linux 28):
@@ -131,7 +131,7 @@ Please make sure you fork the repo and change the clone URL in the example below
     - Running the docs server:
 
     ```bash
-    mkdocs serve --dev-addr 0.0.0.0:8000
+    mkdocs serve --dev-addr 0.0.0.0:8000 --config-file .github/mkdocs/mkdocs.yml
     ```
 
 After these commands, the current branch is accessible through your favorite browser at <http://localhost:8000>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,1 +1,0 @@
-.github/mkdocs/mkdocs.yml


### PR DESCRIPTION
Dies entfernt den symlink zur mkdocs.yml am Stammverzeichnis des Repos und bewahrt die funktionalität des generate_mkdocs actions.