### PR TITLE
docker(action): add ghcr cleanup

### DIFF
--- a/.github/workflows/image_dl-packs.yml
+++ b/.github/workflows/image_dl-packs.yml
@@ -22,6 +22,8 @@ jobs:
       packages: write
     runs-on: ubuntu-latest
     if: github.repository == 'freetz-ng/freetz-ng'
+    outputs:
+      image: ${{ steps.prepare.outputs.image }}
 
     steps:
 
@@ -54,4 +56,24 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ghcr.io/${{ steps.prepare.outputs.owner }}/${{ steps.prepare.outputs.image }}:latest
 
+  cleanup:
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+    runs-on: ubuntu-latest
+    if: github.repository == 'freetz-ng/freetz-ng'
 
+    steps:
+
+      - name: cleanup
+        if: github.event_name != 'pull_request'
+        uses: Chizkiyahu/delete-untagged-ghcr-action@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository_owner: ${{ github.repository_owner }}
+          repository: ${{ github.repository }}
+          package_name: ${{ needs.build.outputs.image }}
+          untagged_only: true
+          owner_type: org # or user
+          except_untagged_multiplatform: true

--- a/.github/workflows/image_firmware.yml
+++ b/.github/workflows/image_firmware.yml
@@ -22,6 +22,8 @@ jobs:
       packages: write
     runs-on: ubuntu-latest
     if: github.repository == 'freetz-ng/freetz-ng'
+    outputs:
+      image: ${{ steps.prepare.outputs.image }}
 
     steps:
 
@@ -54,4 +56,24 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ghcr.io/${{ steps.prepare.outputs.owner }}/${{ steps.prepare.outputs.image }}:latest
 
+  cleanup:
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+    runs-on: ubuntu-latest
+    if: github.repository == 'freetz-ng/freetz-ng'
 
+    steps:
+
+      - name: cleanup
+        if: github.event_name != 'pull_request'
+        uses: Chizkiyahu/delete-untagged-ghcr-action@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository_owner: ${{ github.repository_owner }}
+          repository: ${{ github.repository }}
+          package_name: ${{ needs.build.outputs.image }}
+          untagged_only: true
+          owner_type: org # or user
+          except_untagged_multiplatform: true

--- a/.github/workflows/image_generate.yml
+++ b/.github/workflows/image_generate.yml
@@ -22,6 +22,8 @@ jobs:
       packages: write
     runs-on: ubuntu-latest
     if: github.repository == 'freetz-ng/freetz-ng'
+    outputs:
+      image: ${{ steps.prepare.outputs.image }}
 
     steps:
 
@@ -54,4 +56,24 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ghcr.io/${{ steps.prepare.outputs.owner }}/${{ steps.prepare.outputs.image }}:latest
 
+  cleanup:
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+    runs-on: ubuntu-latest
+    if: github.repository == 'freetz-ng/freetz-ng'
 
+    steps:
+
+      - name: cleanup
+        if: github.event_name != 'pull_request'
+        uses: Chizkiyahu/delete-untagged-ghcr-action@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository_owner: ${{ github.repository_owner }}
+          repository: ${{ github.repository }}
+          package_name: ${{ needs.build.outputs.image }}
+          untagged_only: true
+          owner_type: org # or user
+          except_untagged_multiplatform: true


### PR DESCRIPTION
Dies fügt ~~ein neuer Action~~ in den bestehenden Docker Build Actions ein neuer job hinzu mit den in ghcr registry die untagged Images gelöscht werden.
Bedeutet wenn ein neues Dockerimage mit z.b. latest gepusht wird, dann wird das was vorher als latest gewesen ist, nun als untagged Image und das bleibt im ghcr übrig und kann sich ziemlich aufsummieren.
Mir sind zwar keine Probleme dessen bekannt aber es scheint als normal zusein "housekeeping" des eigenen ghcr registrys zu betreiben.

### Bekannte Repos die dies oder ähnliches einsetzen.
- [pi-hole](https://github.com/pi-hole/docker-pi-hole/blob/development/.github/workflows/housekeeping.yml)
- [pfichtner-freetz](https://github.com/pfichtner/pfichtner-freetz/blob/main/.github/workflows/delete-untagged-images.yml)

### Laut der unterstützen Recherche <sup>Ki</sup>

> Wenn du untagged Images im GHCR *nicht* bereinigst, passiert technisch **kein Fehler oder Datenverlust** – aber sie sammeln sich an, **belegen Speicherplatz**, können **Speicher- und Kontingentprobleme** erzeugen und verschlechtern die Übersicht über deine Registry. Außerdem gibt es keine eingebaute automatische Löschung; deshalb lohnt sich oft ein Aufräum-Workflow. ([GitHub Docs][1])

[1]: https://docs.github.com/en/billing/concepts/product-billing/github-packages?utm_source=chatgpt.com "GitHub Packages billing"

### Gegenbeispiel

[wg-easy](https://github.com/wg-easy/wg-easy) verwendet (Stand: 26.12.2025) keine bereinigung des ghcr registrys und das sieht man auch an der Übersicht deutlich:
[<img width="231" height="53" alt="Screenshot 2025-12-26 at 15-26-46 wg-easy versions · wg-easy" src="https://github.com/user-attachments/assets/a1c9d053-653c-4f73-89f5-2eed2047920c" />](https://github.com/wg-easy/wg-easy/pkgs/container/wg-easy/versions?filters%5Bversion_type%5D=tagged)

