### PR TITLE
binutils-tools: add c++filt and elfedit

### DIFF
--- a/make/pkgs/binutils-tools/Config.in
+++ b/make/pkgs/binutils-tools/Config.in
@@ -11,7 +11,9 @@ menuconfig FREETZ_PACKAGE_BINUTILS_TOOLS
 		!FREETZ_PACKAGE_BINUTILS_TOOLS_RANLIB && \
 		!FREETZ_PACKAGE_BINUTILS_TOOLS_SIZE && \
 		!FREETZ_PACKAGE_BINUTILS_TOOLS_STRINGS && \
-		!FREETZ_PACKAGE_BINUTILS_TOOLS_STRIP
+		!FREETZ_PACKAGE_BINUTILS_TOOLS_STRIP && \
+		!FREETZ_PACKAGE_BINUTILS_TOOLS_CXXFILT && \
+		!FREETZ_PACKAGE_BINUTILS_TOOLS_ELFEDIT
 	help
 		Collection of essential tools for analyzing and
 		manipulating ELF binaries.
@@ -100,6 +102,20 @@ if FREETZ_PACKAGE_BINUTILS_TOOLS
 		help
 			Removes debugging symbols and other unnecessary information from object files,
 			reducing their size. Note: BusyBox already provides a 'strip' command.
+
+	config FREETZ_PACKAGE_BINUTILS_TOOLS_CXXFILT
+		bool "c++filt - Demangle C++ symbols"
+		select FREETZ_LIB_libbfd
+		default n
+		help
+			Demangles C++ mangled names, making them readable.
+
+	config FREETZ_PACKAGE_BINUTILS_TOOLS_ELFEDIT
+		bool "elfedit - Update ELF header information"
+		select FREETZ_LIB_libbfd
+		default n
+		help
+			Updates ELF header information in ELF files.
 
 endif # FREETZ_PACKAGE_BINUTILS_TOOLS
 

--- a/make/pkgs/binutils-tools/binutils-tools.mk
+++ b/make/pkgs/binutils-tools/binutils-tools.mk
@@ -12,10 +12,12 @@ $(PKG)_SITE:=@GNU/binutils
 $(PKG)_CATEGORY:=Debug helpers
 
 $(PKG)_SRC_POSTFIX:=-new
-$(PKG)_SRC_BIN:=ar addr2line nm-new objcopy objdump ranlib readelf size strings strip-new
+$(PKG)_SRC_BIN:=ar addr2line nm-new objcopy objdump ranlib readelf size strings strip-new cxxfilt elfedit
 $(PKG)_DST_BIN:=$(patsubst %$($(PKG)_SRC_POSTFIX),%,$($(PKG)_SRC_BIN))
 $(PKG)_SEL_BIN:=$(call PKG_SELECTED_SUBOPTIONS,$($(PKG)_DST_BIN))
-$(PKG)_SRC_DIR:=$($(PKG)_SRC_BIN:%=$($(PKG)_DIR)/binutils/.libs/%)
+$(PKG)_SRC_DIR_LIBS:=$(filter-out $($(PKG)_DIR)/binutils/.libs/elfedit,$($(PKG)_SRC_BIN:%=$($(PKG)_DIR)/binutils/.libs/%))
+$(PKG)_SRC_DIR_BIN:=$($(PKG)_DIR)/binutils/elfedit
+$(PKG)_SRC_DIR:=$($(PKG)_SRC_DIR_LIBS) $($(PKG)_SRC_DIR_BIN)
 $(PKG)_DST_DIR:=$($(PKG)_DST_BIN:%=$($(PKG)_DEST_DIR)/usr/bin/%)
 $(PKG)_SEL_DIR:=$($(PKG)_SEL_BIN:%=$($(PKG)_DEST_DIR)/usr/bin/%)
 $(PKG)_EXCLUDED:=$(filter-out $($(PKG)_SEL_DIR),$($(PKG)_DST_DIR))
@@ -49,6 +51,7 @@ $(PKG)_CONFIGURE_OPTIONS += --without-included-gettext
 $(PKG)_CONFIGURE_OPTIONS += --enable-deterministic-archives
 # Disable gprofng (requires glibc-only features: dlvsym, Dl_serinfo, RTLD_DI_SERINFOSIZE)
 $(PKG)_CONFIGURE_OPTIONS += --disable-gprofng
+$(PKG)_CONFIGURE_OPTIONS += --enable-elfedit
 
 
 $(PKG_SOURCE_DOWNLOAD)


### PR DESCRIPTION
Add `c++filt` and `elfedit\ as options to binutils-tools (not selected by default).

Notice that the binutils issue related https://github.com/Freetz-NG/freetz-ng/actions/runs/20134176185/job/57782985832 is not included here and has pending decisions to be separately evaluated (either remove libiberty* files from the sysroot after GCC installation, or fixing the patches 010-make-j-fixes.pr42980_backport.install-multi.patch).