### PR TITLE
Fix parallel build issues for OpenSSL 0.9.8 on Fritz!Box 7390

### DIFF
--- a/make/pkgs/openssl/openssl.mk
+++ b/make/pkgs/openssl/openssl.mk
@@ -96,7 +96,7 @@ $($(PKG)_BINARY_BUILD_DIR) $($(PKG)_LIBS_BUILD_DIR): $($(PKG)_DIR)/.configured
 #	Remove installed libs also from freetz' packages dir to ensure
 #	that it doesn't contain files from previous builds (0.9.8 to/from 1.0.x switch).
 	$(MAKE) openssl-clean-staging openssl-uninstall $(SILENT)
-	$(SUBMAKE1) $(OPENSSL_MAKE_FLAGS) depend
+	$(SUBMAKE) $(OPENSSL_MAKE_FLAGS) depend
 	$(SUBMAKE) $(OPENSSL_MAKE_FLAGS) all
 
 $($(PKG)_LIBS_STAGING_DIR): $($(PKG)_LIBS_BUILD_DIR)

--- a/make/pkgs/openssl/patches/0.9/098-fix-parallel-build.patch
+++ b/make/pkgs/openssl/patches/0.9/098-fix-parallel-build.patch
@@ -1,0 +1,12 @@
+--- Makefile.org.orig
++++ Makefile.org
+@@ -1,6 +1,9 @@
+ ##
+ ## Makefile for OpenSSL
+ ##
++
++# Prevent parallel execution of top-level targets to avoid race conditions
++.NOTPARALLEL:
+ 
+ VERSION=
+ MAJOR=


### PR DESCRIPTION
This PR addresses race conditions during parallel builds of OpenSSL 0.9.8, particularly affecting Fritz!Box 7390 devices. The issue arises when multiple make jobs execute simultaneously, leading to conflicts in dependency generation and compilation steps.

This patch was found while testing Python2/Python 3.14 on this device.