### PR TITLE
socat: fix posix_memalign and add VSOCK compatibility

### DIFF
--- a/make/pkgs/socat/patches/030-posix_memalign.patch
+++ b/make/pkgs/socat/patches/030-posix_memalign.patch
@@ -1,0 +1,27 @@
+--- a/sycls.c
++++ b/sycls.c
+@@ -5,6 +5,7 @@
+ /* explicit system call and C library trace function, for those who miss strace
+  */
+ 
++#include <malloc.h>
+ #include "config.h"
+ #include "xioconfig.h"	/* what features are enabled */
+ 
+@@ -29,6 +30,11 @@ int Posix_memalign(void **memptr, size_t alignment, size_t size) {
+-   int result;
+-   Debug3("posix_memalign(%p, "F_Zu", "F_Zu")", memptr, alignment, size);
+-   result = posix_memalign(memptr, alignment, size);
+-   Debug1("posix_memalign(...) -> %d", result);
+-   return result;
++   void *ptr;
++   Debug3("memalign(%p, "F_Zu", "F_Zu")", memptr, alignment, size);
++   ptr = memalign(alignment, size);
++   if (ptr == NULL) {
++      Debug1("memalign(...) -> %d", ENOMEM);
++      return ENOMEM;
++   } else {
++      *memptr = ptr;
++      return 0;
++   }
+ }

--- a/make/pkgs/socat/patches/040-af_vsock.patch
+++ b/make/pkgs/socat/patches/040-af_vsock.patch
@@ -1,0 +1,66 @@
+--- a/xioopts.c
++++ b/xioopts.c
+@@ -3313,5 +3313,5 @@
+ #if WITH_IP4 || WITH_IP6 || WITH_VSOCK
+    case AF_UNSPEC:
+-#if WITH_VSOCK
++#if WITH_VSOCK && defined(AF_VSOCK)
+    case AF_VSOCK:
+ #endif
+--- a/xio-ip.c
++++ b/xio-ip.c
+@@ -473,5 +473,5 @@
+ #if LATER
+-#ifdef WITH_VSOCK
++#if defined(WITH_VSOCK) && defined(AF_VSOCK)
+    if (family == AF_VSOCK) {
+       error_num = sockaddr_vm_parse(&sau->vm, node, service);
+       if (error_num < 0) {
+--- a/sysutils.c
++++ b/sysutils.c
+@@ -249,5 +249,5 @@
+ #endif
+-#if WITH_VSOCK
++#if WITH_VSOCK && defined(AF_VSOCK)
+    case AF_VSOCK: sockaddr_vm_info(&sau->vm, cp, blen);
+       break;
+ #endif
+--- a/xio-socket.c
++++ b/xio-socket.c
+@@ -2072,5 +2072,5 @@
+       } while (result > 0);
+      break;
+ #endif /* WITH_IP6 */
+-#if WITH_VSOCK
++#if WITH_VSOCK && defined(PF_VSOCK)
+    case PF_VSOCK:
+      strcpy(namebuff, lr);
+      do {
+--- a/xio-vsock.c
++++ b/xio-vsock.c
+@@ -7,7 +7,7 @@
+ /* This file contains the source for opening addresses of VSOCK soc
+ ket type */                                                        
+ #include "xiosysincludes.h"
+ 
+-#ifdef WITH_VSOCK
++#if defined(WITH_VSOCK) && defined(PF_VSOCK)
+ #include "xioopen.h"
+ #include "xio-listen.h"
+ #include "xio-socket.h"
+--- a/xioopen.c
++++ b/xioopen.c
+@@ -406,11 +406,11 @@
+    { "UNIX-SEND",      &xioaddr_unix_sendto },
+    { "UNIX-SENDTO",    &xioaddr_unix_sendto },
+ #endif
+-#if WITH_VSOCK
++#if WITH_VSOCK && defined(PF_VSOCK)
+    { "VSOCK",			&xioaddr_vsock_connect },
+    { "VSOCK-CONNECT",		&xioaddr_vsock_connect },
+ #endif
+-#if WITH_VSOCK && WITH_LISTEN
++#if WITH_VSOCK && defined(PF_VSOCK) && WITH_LISTEN
+    { "VSOCK-L",			&xioaddr_vsock_listen },
+    { "VSOCK-LISTEN",		&xioaddr_vsock_listen },
+ #endif


### PR DESCRIPTION
Add socat patches for posix_memalign (old uClibc) and VSOCK (kernels <4.8) compatibility