### PR TITLE
exclusive user controlled stunnel config - ignore historical freetz default settings

### DIFF
--- a/docs/make/stunnel.md
+++ b/docs/make/stunnel.md
@@ -55,6 +55,28 @@ Homepage](http://www.stunnel.org/examples/).
     */tmp/flash/stunnel/key.pem* verwendet, welche vom Webinterface aus
     verwaltet werden (Punkt 2).
 
+    Die Standardeinstellungen von Freetz können mit der Zeile `#EXCLUSIVE#` deaktiviert werden.
+    Dies ermöglicht, globale Einstellungen außerhalb der `[<section>]` vorzunehmen.
+    Zum Beispiel:
+    ```
+    #EXCLUSIVE#
+    
+    TIMEOUTclose = 0
+    verifyChain = yes
+    CAfile = /tmp/flash/stunnel/certs.pem
+    cert = /tmp/flash/stunnel/key.pem
+    options = SINGLE_ECDH_USE
+    options = SINGLE_DH_USE
+
+    [freetz https Web-Interface]
+    accept = 4433
+    connect = 81
+
+    [avm https Web-Interface]
+    accept = 4434
+    connect = 80
+    ```
+
 <!-- -->
 
 4.  Zugriff (intern) über

--- a/make/pkgs/stunnel/files/root/etc/init.d/rc.stunnel
+++ b/make/pkgs/stunnel/files/root/etc/init.d/rc.stunnel
@@ -6,6 +6,7 @@ DAEMON=stunnel
 config() {
 	modlib_config
 	[ -r "/tmp/flash/stunnel/svcs" ] && cat /tmp/flash/stunnel/svcs >> $DAEMON_CONFIG
+	grep -q '#EXCLUSIVE#' /tmp/flash/stunnel/svcs && cat /tmp/flash/stunnel/svcs > $DAEMON_CONFIG
 }
 
 start() {


### PR DESCRIPTION
Add `#EXCLUSIVE#` to your stunnel services to archive full control over the stunnel config and ignore historical freetz default settings. [v5.76](https://github.com/Freetz-NG/freetz-ng/commit/9d9010f58a711704de3bc1d06662c6344aa10454#commitcomment-171133353)