### PR TITLE
Fix Python third-party modules cross-compilation

### DIFF
--- a/make/pkgs/python/python-module-macros.mk.in
+++ b/make/pkgs/python/python-module-macros.mk.in
@@ -22,13 +22,31 @@ define HostPython2
 		export PYTHONHOME="$(HOST_TOOLS_DIR)/usr"; \
 		export PYTHON_INCDIR="$(PYTHON_STAGING_INC_DIR)"; \
 		export PYTHON_LIBDIR="$(PYTHON_STAGING_LIB_DIR)"; \
-		export PYTHONPATH="$(PYTHON_STAGING_LIB_DIR):$(TARGET_TOOLCHAIN_STAGING_DIR)/$(PYTHON_SITE_PKG_DIR)"; \
+		export PYTHONPATH="$(PYTHON_STAGING_LIB_DIR):$(TARGET_TOOLCHAIN_STAGING_DIR)$(PYTHON_SITE_PKG_DIR)"; \
 		export PYTHONOPTIMIZE=""; \
 		export PYTHONDONTWRITEBYTECODE="x"; \
-		export CFLAGS="$(TARGET_CFLAGS) -I$(PYTHON_STAGING_INC_DIR)"; \
-		export CPPFLAGS="$(TARGET_CFLAGS) -I$(PYTHON_STAGING_INC_DIR)"; \
-		export LDFLAGS="$(TARGET_LDFLAGS) -L$(PYTHON_STAGING_LIB_DIR)"; \
+		export PYTHONNOUSERSITE="1"; \
+		export DISTUTILS_USE_SDK="1"; \
+		export _python_sysroot="$(TARGET_TOOLCHAIN_STAGING_DIR)"; \
+		export _PYTHON_SYSROOT="$(TARGET_TOOLCHAIN_STAGING_DIR)"; \
+		export CC="$(TARGET_CC)"; \
+		export CXX="$(TARGET_CXX)"; \
+		export LD="$(TARGET_CC)"; \
+		export LDSHARED="$(TARGET_CC) -shared"; \
+		export BLDSHARED="$(TARGET_CC) -shared"; \
+		export AR="$(TARGET_AR)"; \
+		export RANLIB="$(TARGET_RANLIB)"; \
+		export STRIP="$(TARGET_STRIP)"; \
+		export CPPFLAGS="-I$(PYTHON_STAGING_INC_DIR)"; \
+		export CFLAGS="$(TARGET_CFLAGS) -I$(PYTHON_STAGING_INC_DIR) -D_Py_LONG_BIT=32"; \
+		export GIT_PAGER="cat"; \
+		export _PYTHON_HOST_PLATFORM="$(GNU_TARGET_NAME)"; \
+		export _PYTHON_SYSCONFIGDATA_NAME="_sysconfigdata"; \
+		export LIBRARY_PATH="$(PYTHON_STAGING_LIB_DIR):$(TARGET_TOOLCHAIN_STAGING_DIR)/usr/lib"; \
+		export LD_RUN_PATH="$(PYTHON_STAGING_LIB_DIR):$(TARGET_TOOLCHAIN_STAGING_DIR)/usr/lib"; \
+		export LD_LIBRARY_PATH="$(PYTHON_STAGING_LIB_DIR):$(TARGET_TOOLCHAIN_STAGING_DIR)/usr/lib"; \
 		$(1) \
+		export LDFLAGS="-L$(PYTHON_STAGING_LIB_DIR) -L$(TARGET_TOOLCHAIN_STAGING_DIR)/usr/lib -Wl,--rpath-link=$(TARGET_TOOLCHAIN_STAGING_DIR)/usr/lib -Wl,-rpath=/usr/lib/freetz"; \
 		$(HOST_PYTHON_BIN) $(2); \
 	)
 endef
@@ -44,8 +62,11 @@ define Build/PyMod2/Generic
 		$(FREETZ_LD_RUN_PATH) \
 		$(3) \
 		, \
-		./setup.py $(2) \
-		$(SILENT) \
+		./setup.py build_ext \
+			--include-dirs=$(PYTHON_STAGING_INC_DIR) \
+			--library-dirs=$(PYTHON_STAGING_LIB_DIR):$(TARGET_TOOLCHAIN_STAGING_DIR)/usr/lib \
+			--rpath=/usr/lib/freetz \
+		$(2) \
 	)
 	$(if $(strip $(4)),find $(strip $(4)) -type f -name "*.so" -exec $(TARGET_STRIP) \{\} \+)
 endef


### PR DESCRIPTION
__Fix Python third-party modules cross-compilation__

This PR updates the make/pkgs/python/python-module-macros.mk.in macros to resolve cross-compilation issues for Python2 third-party modules (e.g., PIL, pyserial). The changes ensure that hostpython uses target toolchain variables, prioritizes target libraries over host ones, and allows the build of modules across architectures.

Even though the compilation paths in the Python addons build include host library references due to legacy Python2 setup.py behavior, the LD_LIBRARY_PATH environment variable set in the HostPython2 macro prioritizes the target libraries, as confirmed by ldd checks showing no host dependencies. The cross-compilation is [successful and clean](https://github.com/Ircama/freetz-ng/actions/runs/19807599600) for 35 devices (including 7590 AX).

This PR refers and replaces https://github.com/Freetz-NG/freetz-ng/pull/1242 (not as invasive as the initial work was), created because [ircama-fix-3rd-python2](https://github.com/Freetz-NG/freetz-ng/pull/1242#event-21255826459) was closed by mistake.