### PR TITLE
Revert "add devcontainer config"

### DIFF
--- a/.devcontainer/build/devcontainer.json
+++ b/.devcontainer/build/devcontainer.json
@@ -1,8 +1,0 @@
-{
-  "name": "Freetz-NG Build Env",
-  "image": "ghcr.io/freetz-ng/dl-packs:latest",
-
-  "remoteUser": "freetz",
-
-  "postCreateCommand": "sudo chown -R freetz:freetz ${containerWorkspaceFolder} /tmp && sudo chmod -R 755 ${containerWorkspaceFolder} /tmp && git -C ${containerWorkspaceFolder} checkout --force"
-}


### PR DESCRIPTION
Dies macht die Änderungen von Freetz-NG/freetz-ng#1410 wieder rückgängig.
Möglicherweise wird der devcontainer config auch nicht unbedingt Verwendung finden.

Für das Bauen von images gibt es bereits den `make_tester`. 
Daher wird der devcontainer nicht mehr benötigt.