### PR TITLE
symvers: commit only as merged commit

### DIFF
--- a/.github/workflows/postcommit_symvers.yml
+++ b/.github/workflows/postcommit_symvers.yml
@@ -250,7 +250,7 @@ jobs:
       - name: download-artifact
         uses: actions/download-artifact@v8
         with:
-          pattern: ${{ github.workflow }}--*.zip
+          pattern: ${{ github.workflow }}--*
           path: make/kernel/configs/symvers/
           merge-multiple: true
       

--- a/.github/workflows/postcommit_symvers.yml
+++ b/.github/workflows/postcommit_symvers.yml
@@ -139,7 +139,6 @@ jobs:
           clean: false
           persist-credentials: true
 
-
       - name: cache_load
         uses: actions/cache/restore@v5
         if: always()
@@ -191,19 +190,16 @@ jobs:
           ls -l images/
           sha256sum images/*
 
-      - name: commit
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git config --global --add safe.directory $GITHUB_WORKSPACE
-          git pull || exit
-          git add make/kernel/configs/symvers/
-          git status
-          git config --local user.name github-actions[bot]
-          git config --local user.email github-actions[bot]@users.noreply.github.com
-          git diff --cached --quiet && exit 0 || git commit -m "symvers: automatic update"
-          git config --local credential.helper '!x() { echo "password=$GITHUB_TOKEN"; };x'
-          git push origin $GITHUB_REF_NAME
+      - name: upload-artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ github.workflow }}--${{ github.job }}
+          path: make/kernel/configs/symvers/
+          if-no-files-found: warn
+          retention-days: 1
+          compression-level: 0
+          overwrite: true
+          include-hidden-files: false
 
 #     - name: cache_clear
 #       if: github.repository == 'freetz-ng/freetz-ng'
@@ -224,3 +220,50 @@ jobs:
 #         key: ${{ github.workflow }}--${{ matrix.fritz.box }}
 
 
+  merge:
+    permissions:
+      contents: write
+    container:
+#     image: ubuntu:20.04
+#     image: freetzng/generate
+      image: ghcr.io/freetz-ng/generate
+      options: --user 1001:1001
+    needs: build
+    runs-on: ubuntu-latest
+    if: ${{ !cancelled() && true }}
+#   if: github.repository == 'freetz-ng/freetz-ng'
+      
+    steps:
+
+      - name: clone
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          set-safe-directory: true
+          repository: ${{ github.repository }}
+          ref: ${{ github.ref_name }}
+          path: ${{ github.workspace }}
+          fetch-depth: 0
+          clean: false
+          persist-credentials: true
+
+      - name: download-artifact
+        uses: actions/download-artifact@v8
+        with:
+          pattern: ${{ github.workflow }}--*.zip
+          path: make/kernel/configs/symvers/
+          merge-multiple: true
+      
+      - name: commit
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+          git pull || exit
+          git add make/kernel/configs/symvers/
+          git status
+          git config --local user.name github-actions[bot]
+          git config --local user.email github-actions[bot]@users.noreply.github.com
+          git diff --cached --quiet && exit 0 || git commit -m "symvers: automatic update"
+          git config --local credential.helper '!x() { echo "password=$GITHUB_TOKEN"; };x'
+          git push origin $GITHUB_REF_NAME

--- a/.github/workflows/postcommit_symvers.yml
+++ b/.github/workflows/postcommit_symvers.yml
@@ -193,7 +193,7 @@ jobs:
       - name: upload-artifact
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ github.workflow }}--${{ github.job }}
+          name: ${{ github.workflow }}--${{ matrix.fritz.fos }}-${{ matrix.fritz.box }}
           path: make/kernel/configs/symvers/
           if-no-files-found: warn
           retention-days: 1


### PR DESCRIPTION
Dies ermöglicht es das erst wenn der ganze Matrix durchgelaufen ist, dass dann erst ein commit mit den Daten aus der Matrix gemacht wird.

Vorteile:
- Ein Commit pro Durchlauf und nicht pro Matrix Runners in ein Durchlauf
- Keine `The following untracked working tree files would be overwritten by merge` fehler