### PR TITLE
mod-cgi: switch page charset from Latin-1 to UTF-8 and fix impacted CGI strings

### DIFF
--- a/make/pkgs/cpmaccfg-cgi/files/root/usr/lib/cgi-bin/cpmaccfg.cgi
+++ b/make/pkgs/cpmaccfg-cgi/files/root/usr/lib/cgi-bin/cpmaccfg.cgi
@@ -84,7 +84,7 @@ cat << EOF
 
 EOF
 
-# Dropdown für Einstellungen anzeigen
+# Dropdown fuer Einstellungen anzeigen
 . /bin/env.mod.rcconf
 BOXTYPE=${CONFIG_PRODUKT#Fritz_Box_}
 if [ "$BOXTYPE" != "7170" ]; then drop="disabled"; fi

--- a/make/pkgs/downloader/files/root/usr/lib/cgi-bin/downloader.cgi
+++ b/make/pkgs/downloader/files/root/usr/lib/cgi-bin/downloader.cgi
@@ -52,7 +52,7 @@ value="http://"$http_chk>http://</option>
 </td>
 </tr>
 </table>
-<h2>$(lang de:"Nur für FTP-Server" en:"Only for ftp server"):</h2>
+<h2>$(lang de:"Nur f&uuml;r FTP-Server" en:"Only for ftp server"):</h2>
 <p>$(lang de:"Benutzer" en:"User"):
 <input type="text" name="srvusr" size="20" maxlength="30" value="$(html "$DOWNLOADER_SRVUSR")">
 &nbsp;&nbsp;&nbsp;&nbsp;Passwor$(lang de:"t" en:"d"):
@@ -91,7 +91,7 @@ sec_begin 'Extras'
 cat << EOF
 <ul>
 <li>
-<a href="$(href extra downloader downremover)">$(lang de:"Heruntergeladene Dateien löschen" en:"Remove downloaded files")</a>
+<a href="$(href extra downloader downremover)">$(lang de:"Heruntergeladene Dateien l&ouml;schen" en:"Remove downloaded files")</a>
 </li>
 <li>
 <a href="$(href extra downloader downlog)">$(lang de:"Protokoll ansehen" en:"View log file")</a>

--- a/make/pkgs/iptables-cgi/files/root/usr/lib/cgi-bin/iptables.cgi
+++ b/make/pkgs/iptables-cgi/files/root/usr/lib/cgi-bin/iptables.cgi
@@ -15,7 +15,7 @@ sec_begin "$(lang de:"Einstellungen" en:"Settings")"
 cat << EOF
 <h2>ip_conntrack</h2>
 <p>hashsize: <input type="text" name="ip_conntrack_hashsize" size="10" maxlength="255" value="$(html "$IPTABLES_IP_CONNTRACK_HASHSIZE")"></p>
-<p><font size="1">$(lang de:"Evtl. ist ein Neustart nötig" en:"Reboot may be necessary")</font></p>
+<p><font size="1">$(lang de:"Evtl. ist ein Neustart n&ouml;tig" en:"Reboot may be necessary")</font></p>
 EOF
 sec_end
 

--- a/make/pkgs/mod/files/root/usr/lib/mod/cgi/page.sh
+++ b/make/pkgs/mod/files/root/usr/lib/mod/cgi/page.sh
@@ -73,7 +73,7 @@ cgi_begin() {
 	fi
 	local CRet=$'\r'
 	cat << EOF
-Content-Type: text/html; charset=ISO-8859-1${CRet}
+Content-Type: text/html; charset=UTF-8${CRet}
 Content-Language: $(lang de:"de" en:"en")${CRet}
 Expires: 0${CRet}
 Pragma: no-cache${CRet}
@@ -83,7 +83,7 @@ ${CRet}
    "http://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 EOF
 	site_refresh
 	cgi_width_setup

--- a/make/pkgs/mod/files/root/usr/mww/cgi-bin/shell/index.cgi
+++ b/make/pkgs/mod/files/root/usr/mww/cgi-bin/shell/index.cgi
@@ -65,7 +65,7 @@ cat << EOF
 				ajax_exec('script=echo "'+encodeURIComponent(code.value)+'" > '+file.value);
 				code.value="";
 				output.innerHTML="$(lang de:"Editiert!" en:"Edited!")";
-				exec.value="$(lang de:"Skript ausführen" en:"Run script")";
+				exec.value="$(lang de:"Skript ausf&uuml;hren" en:"Run script")";
 				editing=0;
 			}
 			else{

--- a/make/pkgs/mod/files/root/usr/mww/cgi-bin/update/external.cgi
+++ b/make/pkgs/mod/files/root/usr/mww/cgi-bin/update/external.cgi
@@ -41,7 +41,7 @@ $(lang de:"hochgeladen werden." en:"upload the appropriate firmware afterwards."
 <form action="do_external.cgi" method=POST enctype="multipart/form-data" onsubmit="return CheckInput(document.forms[0]);">
 	<p>$(lang de:"external-Datei" en:"External-file") <input type=file size=50 id="ex_file"></p>
 	<p>$(lang de:"Zielverzeichnis" en:"Target directory") <input type="textfield" size=50 name="the_target" value="$MOD_EXTERNAL_DIRECTORY"></p>
-	<p><input type="checkbox" name="delete" value="delete">$(lang de:"Alte External-Dateien löschen" en:"Delete old external files")</p>
+	<p><input type="checkbox" name="delete" value="delete">$(lang de:"Alte External-Dateien l&ouml;schen" en:"Delete old external files")</p>
 	<p><input type="checkbox" name="ex_start" value="ex_start">$(lang de:"External Dienste nach Update starten" en:"Start external services after update")</p>
 	<input type=submit value="$(lang de:"Datei hochladen" en:"Upload file")" style="width:200px">
 </form>


### PR DESCRIPTION
## mod-cgi: switch page charset from Latin-1 to UTF-8 and fix impacted CGI strings

This PR is functional for AI Translation and has been separated from https://github.com/Freetz-NG/freetz-ng/pull/1424 for better review.

- change page output charset from ISO-8859-1 to UTF-8 in page.sh (HTTP header + meta) to allow better support of AI translated strings.
- fix affected non-UTF-8/mojibake strings in CGI pages loaded via libmodcgi
- normalize German umlauts using HTML entities where needed to keep rendering stable
- scope intentionally limited to page.sh and directly impacted CGI files
- see also changes in /cgi-bin/file/authorized-keys/authorized_keys in https://github.com/Freetz-NG/freetz-ng/pull/1424