### PR TITLE
docker: install gcc-10 instead of default gcc (part 2)

### DIFF
--- a/.github/docker/dl-packs/Dockerfile
+++ b/.github/docker/dl-packs/Dockerfile
@@ -4,6 +4,9 @@ ARG BUILD_GRP=freetz
 ARG BUILD_UID=1001
 ARG BUILD_GID=1001
 
+RUN printf "deb http://old-releases.ubuntu.com/ubuntu hirsute main restricted universe multiverse\n" > /etc/apt/sources.list.d/hirsute.list \
+ && printf "Package: gcc g++ cpp gcc-multilib\nPin: release n=hirsute,o=Ubuntu\nPin-Priority: 700\n\nPackage: *\nPin: release n=hirsute,o=Ubuntu\nPin-Priority: -10\n" > /etc/apt/preferences.d/hirsute
+
 RUN apt-get -y update && apt-get -y upgrade && apt-get -y dist-upgrade \
  && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     bash locales libarchive-zip-perl  \

--- a/.github/docker/firmware/Dockerfile
+++ b/.github/docker/firmware/Dockerfile
@@ -4,6 +4,9 @@ ARG BUILD_GRP=freetz
 ARG BUILD_UID=1001
 ARG BUILD_GID=1001
 
+RUN printf "deb http://old-releases.ubuntu.com/ubuntu hirsute main restricted universe multiverse\n" > /etc/apt/sources.list.d/hirsute.list \
+ && printf "Package: gcc g++ cpp gcc-multilib\nPin: release n=hirsute,o=Ubuntu\nPin-Priority: 700\n\nPackage: *\nPin: release n=hirsute,o=Ubuntu\nPin-Priority: -10\n" > /etc/apt/preferences.d/hirsute
+
 RUN apt-get -y update && apt-get -y upgrade && apt-get -y dist-upgrade \
  && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     bash locales \

--- a/.github/docker/generate/Dockerfile
+++ b/.github/docker/generate/Dockerfile
@@ -4,6 +4,9 @@ ARG BUILD_GRP=freetz
 ARG BUILD_UID=1001
 ARG BUILD_GID=1001
 
+RUN printf "deb http://old-releases.ubuntu.com/ubuntu hirsute main restricted universe multiverse\n" > /etc/apt/sources.list.d/hirsute.list \
+ && printf "Package: gcc g++ cpp gcc-multilib\nPin: release n=hirsute,o=Ubuntu\nPin-Priority: 700\n\nPackage: *\nPin: release n=hirsute,o=Ubuntu\nPin-Priority: -10\n" > /etc/apt/preferences.d/hirsute
+
 RUN apt-get -y update && apt-get -y upgrade && apt-get -y dist-upgrade \
  && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     git bash locales imagemagick netcat-openbsd curl bsdmainutils xxd libarchive-zip-perl wget \


### PR DESCRIPTION
Dies greift nochmals die idee aus https://github.com/Freetz-NG/freetz-ng/pull/1462#issuecomment-4019100756 auf und installiert `gcc-10` in den es das metapaket `gcc` als einziges über den apt mirror von ubuntu 21.04 lädt.
Dessen Metapaket gcc zeigt auf `gcc-10`. `gcc-10` wird wiederum weiterhin über den default mirror aus ubuntu 20.04 geladen.

Mit diesen Mirror Trick lässt sich zumindest `gcc` default in der version installieren die man möchte ob wohl das default paket (`gcc` als metapaket) für die gewünschte version nicht in ubuntu 20.04 vorhanden ist.
So lässt sich das "default" `gcc` in der version 10 auf ubuntu 20.04 sauber, ohne bastelei und ohne rückstände installieren und mit u.a. als `gcc`, `cpp`, `g++`, `cc` command aufrufen.

Würde man u.a. als `gcc`, `cpp`, `g++`, `cc` `--version` aufrufen würde man sehen das es gcc in Version 10.5 ist.
unter `/usr/bin` befinden sich neben u.a. `gcc` auch `gcc-10` und kein `gcc-9`. Damit sind keine zwei gcc Versionen installiert.

Bei den LTS Versionen zeigt `gcc` als Metapaket auf ungrade Versionsnummern und bei den **.04 Versionen von ubuntu dazwischen zeigt diese auf die mit der Versionsnummer mit der Graden Zahl.