### PR TITLE
prerequisites: revert `handling for install gnu coreutils for ubuntu26`

### DIFF
--- a/docs/prerequisites/README.tpl
+++ b/docs/prerequisites/README.tpl
@@ -168,7 +168,7 @@ sudo apt-get remove --allow-remove-essential coreutils-from-uutils
 
   - Ubuntu 26 64-Bit:
 ```
-sudo apt-get -y install --allow-remove-essential %%Ubuntu26%%
+sudo apt-get -y install %%Ubuntu26%%
 
   - Ubuntu 23/24/25 64-Bit:
 ```

--- a/tools/.prerequisites/Ubuntu26
+++ b/tools/.prerequisites/Ubuntu26
@@ -6,8 +6,6 @@ bsdmainutils
 bzip2
 ccache
 cmake
-coreutils-from-gnu
-coreutils-from-uutils-
 curl
 ecj
 flex

--- a/tools/prerequisites
+++ b/tools/prerequisites
@@ -100,9 +100,6 @@ detect_linux() {
 install_requisite() {
 	local OSV="$1" ARG="$2"DOY="$3"
 
-	local DNF_PARAMETERS="--refresh"
-	local APT_PARAMETERS="$(dpkg --compare-versions "$(awk -F= '$1=="VERSION_ID"{gsub(/"/,"",$2);print $2}' /etc/os-release)" ge 26.04 && echo "--allow-remove-essential")"
-
 	[ -z "$OSV" ] && OSV="$(detect_linux)"
 	[ -z "$OSV" ] && echo 'Can not detect you Linux version, set it manually'&& list_linux  && exit 1
 
@@ -116,10 +113,10 @@ install_requisite() {
 	echo -e "\nPackages for '$OSV':\n$vals\n"
 	[ "${ARG:0:1}" == "s" ] && exit 0
 	case "$OSV" in
-		Fedora*)                                       $SUDO dnf     ${DNF_PARAMETERS} install $DOY $vals || exit 1 ;;
-		Debian*|Devuan*|LMDE*) $SUDO apt-get update && $SUDO apt     ${APT_PARAMETERS} install $DOY $vals || exit 1 ;;
-		Ubuntu*|Mint*)         $SUDO apt-get update && $SUDO apt-get ${APT_PARAMETERS} install $DOY $vals || exit 1 ;;
-		*)                     echo 'No known installer'                                                  && exit 1 ;;
+		Fedora*)                                       $SUDO dnf --refresh  install $DOY $vals || exit 1 ;;
+		Debian*|Devuan*|LMDE*) $SUDO apt-get update && $SUDO apt            install $DOY $vals || exit 1 ;;
+		Ubuntu*|Mint*)         $SUDO apt-get update && $SUDO apt-get        install $DOY $vals || exit 1 ;;
+		*)                     echo 'No known installer'                                       && exit 1 ;;
 	esac
 	exit 0
 }


### PR DESCRIPTION
Dies macht die Änderung bezüglich der Handhabung für die installation von gnu coreutils aus #1453 rückgängig.
Der zusätzlich noch existierenden Hinweis reicht noch aus:
https://github.com/Freetz-NG/freetz-ng/blob/96c6512135095fe03290caa74cb97884a0ab3403/Makefile#L238-L243