### PR TITLE
docker: install gcc-10 instead of default gcc

### DIFF
--- a/.github/docker/dl-packs/Dockerfile
+++ b/.github/docker/dl-packs/Dockerfile
@@ -3,15 +3,17 @@ ARG BUILD_USR=freetz
 ARG BUILD_GRP=freetz
 ARG BUILD_UID=1001
 ARG BUILD_GID=1001
+ARG BUILD_GCC=10
 
 RUN apt-get -y update && apt-get -y upgrade && apt-get -y dist-upgrade \
  && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     bash locales libarchive-zip-perl  \
-    pv cpio rsync kmod imagemagick inkscape graphicsmagick subversion git bc unar wget sudo gcc g++ binutils autoconf automake \
+    pv cpio rsync kmod imagemagick inkscape graphicsmagick subversion git bc unar wget sudo gcc-${BUILD_GCC} g++-${BUILD_GCC} binutils autoconf automake \
     autopoint libtool-bin make bzip2 libncurses5-dev libreadline-dev zlib1g-dev flex bison patch texinfo tofrodos gettext pkg-config ecj \
     perl libstring-crc32-perl ruby ruby1.9 gawk libusb-dev unzip intltool libacl1-dev libcap-dev libc6-dev-i386 lib32ncurses5-dev \
-    gcc-multilib bsdmainutils lib32stdc++6 libglib2.0-dev ccache cmake lib32z1-dev libsqlite3-dev sqlite3 libzstd-dev netcat curl \
-    uuid-dev libssl-dev libgnutls28-dev u-boot-tools device-tree-compiler openssl build-essential libelf-dev patchutils \
+    gcc-${BUILD_GCC}-multilib bsdmainutils lib32stdc++6 libglib2.0-dev ccache cmake lib32z1-dev libsqlite3-dev sqlite3 libzstd-dev netcat curl \
+    uuid-dev libssl-dev libgnutls28-dev u-boot-tools device-tree-compiler openssl libelf-dev patchutils \
+    $(apt-cache depends build-essential | awk '/Depends:/ {print $2}' | grep -vE 'gcc|g\+\+') gcc- g++- gcc-multilib- \
  && DEBIAN_FRONTEND=noninteractive apt-get -y clean \
  && rm -rf /var/lib/apt/lists/* \
  && locale-gen en_US.utf8 && locale-gen de_DE.UTF-8 && update-locale \

--- a/.github/docker/dl-packs/Dockerfile
+++ b/.github/docker/dl-packs/Dockerfile
@@ -14,7 +14,9 @@ RUN apt-get -y update && apt-get -y upgrade && apt-get -y dist-upgrade \
     gcc-${BUILD_GCC}-multilib bsdmainutils lib32stdc++6 libglib2.0-dev ccache cmake lib32z1-dev libsqlite3-dev sqlite3 libzstd-dev netcat curl \
     uuid-dev libssl-dev libgnutls28-dev u-boot-tools device-tree-compiler openssl libelf-dev patchutils \
     $(apt-cache depends build-essential | awk '/Depends:/ {print $2}' | grep -vE '^(gcc|g\+\+|<)') gcc- g++- gcc-multilib- \
- && for a in gcc g++; do update-alternatives --install /usr/bin/$a $a /usr/bin/$a-${BUILD_GCC} 100; done \
+ && for a in gcc g++ cpp; do update-alternatives --install /usr/bin/$a $a /usr/bin/$a-${BUILD_GCC} 100; done \
+ && for a in cc_gcc c++_g++; do export AA=$(echo $a | awk -F'_' '{print $1}') && export BB=$(echo $a | awk -F'_' '{print $2}') \
+    && update-alternatives --install /usr/bin/$AA $AA /usr/bin/$BB 100 && update-alternatives --set $AA /usr/bin/$BB; done \
  && DEBIAN_FRONTEND=noninteractive apt-get -y clean \
  && rm -rf /var/lib/apt/lists/* \
  && locale-gen en_US.utf8 && locale-gen de_DE.UTF-8 && update-locale \

--- a/.github/docker/dl-packs/Dockerfile
+++ b/.github/docker/dl-packs/Dockerfile
@@ -13,7 +13,8 @@ RUN apt-get -y update && apt-get -y upgrade && apt-get -y dist-upgrade \
     perl libstring-crc32-perl ruby ruby1.9 gawk libusb-dev unzip intltool libacl1-dev libcap-dev libc6-dev-i386 lib32ncurses5-dev \
     gcc-${BUILD_GCC}-multilib bsdmainutils lib32stdc++6 libglib2.0-dev ccache cmake lib32z1-dev libsqlite3-dev sqlite3 libzstd-dev netcat curl \
     uuid-dev libssl-dev libgnutls28-dev u-boot-tools device-tree-compiler openssl libelf-dev patchutils \
-    $(apt-cache depends build-essential | awk '/Depends:/ {print $2}' | grep -vE 'gcc|g\+\+') gcc- g++- gcc-multilib- \
+    $(apt-cache depends build-essential | awk '/Depends:/ {print $2}' | grep -vE '^(gcc|g\+\+|<)') gcc- g++- gcc-multilib- \
+ && for a in gcc g++; do update-alternatives --install /usr/bin/$a $a /usr/bin/$a-${BUILD_GCC} 100; done \
  && DEBIAN_FRONTEND=noninteractive apt-get -y clean \
  && rm -rf /var/lib/apt/lists/* \
  && locale-gen en_US.utf8 && locale-gen de_DE.UTF-8 && update-locale \

--- a/.github/docker/firmware/Dockerfile
+++ b/.github/docker/firmware/Dockerfile
@@ -14,7 +14,9 @@ RUN apt-get -y update && apt-get -y upgrade && apt-get -y dist-upgrade \
     lib32ncurses5-dev gcc-${BUILD_GCC}-multilib bsdmainutils lib32stdc++6 libglib2.0-dev ccache cmake lib32z1-dev libsqlite3-dev sqlite3 libzstd-dev \
     netcat curl uuid-dev libssl-dev libgnutls28-dev u-boot-tools device-tree-compiler libelf-dev patchutils \
     gcc- g++- gcc-multilib- \
- && for a in gcc g++; do update-alternatives --install /usr/bin/$a $a /usr/bin/$a-${BUILD_GCC} 100; done \
+ && for a in gcc g++ cpp; do update-alternatives --install /usr/bin/$a $a /usr/bin/$a-${BUILD_GCC} 100; done \
+ && for a in cc_gcc c++_g++; do export AA=$(echo $a | awk -F'_' '{print $1}') && export BB=$(echo $a | awk -F'_' '{print $2}') \
+    && update-alternatives --install /usr/bin/$AA $AA /usr/bin/$BB 100 && update-alternatives --set $AA /usr/bin/$BB; done \
  && DEBIAN_FRONTEND=noninteractive apt-get -y clean \
  && rm -rf /var/lib/apt/lists/* \
  && locale-gen en_US.utf8 && locale-gen de_DE.UTF-8 && update-locale \

--- a/.github/docker/firmware/Dockerfile
+++ b/.github/docker/firmware/Dockerfile
@@ -3,15 +3,17 @@ ARG BUILD_USR=freetz
 ARG BUILD_GRP=freetz
 ARG BUILD_UID=1001
 ARG BUILD_GID=1001
+ARG BUILD_GCC=10
 
 RUN apt-get -y update && apt-get -y upgrade && apt-get -y dist-upgrade \
  && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     bash locales \
-    pv cpio rsync kmod imagemagick inkscape graphicsmagick subversion git bc unar wget sudo gcc g++ binutils autoconf automake \
+    pv cpio rsync kmod imagemagick inkscape graphicsmagick subversion git bc unar wget sudo gcc-${BUILD_GCC} g++-${BUILD_GCC} binutils autoconf automake \
     autopoint libtool-bin make bzip2 libncurses5-dev libreadline-dev zlib1g-dev flex bison patch texinfo tofrodos gettext pkg-config ecj \
     perl libstring-crc32-perl ruby gawk libusb-dev unzip intltool libacl1-dev libcap-dev libc6-dev-i386 \
-    lib32ncurses5-dev gcc-multilib bsdmainutils lib32stdc++6 libglib2.0-dev ccache cmake lib32z1-dev libsqlite3-dev sqlite3 libzstd-dev \
+    lib32ncurses5-dev gcc-${BUILD_GCC}-multilib bsdmainutils lib32stdc++6 libglib2.0-dev ccache cmake lib32z1-dev libsqlite3-dev sqlite3 libzstd-dev \
     netcat curl uuid-dev libssl-dev libgnutls28-dev u-boot-tools device-tree-compiler libelf-dev patchutils \
+    gcc- g++- gcc-multilib- \
  && DEBIAN_FRONTEND=noninteractive apt-get -y clean \
  && rm -rf /var/lib/apt/lists/* \
  && locale-gen en_US.utf8 && locale-gen de_DE.UTF-8 && update-locale \

--- a/.github/docker/firmware/Dockerfile
+++ b/.github/docker/firmware/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get -y update && apt-get -y upgrade && apt-get -y dist-upgrade \
     lib32ncurses5-dev gcc-${BUILD_GCC}-multilib bsdmainutils lib32stdc++6 libglib2.0-dev ccache cmake lib32z1-dev libsqlite3-dev sqlite3 libzstd-dev \
     netcat curl uuid-dev libssl-dev libgnutls28-dev u-boot-tools device-tree-compiler libelf-dev patchutils \
     gcc- g++- gcc-multilib- \
+ && for a in gcc g++; do update-alternatives --install /usr/bin/$a $a /usr/bin/$a-${BUILD_GCC} 100; done \
  && DEBIAN_FRONTEND=noninteractive apt-get -y clean \
  && rm -rf /var/lib/apt/lists/* \
  && locale-gen en_US.utf8 && locale-gen de_DE.UTF-8 && update-locale \

--- a/.github/docker/generate/Dockerfile
+++ b/.github/docker/generate/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get -y update && apt-get -y upgrade && apt-get -y dist-upgrade \
     \
     \
     \
+ \
  && DEBIAN_FRONTEND=noninteractive apt-get -y clean \
  && rm -rf /var/lib/apt/lists/* \
  && locale-gen en_US.utf8 && locale-gen de_DE.UTF-8 && update-locale \

--- a/.github/docker/generate/Dockerfile
+++ b/.github/docker/generate/Dockerfile
@@ -15,6 +15,8 @@ RUN apt-get -y update && apt-get -y upgrade && apt-get -y dist-upgrade \
     \
     \
  \
+ \
+    \
  && DEBIAN_FRONTEND=noninteractive apt-get -y clean \
  && rm -rf /var/lib/apt/lists/* \
  && locale-gen en_US.utf8 && locale-gen de_DE.UTF-8 && update-locale \

--- a/.github/docker/generate/Dockerfile
+++ b/.github/docker/generate/Dockerfile
@@ -3,10 +3,12 @@ ARG BUILD_USR=freetz
 ARG BUILD_GRP=freetz
 ARG BUILD_UID=1001
 ARG BUILD_GID=1001
+ARG BUILD_GCC=10
 
 RUN apt-get -y update && apt-get -y upgrade && apt-get -y dist-upgrade \
  && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     git bash locales imagemagick netcat curl bsdmainutils xxd libarchive-zip-perl wget \
+    \
     \
     \
     \


### PR DESCRIPTION
Mit der Methode wird `gcc-10` und `g++-10` installiert und durch die verwendung von `gcc-` und` g++-` sowie das filtern des Meta-Paketes `build-essential` (das davon alles außer den default `gcc` und `g++` installiert wird) wird verhindert das das default `gcc` und `g++` installiert wird.