### PR TITLE
actions: use for short running workflows `ubuntu-slim` as gha image

### DIFF
--- a/.github/workflows/generate_ghpages.yml
+++ b/.github/workflows/generate_ghpages.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -44,7 +44,7 @@ jobs:
     permissions:
       pages: write
       id-token: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: build
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/generate_zensical.yml
+++ b/.github/workflows/generate_zensical.yml
@@ -28,7 +28,7 @@ jobs:
       ZENSICAL_INPUT_PATH: .github/zensical/site
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -50,7 +50,7 @@ jobs:
     permissions:
       pages: write
       id-token: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: build
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/task_lockdown.yml
+++ b/.github/workflows/task_lockdown.yml
@@ -5,15 +5,11 @@ on:
     types: opened
   workflow_dispatch:
 
-
-
-
-
 jobs:
   build:
     permissions:
       issues: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: github.repository == 'freetz-ng/freetz-ng'
 
     steps:
@@ -31,4 +27,3 @@ jobs:
           issue-lock-reason: ''
           log-output: true
           process-only: 'issues'
-

--- a/.github/workflows/task_stalled.yml
+++ b/.github/workflows/task_stalled.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       pull-requests: write
       issues: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: github.repository == 'freetz-ng/freetz-ng'
 
     steps:


### PR DESCRIPTION
Dies stellt folgende workflows auf das effizientere `ubuntu-slim` gha image um:
- generate_ghpage
- generate_zensical
- task_lockdown
- task_stalled

Der `ubuntu-slim` gha image ist laut github blog genau dafür gemacht um kurze workflows damit abarbeiten zu können die weniger als 15 Minuten laufen und dabei kein docker benötigen.

- refs:
  - https://github.blog/changelog/2026-01-22-1-vcpu-linux-runner-now-generally-available-in-github-actions/
  - https://github.com/actions/runner-images/blob/main/images/ubuntu-slim/ubuntu-slim-Readme.md