### PR TITLE
Fix sqlite: disable math functions for uClibc 0.9.28/29

### DIFF
--- a/make/pkgs/sqlite/sqlite.mk
+++ b/make/pkgs/sqlite/sqlite.mk
@@ -35,6 +35,10 @@ $(PKG)_CONFIGURE_OPTIONS += --disable-static-shell
 $(PKG)_CONFIGURE_OPTIONS += $(if $(FREETZ_PACKAGE_SQLITE_WITH_READLINE),--enable-readline,--disable-readline)
 
 $(PKG)_CONFIGURE_ENV += ac_cv_header_zlib_h=no
+# Disable math functions for uClibc 0.9.28/29 (missing trunc() and other C99 math functions)
+ifeq ($(strip $(FREETZ_LIB_libsqlite3_WITH_VERSION_ABANDON)),y)
+$(PKG)_CONFIGURE_ENV += CFLAGS="$(TARGET_CFLAGS) -USQLITE_ENABLE_MATH_FUNCTIONS"
+endif
 
 
 $(PKG_SOURCE_DOWNLOAD)


### PR DESCRIPTION
This PR fixes compilation issues with SQLite on systems using uClibc 0.9.28/29, which lack certain C99 math functions like trunc(). The problem manifests as undefined references during linking when SQLite's math functions are enabled.

Added conditional logic to disable SQLite math functions when FREETZ_LIB_libsqlite3_WITH_VERSION_ABANDON=y is set. This prevents compilation errors on uClibc-based systems by undefining SQLITE_ENABLE_MATH_FUNCTIONS in the CFLAGS.

This patch was found while testing Python2/Python 3.14 with device WLAN - 04_XX.

```
libtool: link: /__w/freetz-ng/freetz-ng/toolchain/build/mipsel_gcc-4.6.4_uClibc-0.9.28/mipsel-linux-uclibc/bin/mipsel-linux-uclibc-gcc -D_REENTRANT=1 -DSQLITE_THREADSAFE=1 -DSQLITE_ENABLE_MATH_FUNCTIONS -DSQLITE_ENABLE_FTS4 -DSQLITE_ENABLE_FTS5 -DSQLITE_ENABLE_RTREE -DSQLITE_ENABLE_GEOPOLY -DSQLITE_ENABLE_EXPLAIN_COMMENTS -DSQLITE_ENABLE_DBPAGE_VTAB -DSQLITE_ENABLE_STMTVTAB -DSQLITE_ENABLE_DBSTAT_VTAB -march=4kc -mtune=4kc -msoft-float -Os -pipe -Wa,--trap -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 --std=gnu99 -o .libs/sqlite3 sqlite3-shell.o  ./.libs/libsqlite3.so -lm -ldl -lpthread
./.libs/libsqlite3.so: undefined reference to `trunc'
collect2: ld returned 1 exit status
make[2]: *** [Makefile:509: sqlite3] Error 1
make[1]: *** [make/pkgs/sqlite/sqlite.mk:45: source/target-mipsel_gcc-4.6.4_uClibc-0.9.28/sqlite-3400100/.libs/libsqlite3.so.0.8.6] Terminated
make[1]: *** Deleting file 'source/target-mipsel_gcc-4.6.4_uClibc-0.9.28/sqlite-3400100/.libs/libsqlite3.so.0.8.6'
```
