### PR TITLE
bump pseudo-host

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -72,6 +72,7 @@ Latest changes
     * gperf 3.3
     * patchelf 0.14.5/0.18.0-b49de1b33
     * patchelf-target 0.14.5/0.15.0
+    * pseudo 1.9.2
     * python3 3.14.0
     * python3-attrs 25.4.0
     * python3-jsonschema 4.25.1

--- a/make/host-tools/pseudo-host/pseudo-host.mk
+++ b/make/host-tools/pseudo-host/pseudo-host.mk
@@ -1,12 +1,12 @@
-$(call TOOLS_INIT, cc1f6167cb5065daba1462056e2dce8ff72aa855)
+$(call TOOLS_INIT, b4645cb30573c5b3d5e94b9d50e1e2f8beefe9be)
 $(PKG)_SOURCE:=pseudo-$($(PKG)_VERSION).tar.xz
-$(PKG)_HASH:=47d501e5fb5b0e22d2bf435e225db44bbcaac226e4c718fd6bc7c061afc979a8
+$(PKG)_HASH:=9632356f69687199434d9d8afb34415c9182b2b8d31a05f62361f579c6031394
 $(PKG)_SITE:=git@https://git.yoctoproject.org/git/pseudo
 #$(PKG)_SITE:=https://downloads.yoctoproject.org/releases/pseudo/
-### VERSION:=1.9.0 oe-core cc1f616
+### VERSION:=1.9.2 pseudo-1.9.2 b4645cb
 ### WEBSITE:=https://www.yoctoproject.org/software-item/pseudo/
 ### MANPAGE:=https://manpages.debian.org/testing/pseudo/pseudo.1.en.html
-### CHANGES:=https://git.yoctoproject.org/pseudo/log/?h=oe-core
+### CHANGES:=https://git.yoctoproject.org/pseudo/log/?h=pseudo-1.9.2
 ### CVSREPO:=https://git.yoctoproject.org/pseudo/
 ### SUPPORT:=fda77
 

--- a/make/host-tools/pseudo-host/pseudo-host.mk
+++ b/make/host-tools/pseudo-host/pseudo-host.mk
@@ -1,12 +1,13 @@
-$(call TOOLS_INIT, b4645cb30573c5b3d5e94b9d50e1e2f8beefe9be)
-$(PKG)_SOURCE:=pseudo-$($(PKG)_VERSION).tar.xz
-$(PKG)_HASH:=9632356f69687199434d9d8afb34415c9182b2b8d31a05f62361f579c6031394
-$(PKG)_SITE:=git@https://git.yoctoproject.org/git/pseudo
+$(call TOOLS_INIT, 1.9.2)
+$(PKG)_SOURCE:=pseudo-$($(PKG)_VERSION).tar.gz
+$(PKG)_HASH:=d1f6552be3213cae42cd36f30df5accb5ec65aef4a193fba1d118415ca524c69
+$(PKG)_SITE:=https://git.yoctoproject.org/pseudo/snapshot/
+#$(PKG)_SITE:=git@https://git.yoctoproject.org/git/pseudo
 #$(PKG)_SITE:=https://downloads.yoctoproject.org/releases/pseudo/
-### VERSION:=1.9.2 pseudo-1.9.2 b4645cb
+### VERSION:=1.9.2
 ### WEBSITE:=https://www.yoctoproject.org/software-item/pseudo/
 ### MANPAGE:=https://manpages.debian.org/testing/pseudo/pseudo.1.en.html
-### CHANGES:=https://git.yoctoproject.org/pseudo/log/?h=pseudo-1.9.2
+### CHANGES:=https://git.yoctoproject.org/pseudo/log/?h=master
 ### CVSREPO:=https://git.yoctoproject.org/pseudo/
 ### SUPPORT:=fda77
 


### PR DESCRIPTION
Dies aktualisiert pseudo-host von Version 1.9.0 zu 1.9.2.