### PR TITLE
p7zip: add FHS-compliant library/codec lookup and remove clean error

### DIFF
--- a/make/pkgs/p7zip/p7zip.mk
+++ b/make/pkgs/p7zip/p7zip.mk
@@ -43,7 +43,7 @@ $(pkg)-precompiled: $($(PKG)_LIB_TARGET_DIR) $($(PKG)_CODECS_TARGET_DIR) $($(PKG
 
 
 $(pkg)-clean:
-	-$(SUBMAKE) -C $(P7ZIP_DIR) -f makefile clean
+	-[ -d $(P7ZIP_DIR) ] && $(MAKE) -C $(P7ZIP_DIR) -f makefile clean $(SILENT)
 
 $(pkg)-uninstall:
 	$(RM) $(P7ZIP_TARGET_BINARY) $(P7ZIP_LIB_TARGET_DIR) $(P7ZIP_CODECS_TARGET_DIR)

--- a/make/pkgs/p7zip/patches/100-search-usr-lib-p7zip.patch
+++ b/make/pkgs/p7zip/patches/100-search-usr-lib-p7zip.patch
@@ -1,0 +1,16 @@
+--- a/CPP/7zip/UI/Common/LoadCodecs.cpp
++++ b/CPP/7zip/UI/Common/LoadCodecs.cpp
+@@ -214,6 +214,13 @@ bool CCodecLib::CreateObject(const GUID
+ 
+ static FString GetBaseFolderPrefixFromRegistry()
+ {
++  // Try /usr/lib/p7zip/ first (for freetz-ng)
++  FString p7zipPath = FTEXT("/usr/lib/p7zip/");
++  if (NFind::DoesFileExist(p7zipPath + kMainDll) ||
++      NFind::DoesDirExist(p7zipPath + kCodecsFolderName) ||
++      NFind::DoesDirExist(p7zipPath + kFormatsFolderName))
++    return p7zipPath;
++
+   FString moduleFolderPrefix = NDLL::GetModuleDirPrefix();
+   #ifdef _WIN32
+   if (!NFind::DoesFileExist(moduleFolderPrefix + kMainDll) &&


### PR DESCRIPTION
This patch extends the upstream lookup logic to first search /usr/lib/p7zip/ for 7z.so and Codecs/*, matching the freetz-ng filesystem layout (separate /usr/bin and /usr/lib).

Without this change, 7z cannot locate its shared libraries and codecs.

```bash
root@fritz:/var/mod/root# ls -R /usr/lib/p7zip
/usr/lib/p7zip:
7z.so   Codecs

/usr/lib/p7zip/Codecs:
Rar.so
```

Also prevents clean error when the package has not yet been unpacked.