### PR TITLE
mkdocs: add more descriptions and improve formatting of copyright space

### DIFF
--- a/.github/mkdocs/mkdocs.yml
+++ b/.github/mkdocs/mkdocs.yml
@@ -1,10 +1,16 @@
 site_name: 'Freetz-NG Documentation'
+site_description: 'Firmware modification for AVM FRITZ!Box devices'
+site_author: 'Freetz-NG'
 site_url: 'https://freetz-ng.github.io/'
 repo_url: 'https://github.com/freetz-ng/freetz-ng'
 edit_uri: '../freetz-ng/blob/master/docs/'
 docs_dir: '../../docs/'
 copyright: |
-  Copyright Freetz-NG. Licensed under <a href="https://github.com/Freetz-NG/freetz-ng/raw/refs/heads/master/COPYING" target="_blank" rel="noopener noreferrer">GPL-2.0</a>
+  <p>
+  &copy <span>Freetz-NG.</span><br/>
+  <span>Licensed under <a href="https://github.com/Freetz-NG/freetz-ng/raw/refs/heads/master/COPYING" target="_blank" rel="noopener noreferrer">GPL-2.0</a></span><br/>
+  <span>This project is not affiliated, associated, authorized, endorsed by, or in any way officially connected with AVM FRITZ!</span><br/>
+  </p>
 remote_branch: gh-pages
 validation:
   links:

--- a/.github/mkdocs/mkdocs.yml
+++ b/.github/mkdocs/mkdocs.yml
@@ -9,7 +9,6 @@ copyright: |
   <p>
   &copy <span>Freetz-NG.</span><br/>
   <span>Licensed under <a href="https://github.com/Freetz-NG/freetz-ng/raw/refs/heads/master/COPYING" target="_blank" rel="noopener noreferrer">GPL-2.0</a></span><br/>
-  <span>This project is not affiliated, associated, authorized, endorsed by, or in any way officially connected with AVM FRITZ!</span><br/>
   </p>
 remote_branch: gh-pages
 validation:


### PR DESCRIPTION
Dies fügt eine Beschreibung und author hinzu und formatiert den Bereich des uhrheberrechts besser und ersetzt das Wort copyright durch das passende Zeichen.