### PR TITLE
generate_stats: switch to html table to view on github and mkdocs

### DIFF
--- a/.github/mkdocs/requirements.txt
+++ b/.github/mkdocs/requirements.txt
@@ -1,3 +1,2 @@
 mkdocs
 mkdocs-material
-pymdown-extensions

--- a/docs/stats/generate.sh
+++ b/docs/stats/generate.sh
@@ -6,29 +6,31 @@ OUTFILE="$PARENT/docs/stats/README.md"
 TMPFILE="$PARENT/.stats"
 rm -f "$TMPFILE".??.*
 
-
-SPACE='<!-- -->'
+SPACE='&nbsp;'
 
 empty_line() {
-	echo "@ ${1:-$SPACE} @ ${2:-$SPACE} @"
+	echo "<tr><td>${1:-$SPACE}</td><td>${2:-$SPACE}</td></tr>"
 }
 
 table_head() {
-	empty_line "$1" "$2"
-	echo '@ --- @ --- @'
+	echo "<table>"
+	echo "<thead><tr><th>$1</th><th>$2</th></tr></thead>"
+	echo "<tbody>"
+}
+
+table_foot() {
+	echo "</tbody></table>"
 }
 
 spoiler_head() {
-#	echo '<details markdown>'
-#	echo "  <summary>$(cat "$1" | wc -l | tr -d '\n') $2</summary>"
-	echo "??? tip \"$(cat "$1" | wc -l | tr -d '\n') $2\""
+	count=$(cat "$1" | wc -l | tr -d '\n')
+	echo "<details><summary>${count} $2</summary>"
 	echo
 }
 
 spoiler_foot() {
-	cat "$1" | sed 's/|/\\|/g' | sed -r 's, *@ (.*) @ (.*) @,    | \2 | \1 |,g'
-#	cat "$1" | sed 's/|/\\|/g' | sed -r 's, *@ (.*) @ (.*) @,| \2 | \1 |,g'
-#	echo '</details>'
+	cat "$1" | sed 's/|/\\|/g' | sed -r 's, *@ (.*) @ (.*) @,<tr><td>\2</td><td>\1</td></tr>,g'
+	echo "</details>"
 	echo
 }
 
@@ -37,11 +39,11 @@ get_fw() {
 	file="config/ui/firmware.in"
 	(
 		table_head "Symbol" "Version"
-		empty_line
 		cat "$file" | grep "prompt \"${area}\"" -m1 -A9999 | grep "^endchoice" -m1 -B9999 | sed 's/^[ \t]*//g' | grep -E "^(config|bool) " | while read -r line; do
 			[ "${line#config}"  != "$line" ] && echo "$line" | tr -d '\n'  | sed 's/^[^\t ]*[ \t]*/@ /g;s/$/ @ /g'
 			[ "${line#bool}"    != "$line" ] && echo "$line"               | sed 's/^[^\t ]*[ \t]*"//g;s/"/ @/g' && echo >> "$TMPFILE.fw.head"
 		done | sed 's/ - [^ ]*//g' | grep -Evi "(inhaus|labor|plus)"
+		table_foot
 	) > "$TMPFILE.fw.body"
 }
 
@@ -51,10 +53,11 @@ get_hw() {
 	(
 		table_head "Symbol" "Name"
 		cat "$file" | grep "prompt \"${area}\"" -m1 -A9999 | grep "^endchoice" -m1 -B9999 | sed 's/^[ \t]*//g' | grep -E "^(comment|config|bool) " | while read -r line; do
-			[ "${line#comment}" != "$line" ] && empty_line && echo "$line" | sed "s/^[^\t ]*[ \t]*\"/@ $SPACE @ **/g;s/\"/** @/g"
-			[ "${line#config}"  != "$line" ] && echo "$line" | tr -d '\n'  | sed 's/^[^\t ]*[ \t]*/@ /g;s/$/ @ /g'
-			[ "${line#bool}"    != "$line" ] && echo "$line"               | sed 's/^[^\t ]*[ \t]*"//g;s/"/ @/g' && echo >> "$TMPFILE.hw.head"
+			[ "${line#comment}" != "$line" ] && empty_line "<strong>$(echo "$line"  | sed 's/^[^\t ]*[ \t]*"//;s/".*//')</strong>" "&nbsp;"
+			[ "${line#config}"  != "$line" ] && echo "$line" | tr -d '\n'           | sed 's/^[^\t ]*[ \t]*/@ /g;s/$/ @ /g'
+			[ "${line#bool}"    != "$line" ] && echo "$line"                        | sed 's/^[^\t ]*[ \t]*"//g;s/"/ @/g' && echo >> "$TMPFILE.hw.head"
 		done | sed 's/ - [^ ]*//g'
+		table_foot
 	) > "$TMPFILE.hw.body"
 }
 
@@ -63,38 +66,37 @@ get_dl() {
 	file="config/mod/dl-firmware.in"
 	(
 		table_head "Symbole" "Datei(/AVM)"
-		empty_line
 		cat "$file" | grep "string \"${area}\"" -m1 -A9999 | grep "^config " -m1 -B9999 | sed 's/^[ \t]*//g' | grep -E "^(default) " | while read -r line; do
 			echo "$line" | tr -s ' ' | sed -r 's/.*"(.*)".* if (.*)/@ \2 @ \1 @/g' && echo >> "$TMPFILE.dl.head"
 		done | sed -r 's/_(inhaus|labor|plus)//gI' | grep -v "DETECT_IMAGE_NAME"
+		table_foot
 	) > "$TMPFILE.dl.body"
 }
 
 main() {
 
 	# head
-	echo '# Statistiken rund um Freetz-NG'
+	echo "<h1>Statistiken rund um Freetz-NG</h1>"
 	echo
 
 	# firmware
 	get_fw
-	spoiler_head "$TMPFILE.fw.head" "verschieden FRITZ!OS"
+	spoiler_head "$TMPFILE.fw.head" "verschiedene FRITZ!OS"
 	spoiler_foot "$TMPFILE.fw.body"
 	rm -f "$TMPFILE.fw."*
 
 	# hardware
 	get_hw
-	spoiler_head "$TMPFILE.hw.head" "verschieden Geräte"
+	spoiler_head "$TMPFILE.hw.head" "verschiedene Geräte"
 	spoiler_foot "$TMPFILE.hw.body"
 	rm -f "$TMPFILE.hw."*
 
 	# image
 	get_dl
-	spoiler_head "$TMPFILE.dl.head" "verschieden Images"
+	spoiler_head "$TMPFILE.dl.head" "verschiedene Images"
 	spoiler_foot "$TMPFILE.dl.body"
 	rm -f "$TMPFILE.dl."*
 
 }
+
 main > "$OUTFILE"
-
-


### PR DESCRIPTION
Dies ändert die Generierung der stats readme.md, damit die Tabelle in Markdown unter GitHub und auch unter mkdocs angezeigt werden.
<sub>(Teile der Änderung wurden durch Copilot generiert, aber auf Funktion geprüft.)</sub>

refs: https://github.com/Freetz-NG/freetz-ng/pull/1325#issuecomment-3514084215