### PR TITLE
mkdocs: correct the description, formatting

### DIFF
--- a/.github/mkdocs/mkdocs.yml
+++ b/.github/mkdocs/mkdocs.yml
@@ -1,15 +1,13 @@
 site_name: 'Freetz-NG Documentation'
-site_description: 'Firmware modification for AVM FRITZ!Box devices'
+site_description: 'Freetz-NG firmware modification for ​AVM devices like FRITZ!Box'
 site_author: 'Freetz-NG'
 site_url: 'https://freetz-ng.github.io/'
 repo_url: 'https://github.com/freetz-ng/freetz-ng'
 edit_uri: '../freetz-ng/blob/master/docs/'
 docs_dir: '../../docs/'
 copyright: |
-  <p>
-  &copy <span>Freetz-NG.</span><br/>
+  &copy <span>Freetz-NG</span><br/>
   <span>Licensed under <a href="https://github.com/Freetz-NG/freetz-ng/raw/refs/heads/master/COPYING" target="_blank" rel="noopener noreferrer">GPL-2.0</a></span><br/>
-  </p>
 remote_branch: gh-pages
 validation:
   links:


### PR DESCRIPTION
Dies korigiert das Blockformat in im ©-Bereich der Webseite und passt die Beschreibung an die des Repos an.
refs: https://github.com/Freetz-NG/freetz-ng/pull/1350#issuecomment-3539321982