### PR TITLE
Break build if broken symlinks

### DIFF
--- a/tools/external
+++ b/tools/external
@@ -117,6 +117,10 @@ for EXTERNAL_FILE in $EXTERNAL_FILES; do
 			EXTERNAL_LINKED=""
 		else
 			EXTERNAL_LINKED=" & linked"
+			# Error if file not found - don't create broken symlinks
+			if [ "$EXTERNAL_MSG" == "not found" ]; then
+				error 1 "$MESSAGE $EXTERNAL_FILE not found, cannot create symlink"
+			fi
 			ln -s "/mod/external$EXTERNAL_LINKSUBDIR/$FILENAME" "${FILESYSTEM_MOD_DIR}$EXTERNAL_FILE"
 		fi
 		echo2 "$EXTERNAL_FILE ... $EXTERNAL_MSG$EXTERNAL_LINKED."


### PR DESCRIPTION
## Break build if broken symlinks

In the final build stage, show error if an externalized file is not found, instead of creating broken symlinks.

This helps develop packages without errors and discover existing errors in the toolchain.