### PR TITLE
add devcontainer config

### DIFF
--- a/.devcontainer/build/devcontainer.json
+++ b/.devcontainer/build/devcontainer.json
@@ -1,0 +1,8 @@
+{
+  "name": "Freetz-NG Build Env",
+  "image": "ghcr.io/freetz-ng/dl-packs:latest",
+
+  "remoteUser": "freetz",
+
+  "postCreateCommand": "sudo chown -R freetz:freetz ${containerWorkspaceFolder} /tmp && sudo chmod -R 755 ${containerWorkspaceFolder} /tmp && git -C ${containerWorkspaceFolder} checkout --force"
+}


### PR DESCRIPTION
Dies fügt eine Dev Container Config hinzu mit den es möglich ist bei u.a. GitHub ein Codespace auf basis dieser Dev Container Config zu ermöglichen um auch über den GitHub Codespace oder auch Lokal mit VSCode mit den Devcontainer eine Buildumgebung zu nutzen mit den man u.a. Firmware bauen kann.

<img width="473.5" height="168.5" alt="Screenshot 2025-12-27 at 13-25-19 Create new codespace" src="https://github.com/user-attachments/assets/5ab1a01c-0bd3-430e-a0fa-b4cee2ce2e16" />

-----

Die Paremeter für die Dev Container Config sind unten verlinkt:
- Docs: https://containers.dev/implementors/json_reference
  - Env's: https://containers.dev/implementors/json_reference/#variables-in-devcontainerjson

(_Der Link zur Doku war auch nicht so einfach über Google zu finden_)