### PR TITLE
kernel_5_modules

### DIFF
--- a/fwmod
+++ b/fwmod
@@ -1395,7 +1395,6 @@ if [ "$DO_MOD" -gt 0 ]; then
 			zeropadding=$(echo $modversions | sed 's/./0/g')
 			symvers=$ABS_BASE_DIR/source/kernel/ref-$KERNEL_ID/linux-$FREETZ_KERNEL_VERSION_MAJOR/Module.symvers
 			firsthash=$(($(head -c10 $symvers)))
-			starttime=$(date +%s)
 			for module in $(cd $MODULES_DIR && find . -name *.ko)
 			do
 				[ -f ${KERNEL_REP_DIR}/modules-${KERNEL_ID}/$(echo $module | sed 's/\/kernel\//\//') ] && continue
@@ -1414,7 +1413,7 @@ if [ "$DO_MOD" -gt 0 ]; then
 						((total++))
 						hash=$(echo $symbol | sed -rn 's/0x(.{8});(.*)/\1/p')
 						name=$(echo $symbol | sed -rn 's/0x(.{8});(.*)/\2/p')
-						#newhash=$(grep -w $name $symvers | sed -rn 's/0x(.{8}).*/\1/p')
+						newhash=$(grep -w $name $symvers | sed -rn 's/0x(.{8}).*/\1/p')
 						if [ $newhash ] && [ $newhash != $hash ]
 						then
 							((updated++))
@@ -1440,7 +1439,6 @@ if [ "$DO_MOD" -gt 0 ]; then
 					sizeinfo mod $module
 				fi
 			done
-			echo $(($(date +%s) - starttime))
 		fi
 		for i in \
 		$( \

--- a/fwmod
+++ b/fwmod
@@ -1420,7 +1420,7 @@ if [ "$DO_MOD" -gt 0 ]; then
 							((updated++))
 							littlehash=$(echo -n $hash | tac -rs ..)
 							newlittlehash=$(echo -n $newhash | tac -rs ..)
-							hexname=$(echo -n $name | xxd -p -c0)
+							hexname=$(echo -n $name | xxd -p -c0)'00'
 							hexmodule=$(echo $hexmodule | sed 's/'$littlehash$hexname'/'$newlittlehash$hexname'/')
 						fi
 					done

--- a/fwmod
+++ b/fwmod
@@ -1423,8 +1423,7 @@ if [ "$DO_MOD" -gt 0 ]; then
 				fi
 				if [ $updated -gt 0 ]
 				then
-					xxd -p -c0 $module | sed -r $pattern | xxd -r -p > tmp
-					mv tmp $module
+					xxd -p -c0 $module | sed -r $pattern | xxd -r -p > tmp && mv tmp $module
 					bn="$(basename "$module")"
 					sizeinfo "$bn"
 					if [ $firsthash -eq 0 ]

--- a/fwmod
+++ b/fwmod
@@ -1429,7 +1429,7 @@ if [ "$DO_MOD" -gt 0 ]; then
 					echo $hexmodule | xxd -r -p > $module
 					bn="$(basename "$module")"
 					sizeinfo "$bn"
-					[ $firsthash -eq 0 ]
+					if [ $firsthash -eq 0 ]
 					then
 						echo -n ' vermagic'
 					else

--- a/fwmod
+++ b/fwmod
@@ -1403,6 +1403,7 @@ if [ "$DO_MOD" -gt 0 ]; then
 				hexmodule=$(xxd -p -c0 $module)
 				updated=0
 				total=0
+				pattern=''
 				if [ $firsthash -eq 0 ]
 				then
 					((total++))
@@ -1421,12 +1422,14 @@ if [ "$DO_MOD" -gt 0 ]; then
 							littlehash=$(echo -n $hash | tac -rs ..)
 							newlittlehash=$(echo -n $newhash | tac -rs ..)
 							hexname=$(echo -n $name | xxd -p -c0)'00'
-							hexmodule=$(echo $hexmodule | sed 's/'$littlehash$hexname'/'$newlittlehash$hexname'/')
+							#hexmodule=$(echo $hexmodule | sed 's/'$littlehash$hexname'/'$newlittlehash$hexname'/')
+							pattern=$pattern's/'$littlehash$hexname'/'$newlittlehash$hexname'/;'
 						fi
 					done
 				fi
 				if [ $updated -gt 0 ]
 				then
+					[ $pattern ] && hexmodule=$(echo $hexmodule | sed $pattern)
 					echo $hexmodule | xxd -r -p > $module
 					bn="$(basename "$module")"
 					sizeinfo "$bn"

--- a/fwmod
+++ b/fwmod
@@ -1405,7 +1405,7 @@ if [ "$DO_MOD" -gt 0 ]; then
 					vermagic=$(echo -n 'vermagic=' | xxd -p -c0)
 					modversions=$(echo -n 'modversions ' | xxd -p -c0)
 					zeropadding=$(echo $modversions | sed 's/./0/g')
-					pattern='s/('$vermagic'.*)'$modversions'(([^0].)*)/\1\2'$zeropadding'/'
+					pattern='s/('$vermagic'.*)'$modversions'(([^0].)*00)/\1\2'$zeropadding'/'
 				else
 					pattern=''
 					for symbol in $(modprobe --dump-modversions $module | sed -r 's/\t/;/')

--- a/fwmod
+++ b/fwmod
@@ -1408,10 +1408,10 @@ if [ "$DO_MOD" -gt 0 ]; then
 					pattern='s/('$vermagic'.*)'$modversions'(([^0].)*00)/\1\2'$zeropadding'/'
 				else
 					pattern=''
-					for symbol in $(modprobe --dump-modversions $module | sed -r 's/\t/;/')
+					for symbol in $(modprobe --dump-modversions $module | sed -r 's/\t/,/')
 					do
 						((total++))
-						declare $(echo $symbol | sed -rn 's/0x(..)(..)(..)(..);(.*)/hash=\4\3\2\1 name=\5/p')
+						declare $(echo $symbol | sed -rn 's/0x(..)(..)(..)(..),(.*)/hash=\4\3\2\1 name=\5/p')
 						newhash=$(grep -w $name $symvers | sed -rn 's/0x(..)(..)(..)(..).*/\4\3\2\1/p')
 						if [ $newhash ] && [ $newhash != $hash ]
 						then

--- a/fwmod
+++ b/fwmod
@@ -1388,6 +1388,50 @@ if [ "$DO_MOD" -gt 0 ]; then
 	if [ "$FREETZ_REPLACE_KERNEL" == "y" -o -n "$(set|grep ^FREETZ_MODULE_.*=y)" -o -n "$FREETZ_MODULES_OWN" ]; then
 		[ "$FREETZ_STRIP_MODULES_FREETZ" == "y" ] && strip_output=" and stripping"
 		echo0 "installing$strip_output modules"
+		if [ "$FREETZ_KERNEL_VERSION_5" = "y" ]
+		then
+			vermagic=$(echo -n 'vermagic=' | xxd -p -c0)
+			modversions=$(echo -n 'modversions ' | xxd -p -c0)
+			zero12=$(printf '%024x' 0)
+			k=$ABS_BASE_DIR/source/kernel/ref-$KERNEL_ID/linux-$FREETZ_KERNEL_VERSION_MAJOR/Module.symvers
+			for f in $(cd $MODULES_DIR && find . -name *.ko)
+			do
+				[ -f ${KERNEL_REP_DIR}/modules-${KERNEL_ID}/$(echo $f | sed 's/\/kernel\//\//') ] && continue
+				f=$MODULES_DIR/$f
+				p=0
+				t=0
+				x=$(xxd -p -c0 $f)
+				if [ $(($(head -c10 $k))) -eq 0 ]
+				then
+					((t--))
+					x=$(echo $x | sed -r 's/('$vermagic'.*)'$modversions'(([^0].)*)/\1\2'$zero12'/')
+				else
+					for s in $(modprobe --dump-modversions $f | sed -r 's/\t//')
+	        			do
+						((t++))
+						h=$(echo $s | sed -rn 's/0x(.{8})(.*)/\1/p')
+						n=$(echo $s | sed -rn 's/0x(.{8})(.*)/\2/p')
+	                			u=$(grep -w $n $k | sed -rn 's/0x(.{8}).*/\1/p')
+						if [ $u ] && [ $h != $u ]
+	                			then
+							((p++))
+							H=$(echo -n $h | tac -rs ..)
+							U=$(echo -n $u | tac -rs ..)
+							N=$(echo -n $n | xxd -p -c0)
+							x=$(echo $x | sed 's/'$H$N'/'$U$N'/')
+						fi
+					done
+				fi
+				if [ $t -ne 0 ]
+				then
+					echo $x | xxd -r -p > $f
+					bn="$(basename "$f")"
+					sizeinfo "$bn"
+					[ $t -gt 0 ] && printf '%5d of %5d symbols updated' $p $t || echo -n ' vermagic updated'
+					sizeinfo mod $f
+				fi
+			done
+		fi
 		for i in \
 		$( \
 			cd "${KERNEL_REP_DIR}/modules-${KERNEL_ID}" && \
@@ -1397,7 +1441,8 @@ if [ "$DO_MOD" -gt 0 ]; then
 			ko_symbol="$(echo "${bn%\.ko}" | tr '\-+' '_x')"
 			ko_install="$(eval "echo \"\$FREETZ_MODULE_$ko_symbol\"")"
 			echo " $FREETZ_MODULES_OWN " | grep -q " $ko_symbol " && ko_install="y"
-			[ "$FREETZ_MODULES_ALL" = "y" -o "$ko_install" == "y" ] || continue
+			ko_file_ori="${MODULES_DIR}/kernel/${i}"
+			[ "$FREETZ_KERNEL_VERSION_5" = "y" -a -f "$ko_file_ori" -o "$FREETZ_MODULES_ALL" = "y" -o "$ko_install" == "y" ] || continue
 			sizeinfo "$bn"
 			ko_file_src="${KERNEL_REP_DIR}/modules-${KERNEL_ID}/${i}"
 			ko_path_dst="${MODULES_DIR}/kernel/$(dirname "$i")"

--- a/fwmod
+++ b/fwmod
@@ -1395,6 +1395,7 @@ if [ "$DO_MOD" -gt 0 ]; then
 			zeropadding=$(echo $modversions | sed 's/./0/g')
 			symvers=$ABS_BASE_DIR/source/kernel/ref-$KERNEL_ID/linux-$FREETZ_KERNEL_VERSION_MAJOR/Module.symvers
 			firsthash=$(($(head -c10 $symvers)))
+			starttime=$(date +%s)
 			for module in $(cd $MODULES_DIR && find . -name *.ko)
 			do
 				[ -f ${KERNEL_REP_DIR}/modules-${KERNEL_ID}/$(echo $module | sed 's/\/kernel\//\//') ] && continue
@@ -1408,12 +1409,12 @@ if [ "$DO_MOD" -gt 0 ]; then
 					((updated++))
 					hexmodule=$(echo $hexmodule | sed -r 's/('$vermagic'.*)'$modversions'(([^0].)*)/\1\2'$zeropadding'/')
 				else
-					for symbol in $(modprobe --dump-modversions $module | sed -r 's/\t//')
+					for symbol in $(modprobe --dump-modversions $module | sed -r 's/\t/;/')
 					do
 						((total++))
-						hash=$(echo $symbol | sed -rn 's/0x(.{8})(.*)/\1/p')
-						name=$(echo $symbol | sed -rn 's/0x(.{8})(.*)/\2/p')
-						newhash=$(grep -w $name $symvers | sed -rn 's/0x(.{8}).*/\1/p')
+						hash=$(echo $symbol | sed -rn 's/0x(.{8});(.*)/\1/p')
+						name=$(echo $symbol | sed -rn 's/0x(.{8});(.*)/\2/p')
+						#newhash=$(grep -w $name $symvers | sed -rn 's/0x(.{8}).*/\1/p')
 						if [ $newhash ] && [ $newhash != $hash ]
 						then
 							((updated++))
@@ -1439,6 +1440,7 @@ if [ "$DO_MOD" -gt 0 ]; then
 					sizeinfo mod $module
 				fi
 			done
+			echo $(($(date +%s) - starttime))
 		fi
 		for i in \
 		$( \

--- a/fwmod
+++ b/fwmod
@@ -1395,9 +1395,10 @@ if [ "$DO_MOD" -gt 0 ]; then
 			zeropadding=$(echo $modversions | sed 's/./0/g')
 			symvers=$ABS_BASE_DIR/source/kernel/ref-$KERNEL_ID/linux-$FREETZ_KERNEL_VERSION_MAJOR/Module.symvers
 			firsthash=$(($(head -c10 $symvers)))
+			starttime=$(date +%s)
 			for module in $(cd $MODULES_DIR && find . -name *.ko)
 			do
-				[ -f ${KERNEL_REP_DIR}/modules-${KERNEL_ID}/$(echo $module | sed 's/\/kernel\//\//') ] && continue
+				[ -f ${KERNEL_REP_DIR}/modules-${KERNEL_ID}/$(echo $module | sed 's,/kernel/,/,') ] && continue
 				module=$MODULES_DIR/$module
 				hexmodule=$(xxd -p -c0 $module)
 				updated=0
@@ -1439,6 +1440,7 @@ if [ "$DO_MOD" -gt 0 ]; then
 					sizeinfo mod $module
 				fi
 			done
+			echo '  took '$(date +%M:%S -d@$(($(date +%s) - starttime)))
 		fi
 		for i in \
 		$( \
@@ -1482,10 +1484,19 @@ if [ "$DO_MOD" -gt 0 ]; then
 			  "$MODULES_DIR/modules.builtin" \
 			  "$MODULES_DIR/modules.builtin.modinfo" \
 			  "$MODULES_DIR/modules.order"
-			LANG=C depmod -e -b "$FILESYSTEM_MOD_DIR" \
-			  -F ${KERNEL_REP_DIR}/System-${KERNEL_ID}.map \
-			  $FREETZ_KERNEL_VERSION \
-			  2>&1 | tee "$DEPMOD_TEMP" | sed "s@ ${ABS_BASE_DIR}/@ @g"
+			if [ "$FREETZ_KERNEL_VERSION_5" = "y" -a $firsthash -ne 0 ]
+			then
+				LANG=C depmod -e -b "$FILESYSTEM_MOD_DIR" \
+				  -F ${KERNEL_REP_DIR}/System-${KERNEL_ID}.map \
+				  -E $symvers \
+				  $FREETZ_KERNEL_VERSION \
+				  2>&1 | tee "$DEPMOD_TEMP" | sed "s@ ${ABS_BASE_DIR}/@ @g"
+			else
+				LANG=C depmod -e -b "$FILESYSTEM_MOD_DIR" \
+				  -F ${KERNEL_REP_DIR}/System-${KERNEL_ID}.map \
+				  $FREETZ_KERNEL_VERSION \
+				  2>&1 | tee "$DEPMOD_TEMP" | sed "s@ ${ABS_BASE_DIR}/@ @g"
+			fi
 		else
 			NM=$NM ${TOOLS_DIR}/depmod.pl -e -b "$MODULES_DIR" \
 			  -F ${KERNEL_REP_DIR}/System-${KERNEL_ID}.map \

--- a/fwmod
+++ b/fwmod
@@ -1393,42 +1393,42 @@ if [ "$DO_MOD" -gt 0 ]; then
 			vermagic=$(echo -n 'vermagic=' | xxd -p -c0)
 			modversions=$(echo -n 'modversions ' | xxd -p -c0)
 			zero12=$(printf '%024x' 0)
-			k=$ABS_BASE_DIR/source/kernel/ref-$KERNEL_ID/linux-$FREETZ_KERNEL_VERSION_MAJOR/Module.symvers
-			for f in $(cd $MODULES_DIR && find . -name *.ko)
+			symvers=$ABS_BASE_DIR/source/kernel/ref-$KERNEL_ID/linux-$FREETZ_KERNEL_VERSION_MAJOR/Module.symvers
+			for module in $(cd $MODULES_DIR && find . -name *.ko)
 			do
-				[ -f ${KERNEL_REP_DIR}/modules-${KERNEL_ID}/$(echo $f | sed 's/\/kernel\//\//') ] && continue
-				f=$MODULES_DIR/$f
-				p=0
-				t=0
-				x=$(xxd -p -c0 $f)
-				if [ $(($(head -c10 $k))) -eq 0 ]
+				[ -f ${KERNEL_REP_DIR}/modules-${KERNEL_ID}/$(echo $module | sed 's/\/kernel\//\//') ] && continue
+				module=$MODULES_DIR/$module
+				updated=0
+				total=0
+				hexmodule=$(xxd -p -c0 $module)
+				if [ $(($(head -c10 $symvers))) -eq 0 ]
 				then
-					((t--))
-					x=$(echo $x | sed -r 's/('$vermagic'.*)'$modversions'(([^0].)*)/\1\2'$zero12'/')
+					((total--))
+					hexmodule=$(echo $hexmodule | sed -r 's/('$vermagic'.*)'$modversions'(([^0].)*)/\1\2'$zero12'/')
 				else
-					for s in $(modprobe --dump-modversions $f | sed -r 's/\t//')
+					for symbol in $(modprobe --dump-modversions $module | sed -r 's/\t//')
 						do
-						((t++))
-						h=$(echo $s | sed -rn 's/0x(.{8})(.*)/\1/p')
-						n=$(echo $s | sed -rn 's/0x(.{8})(.*)/\2/p')
-						u=$(grep -w $n $k | sed -rn 's/0x(.{8}).*/\1/p')
-						if [ $u ] && [ $h != $u ]
+						((total++))
+						hash=$(echo $symbol | sed -rn 's/0x(.{8})(.*)/\1/p')
+						name=$(echo $symbol | sed -rn 's/0x(.{8})(.*)/\2/p')
+						newhash=$(grep -w $name $symvers | sed -rn 's/0x(.{8}).*/\1/p')
+						if [ $newhash ] && [ $newhash != $hash ]
 						then
-							((p++))
-							H=$(echo -n $h | tac -rs ..)
-							U=$(echo -n $u | tac -rs ..)
-							N=$(echo -n $n | xxd -p -c0)
-							x=$(echo $x | sed 's/'$H$N'/'$U$N'/')
+							((updated++))
+							littlehash=$(echo -n $hash | tac -rs ..)
+							newlittlehash=$(echo -n $newhash | tac -rs ..)
+							hexname=$(echo -n $name | xxd -p -c0)
+							hexmodule=$(echo $hexmodule | sed 's/'$littlehash$hexname'/'$newlittlehash$hexname'/')
 						fi
 					done
 				fi
-				if [ $t -ne 0 ]
+				if [ $total -ne 0 ]
 				then
-					echo $x | xxd -r -p > $f
-					bn="$(basename "$f")"
+					echo $hexmodule | xxd -r -p > $module
+					bn="$(basename "$module")"
 					sizeinfo "$bn"
-					[ $t -gt 0 ] && printf '%5d of %5d symbols updated' $p $t || echo -n ' vermagic updated'
-					sizeinfo mod $f
+					[ $total -gt 0 ] && printf '%5d of %5d symbols updated' $updated $total || echo -n ' vermagic updated'
+					sizeinfo mod $module
 				fi
 			done
 		fi

--- a/fwmod
+++ b/fwmod
@@ -1386,12 +1386,11 @@ if [ "$DO_MOD" -gt 0 ]; then
 	fi
 
 	if [ "$FREETZ_REPLACE_KERNEL" == "y" -o -n "$(set|grep ^FREETZ_MODULE_.*=y)" -o -n "$FREETZ_MODULES_OWN" ]; then
-		[ "$FREETZ_STRIP_MODULES_FREETZ" == "y" ] && strip_output=" and stripping"
-		echo0 "installing$strip_output modules"
 		if [ "$FREETZ_KERNEL_VERSION_5" = "y" ]
 		then
 			symvers=$ABS_BASE_DIR/source/kernel/ref-$KERNEL_ID/linux-$FREETZ_KERNEL_VERSION_MAJOR/Module.symvers
 			firsthash=$(($(head -c10 $symvers)))
+			[ $firsthash -eq 0 ] && echo0 "update modules vermagic" || echo0 "update modules symvers"
 			for module in $(cd $MODULES_DIR && find . -name *.ko)
 			do
 				[ -f ${KERNEL_REP_DIR}/modules-${KERNEL_ID}/$(echo $module | sed 's,/kernel/,/,') ] && continue
@@ -1426,17 +1425,13 @@ if [ "$DO_MOD" -gt 0 ]; then
 					xxd -p -c0 $module | sed -r $pattern | xxd -r -p > tmp && mv tmp $module
 					bn="$(basename "$module")"
 					sizeinfo "$bn"
-					if [ $firsthash -eq 0 ]
-					then
-						echo -n ' vermagic'
-					else
-						printf '%5d of %5d symbols' $updated $total
-					fi
-					echo -n ' updated'
+					[ $firsthash -ne 0 ] && printf '%5d of %5d .......' $updated $total
 					sizeinfo mod $module
 				fi
 			done
 		fi
+		[ "$FREETZ_STRIP_MODULES_FREETZ" == "y" ] && strip_output=" and stripping"
+		echo0 "installing$strip_output modules"
 		for i in \
 		$( \
 			cd "${KERNEL_REP_DIR}/modules-${KERNEL_ID}" && \

--- a/fwmod
+++ b/fwmod
@@ -1407,13 +1407,13 @@ if [ "$DO_MOD" -gt 0 ]; then
 					x=$(echo $x | sed -r 's/('$vermagic'.*)'$modversions'(([^0].)*)/\1\2'$zero12'/')
 				else
 					for s in $(modprobe --dump-modversions $f | sed -r 's/\t//')
-	        			do
+						do
 						((t++))
 						h=$(echo $s | sed -rn 's/0x(.{8})(.*)/\1/p')
 						n=$(echo $s | sed -rn 's/0x(.{8})(.*)/\2/p')
-	                			u=$(grep -w $n $k | sed -rn 's/0x(.{8}).*/\1/p')
+						u=$(grep -w $n $k | sed -rn 's/0x(.{8}).*/\1/p')
 						if [ $u ] && [ $h != $u ]
-	                			then
+						then
 							((p++))
 							H=$(echo -n $h | tac -rs ..)
 							U=$(echo -n $u | tac -rs ..)

--- a/fwmod
+++ b/fwmod
@@ -1411,8 +1411,7 @@ if [ "$DO_MOD" -gt 0 ]; then
 					for symbol in $(modprobe --dump-modversions $module | sed -r 's/\t/;/')
 					do
 						((total++))
-						hash=$(echo $symbol | sed -rn 's/0x(.{8});(.*)/\1/p')
-						name=$(echo $symbol | sed -rn 's/0x(.{8});(.*)/\2/p')
+						declare $(echo $symbol | sed -rn 's/0x(.{8});(.*)/hash=\1 name=\2/p')
 						newhash=$(grep -w $name $symvers | sed -rn 's/0x(.{8}).*/\1/p')
 						if [ $newhash ] && [ $newhash != $hash ]
 						then

--- a/fwmod
+++ b/fwmod
@@ -1390,12 +1390,8 @@ if [ "$DO_MOD" -gt 0 ]; then
 		echo0 "installing$strip_output modules"
 		if [ "$FREETZ_KERNEL_VERSION_5" = "y" ]
 		then
-			vermagic=$(echo -n 'vermagic=' | xxd -p -c0)
-			modversions=$(echo -n 'modversions ' | xxd -p -c0)
-			zeropadding=$(echo $modversions | sed 's/./0/g')
 			symvers=$ABS_BASE_DIR/source/kernel/ref-$KERNEL_ID/linux-$FREETZ_KERNEL_VERSION_MAJOR/Module.symvers
 			firsthash=$(($(head -c10 $symvers)))
-			starttime=$(date +%s)
 			for module in $(cd $MODULES_DIR && find . -name *.ko)
 			do
 				[ -f ${KERNEL_REP_DIR}/modules-${KERNEL_ID}/$(echo $module | sed 's,/kernel/,/,') ] && continue
@@ -1406,6 +1402,9 @@ if [ "$DO_MOD" -gt 0 ]; then
 				then
 					((total++))
 					((updated++))
+					vermagic=$(echo -n 'vermagic=' | xxd -p -c0)
+					modversions=$(echo -n 'modversions ' | xxd -p -c0)
+					zeropadding=$(echo $modversions | sed 's/./0/g')
 					pattern='s/('$vermagic'.*)'$modversions'(([^0].)*)/\1\2'$zeropadding'/'
 				else
 					pattern=''
@@ -1441,7 +1440,6 @@ if [ "$DO_MOD" -gt 0 ]; then
 					sizeinfo mod $module
 				fi
 			done
-			echo '  took '$(date +%M:%S -d@$(($(date +%s) - starttime)))
 		fi
 		for i in \
 		$( \

--- a/fwmod
+++ b/fwmod
@@ -1400,16 +1400,15 @@ if [ "$DO_MOD" -gt 0 ]; then
 			do
 				[ -f ${KERNEL_REP_DIR}/modules-${KERNEL_ID}/$(echo $module | sed 's,/kernel/,/,') ] && continue
 				module=$MODULES_DIR/$module
-				hexmodule=$(xxd -p -c0 $module)
 				updated=0
 				total=0
-				pattern=''
 				if [ $firsthash -eq 0 ]
 				then
 					((total++))
 					((updated++))
-					hexmodule=$(echo $hexmodule | sed -r 's/('$vermagic'.*)'$modversions'(([^0].)*)/\1\2'$zeropadding'/')
+					pattern='s/('$vermagic'.*)'$modversions'(([^0].)*)/\1\2'$zeropadding'/'
 				else
+					pattern=''
 					for symbol in $(modprobe --dump-modversions $module | sed -r 's/\t/;/')
 					do
 						((total++))
@@ -1422,15 +1421,14 @@ if [ "$DO_MOD" -gt 0 ]; then
 							littlehash=$(echo -n $hash | tac -rs ..)
 							newlittlehash=$(echo -n $newhash | tac -rs ..)
 							hexname=$(echo -n $name | xxd -p -c0)'00'
-							#hexmodule=$(echo $hexmodule | sed 's/'$littlehash$hexname'/'$newlittlehash$hexname'/')
 							pattern=$pattern's/'$littlehash$hexname'/'$newlittlehash$hexname'/;'
 						fi
 					done
 				fi
 				if [ $updated -gt 0 ]
 				then
-					[ $pattern ] && hexmodule=$(echo $hexmodule | sed $pattern)
-					echo $hexmodule | xxd -r -p > $module
+					xxd -p -c0 $module | sed -r $pattern | xxd -r -p > tmp
+					mv tmp $module
 					bn="$(basename "$module")"
 					sizeinfo "$bn"
 					if [ $firsthash -eq 0 ]

--- a/fwmod
+++ b/fwmod
@@ -1394,6 +1394,7 @@ if [ "$DO_MOD" -gt 0 ]; then
 			modversions=$(echo -n 'modversions ' | xxd -p -c0)
 			zeropadding=$(echo $modversions | sed 's/./0/g')
 			symvers=$ABS_BASE_DIR/source/kernel/ref-$KERNEL_ID/linux-$FREETZ_KERNEL_VERSION_MAJOR/Module.symvers
+			firsthash=$(($(head -c10 $symvers)))
 			for module in $(cd $MODULES_DIR && find . -name *.ko)
 			do
 				[ -f ${KERNEL_REP_DIR}/modules-${KERNEL_ID}/$(echo $module | sed 's/\/kernel\//\//') ] && continue
@@ -1401,7 +1402,6 @@ if [ "$DO_MOD" -gt 0 ]; then
 				hexmodule=$(xxd -p -c0 $module)
 				updated=0
 				total=0
-				firsthash=$(($(head -c10 $symvers)))
 				if [ $firsthash -eq 0 ]
 				then
 					((total++))

--- a/fwmod
+++ b/fwmod
@@ -1392,7 +1392,7 @@ if [ "$DO_MOD" -gt 0 ]; then
 		then
 			vermagic=$(echo -n 'vermagic=' | xxd -p -c0)
 			modversions=$(echo -n 'modversions ' | xxd -p -c0)
-			zeropadding=$(printf '%024x' 0)
+			zeropadding=$(echo $modversions | sed 's/./0/g')
 			symvers=$ABS_BASE_DIR/source/kernel/ref-$KERNEL_ID/linux-$FREETZ_KERNEL_VERSION_MAJOR/Module.symvers
 			for module in $(cd $MODULES_DIR && find . -name *.ko)
 			do

--- a/fwmod
+++ b/fwmod
@@ -1411,15 +1411,13 @@ if [ "$DO_MOD" -gt 0 ]; then
 					for symbol in $(modprobe --dump-modversions $module | sed -r 's/\t/;/')
 					do
 						((total++))
-						declare $(echo $symbol | sed -rn 's/0x(.{8});(.*)/hash=\1 name=\2/p')
-						newhash=$(grep -w $name $symvers | sed -rn 's/0x(.{8}).*/\1/p')
+						declare $(echo $symbol | sed -rn 's/0x(..)(..)(..)(..);(.*)/hash=\4\3\2\1 name=\5/p')
+						newhash=$(grep -w $name $symvers | sed -rn 's/0x(..)(..)(..)(..).*/\4\3\2\1/p')
 						if [ $newhash ] && [ $newhash != $hash ]
 						then
 							((updated++))
-							littlehash=$(echo -n $hash | tac -rs ..)
-							newlittlehash=$(echo -n $newhash | tac -rs ..)
 							hexname=$(echo -n $name | xxd -p -c0)'00'
-							pattern=$pattern's/'$littlehash$hexname'/'$newlittlehash$hexname'/;'
+							pattern=$pattern's/'$hash$hexname'/'$newhash$hexname'/;'
 						fi
 					done
 				fi

--- a/fwmod
+++ b/fwmod
@@ -1392,22 +1392,24 @@ if [ "$DO_MOD" -gt 0 ]; then
 		then
 			vermagic=$(echo -n 'vermagic=' | xxd -p -c0)
 			modversions=$(echo -n 'modversions ' | xxd -p -c0)
-			zero12=$(printf '%024x' 0)
+			zeropadding=$(printf '%024x' 0)
 			symvers=$ABS_BASE_DIR/source/kernel/ref-$KERNEL_ID/linux-$FREETZ_KERNEL_VERSION_MAJOR/Module.symvers
 			for module in $(cd $MODULES_DIR && find . -name *.ko)
 			do
 				[ -f ${KERNEL_REP_DIR}/modules-${KERNEL_ID}/$(echo $module | sed 's/\/kernel\//\//') ] && continue
 				module=$MODULES_DIR/$module
+				hexmodule=$(xxd -p -c0 $module)
 				updated=0
 				total=0
-				hexmodule=$(xxd -p -c0 $module)
-				if [ $(($(head -c10 $symvers))) -eq 0 ]
+				firsthash=$(($(head -c10 $symvers)))
+				if [ $firsthash -eq 0 ]
 				then
-					((total--))
-					hexmodule=$(echo $hexmodule | sed -r 's/('$vermagic'.*)'$modversions'(([^0].)*)/\1\2'$zero12'/')
+					((total++))
+					((updated++))
+					hexmodule=$(echo $hexmodule | sed -r 's/('$vermagic'.*)'$modversions'(([^0].)*)/\1\2'$zeropadding'/')
 				else
 					for symbol in $(modprobe --dump-modversions $module | sed -r 's/\t//')
-						do
+					do
 						((total++))
 						hash=$(echo $symbol | sed -rn 's/0x(.{8})(.*)/\1/p')
 						name=$(echo $symbol | sed -rn 's/0x(.{8})(.*)/\2/p')
@@ -1422,12 +1424,18 @@ if [ "$DO_MOD" -gt 0 ]; then
 						fi
 					done
 				fi
-				if [ $total -ne 0 ]
+				if [ $updated -gt 0 ]
 				then
 					echo $hexmodule | xxd -r -p > $module
 					bn="$(basename "$module")"
 					sizeinfo "$bn"
-					[ $total -gt 0 ] && printf '%5d of %5d symbols updated' $updated $total || echo -n ' vermagic updated'
+					[ $firsthash -eq 0 ]
+					then
+						echo -n ' vermagic'
+					else
+						printf '%5d of %5d symbols' $updated $total
+					fi
+					echo -n ' updated'
 					sizeinfo mod $module
 				fi
 			done


### PR DESCRIPTION
- Newly created kernel modules are integrated into the image. #1367
- Existing modules are modified. 
  - For kernels with `modversions`, 
    - the symbol hashes are updated and 
    - depmod -E uses Module.symvers file to check symbol versions. 
  - For kernels without `modversions`, the `vermagic` is adjusted. 