### PR TITLE
task_stalled and task_lockdown improvements

### DIFF
--- a/.github/workflows/task_lockdown.yml
+++ b/.github/workflows/task_lockdown.yml
@@ -5,10 +5,6 @@ on:
     types: opened
   workflow_dispatch:
 
-
-
-
-
 jobs:
   build:
     permissions:

--- a/.github/workflows/task_lockdown.yml
+++ b/.github/workflows/task_lockdown.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     permissions:
       issues: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: github.repository == 'freetz-ng/freetz-ng'
 
     steps:

--- a/.github/workflows/task_stalled.yml
+++ b/.github/workflows/task_stalled.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       pull-requests: write
       issues: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: github.repository == 'freetz-ng/freetz-ng'
 
     steps:

--- a/.github/workflows/task_stalled.yml
+++ b/.github/workflows/task_stalled.yml
@@ -21,17 +21,33 @@ jobs:
 
       - name: stalled
         uses: actions/stale@v10
+        env:
+          # global
+          STALE_LABEL:             'stalled'
+          EXEMPT_LABEL:            'task'
+          # pr
+          DAYS_BEFORE_PR_STALE:    '7'
+          DAYS_BEFORE_PR_CLOSE:    '7'
+          # issue
+          DAYS_BEFORE_ISSUE_STALE: '7'
+          DAYS_BEFORE_ISSUE_CLOSE: '7'
         with:
-          stale-issue-message: 'This issue is stalled because it has been open for 7 days with no activity.'
-          stale-pr-message: 'This PR is stalled because it has been open for 7 days with no activity.'
-          close-issue-message: 'This issue was closed because it has been inactive for 7 days since being marked as stalled.'
-          close-pr-message: 'This PR was closed because it has been inactive for 7 days since being marked as stalled.'
-          stale-issue-label: 'stalled'
-          stale-pr-label: 'stalled'
-          labels-to-remove-when-unstale: 'stalled'
-          exempt-issue-labels: 'task'
-          exempt-pr-labels: 'task'
-          days-before-stale: 7
-          remove-stale-when-updated: true
+          # global
           enable-statistics: true
-
+          labels-to-remove-when-unstale: ${{ env.STALE_LABEL }}
+          # pr
+          stale-pr-message:        'This PR has been open for ${{ env.DAYS_BEFORE_PR_STALE }} days with no activity. Please comment or update this PR or it will be closed in ${{ env.DAYS_BEFORE_PR_CLOSE }} days.'
+          close-pr-message:        'This PR was closed because it has been inactive for ${{ env.DAYS_BEFORE_PR_CLOSE }} days since being marked as ${{ env.STALE_LABEL }}.'
+          days-before-pr-close:    ${{ env.DAYS_BEFORE_PR_CLOSE }}
+          days-before-pr-stale:    ${{ env.DAYS_BEFORE_PR_STALE }}
+          stale-pr-label:          ${{ env.STALE_LABEL }}
+          exempt-pr-labels:        ${{ env.EXEMPT_LABEL }}
+          remove-pr-stale-when-updated: true
+          # issue
+          stale-issue-message:     'This issue has been open for ${{ env.DAYS_BEFORE_ISSUE_STALE }} days with no activity. Please comment or update this issue or it will be closed in ${{ env.DAYS_BEFORE_ISSUE_CLOSE }} days.'
+          close-issue-message:     'This issue was closed because it has been inactive for ${{ env.DAYS_BEFORE_ISSUE_CLOSE }} days since being marked as ${{ env.STALE_LABEL }}.'
+          days-before-issue-close: ${{ env.DAYS_BEFORE_ISSUE_CLOSE }}
+          days-before-issue-stale: ${{ env.DAYS_BEFORE_ISSUE_STALE }}
+          stale-issue-label:       ${{ env.STALE_LABEL }}
+          exempt-issue-labels:     ${{ env.EXEMPT_LABEL }}
+          remove-issue-stale-when-updated: true


### PR DESCRIPTION
Dies macht folgendes:

- Restrukturiere die `with:` parameters beim stale action, so das es übersichtlicher ist.
  Dies ermöglicht auch auf einfacherer weiße die definierten Tage für das markieren als stale und die definierten Tage für das schließen des PRs zu definieren ohne das entsprechend an mehren stellen ändern zu müssen. (z.b. wenn man die definierten Tage bevor ein PR als stalled markiert wird, von 7 auf 30 erhöhen möchte.)
- Es entfernt bei task_lockdown mehrer leere Zeilen
- Es ändert das verwendete gha runner image von `ubuntu-latest` auf `ubuntu-slim` da diese actions nur kurz laufen und kein docker benötigen. 
  Siehe Beitrag von GitHub: https://github.blog/changelog/2026-01-22-1-vcpu-linux-runner-now-generally-available-in-github-actions/