### PR TITLE
bump ncurses-host

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -80,6 +80,7 @@ Latest changes
     * gperf 3.3
     * kconfig 6.18
     * meson 1.10.0
+    * ncurses 6.6
     * ninja 1.13.2
     * patchelf 0.14.5/0.18.0-b49de1b33
     * patchelf-target 0.14.5/0.15.0

--- a/make/host-tools/ncurses-host/ncurses-host.mk
+++ b/make/host-tools/ncurses-host/ncurses-host.mk
@@ -1,7 +1,8 @@
-$(call TOOLS_INIT, 6.5-20250419)
-$(PKG)_SOURCE:=ncurses-$($(PKG)_VERSION).tgz
-$(PKG)_HASH:=a1dcc10899d5bdb78b3cca0848e5f1d6aeed78992f495d84d449587fe36c7cf4
-$(PKG)_SITE:=@GNU/ncurses,https://invisible-island.net/archives/ncurses
+$(call TOOLS_INIT, 6.6)
+#$(PKG)_SOURCE_DOWNLOAD_NAME:=ncurses-$($(PKG)_VERSION).tgz
+$(PKG)_SOURCE:=ncurses-$($(PKG)_VERSION).tar.gz
+$(PKG)_HASH:=355b4cbbed880b0381a04c46617b7656e362585d52e9cf84a67e2009b749ff11
+$(PKG)_SITE:=@GNU/ncurses,https://invisible-island.net/archives/ncurses,https://invisible-island.net/archives/ncurses/current
 ### WEBSITE:=https://invisible-island.net/ncurses/
 ### MANPAGE:=https://invisible-island.net/ncurses/announce.html
 ### CHANGES:=https://invisible-island.net/ncurses/NEWS.html


### PR DESCRIPTION
Dies aktualisiert `ncurses-host` von Version `6.5-20250419` auf Version `6.6`.
Zusätzlich wird ein Link unter `$(PKG)_SITE` hinzugefügt was die Downloads von dem z.b. Versions-Schema `6.5-xxxxxxxx` möglich macht.