### PR TITLE
Fix db: add ARM big-endian (armeb) mutex support

### DIFF
--- a/make/libs/db/db.mk
+++ b/make/libs/db/db.mk
@@ -14,6 +14,7 @@ $(PKG)_CONFIGURE_PRE_CMDS := ln -sf ../dist/configure $(DB_BUILD_SUBDIR)/ ;
 $(PKG)_CONFIGURE_OPTIONS += --srcdir=../dist/
 
 $(PKG)_MUTEX_arm:=ARM/gcc-assembly
+$(PKG)_MUTEX_armeb:=ARM/gcc-assembly
 $(PKG)_MUTEX_i686:=*x86/gcc-assembly
 $(PKG)_MUTEX_mips:=MIPS/gcc-assembly
 


### PR DESCRIPTION
Add ARM/gcc-assembly mutex configuration for armeb architecture. This enables Berkeley DB to build correctly on ARM big-endian targets like FritzBox 6360 (tested with firmware 06_5X).

Found while testing Python2/Python3.14 compilation with this device.