### PR TITLE
action(make_precompiled): set concurrency to limit concurrent runs for pull requests

### DIFF
--- a/.github/workflows/make_precompiled.yml
+++ b/.github/workflows/make_precompiled.yml
@@ -20,9 +20,9 @@ on:
         required: true
         default: "dropbear"
 
-#concurrency:
-# group: ${{ (github.event_name == 'pull_request') && github.workflow && '-' && github.event.pull_request.number || github.run_id }}
-# cancel-in-progress: ${{ (github.event_name == 'pull_request') && true || false }}
+concurrency:
+  group: ${{ (github.event_name == 'pull_request') && github.workflow && '-' && github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ (github.event_name == 'pull_request') && true || false }}
 
 jobs:
 
@@ -42,6 +42,7 @@ jobs:
     steps:
 
       - uses: ahmadnassri/action-workflow-queue@v1
+        if: github.event_name != 'pull_request'
         with:
           timeout: "18000000"
           delay: "10000"
@@ -93,7 +94,7 @@ jobs:
       options: --user 1001:1001
     needs: matrizifizieren
     strategy:
-      max-parallel: 17
+      max-parallel: ${{ github.event_name == 'pull_request' && 2 || 17 }}
       fail-fast: false
       matrix:
         fritz: ${{ fromJson(needs.matrizifizieren.outputs.matrix) }}


### PR DESCRIPTION
Dies ändert "concurrency" so das es bei nicht pull request runs weiterhin mit einer Warteschlange arbeitet, während bei pull requests parallele Ausführung möglich ist, aber dafür beschränkt auf 2 runners.

Werden z.b. 2 Pull Requests erstellt und beide lösen jeweils einen Run aus, dann laufen beide für sich und wenn z.b. beim ersten pr ein Update oder rebase etc. erfolgt, dann wird der Run des betreffenden pull Requests der noch läuft, beendet und der nächste wird gestartet. Der Run des 2. pr bleibt davon unberührt.

refs: https://github.com/Freetz-NG/freetz-ng/pull/1323#issuecomment-3530513149