### PR TITLE
actions: update used gh api to 2026-03-10

### DIFF
--- a/.github/workflows/avm_juis-recache.yml
+++ b/.github/workflows/avm_juis-recache.yml
@@ -95,9 +95,9 @@ jobs:
 #         ACTIONS_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
 #         CACHE_KEY: ${{ steps.key.outputs.key }}
 #       run: |
-#         ASSETS="$(curl -s  -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches")"
+#         ASSETS="$(curl -s  -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2026-03-10"  "https://api.github.com/repos/${{ github.repository }}/actions/caches")"
 #         ASSID="$(echo "$ASSETS" | grep -B7 "\"key\": *\"${CACHE_KEY}\"" | sed -rn 's/ *"id": *([^,]*),*/\1/p')"
-#         curl -sL -X DELETE -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches/$ASSID" && echo "Deleted ASSID=${ASSID:-null} ..." || true
+#         curl -sL -X DELETE -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2026-03-10"  "https://api.github.com/repos/${{ github.repository }}/actions/caches/$ASSID" && echo "Deleted ASSID=${ASSID:-null} ..." || true
       - name: cache_save
         uses: actions/cache/save@v5
         if: always()

--- a/.github/workflows/avm_juis.yml
+++ b/.github/workflows/avm_juis.yml
@@ -95,9 +95,9 @@ jobs:
 #         ACTIONS_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
 #         CACHE_KEY: ${{ steps.key.outputs.key }}
 #       run: |
-#         ASSETS="$(curl -s  -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches")"
+#         ASSETS="$(curl -s  -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2026-03-10"  "https://api.github.com/repos/${{ github.repository }}/actions/caches")"
 #         ASSID="$(echo "$ASSETS" | grep -B7 "\"key\": *\"${CACHE_KEY}\"" | sed -rn 's/ *"id": *([^,]*),*/\1/p')"
-#         curl -sL -X DELETE -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches/$ASSID" && echo "Deleted ASSID=${ASSID:-null} ..." || true
+#         curl -sL -X DELETE -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2026-03-10"  "https://api.github.com/repos/${{ github.repository }}/actions/caches/$ASSID" && echo "Deleted ASSID=${ASSID:-null} ..." || true
 #     - name: cache_save
 #       uses: actions/cache/save@v4
 #       if: always()

--- a/.github/workflows/make_freetz.yml
+++ b/.github/workflows/make_freetz.yml
@@ -180,9 +180,9 @@ jobs:
 #         ACTIONS_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
 #         CACHE_KEY: ${{ github.workflow }}
 #       run: |
-#         ASSETS="$(curl -s  -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches")"
+#         ASSETS="$(curl -s  -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2026-03-10"  "https://api.github.com/repos/${{ github.repository }}/actions/caches")"
 #         ASSID="$(echo "$ASSETS" | grep -B7 "\"key\": *\"${CACHE_KEY}\"" | sed -rn 's/ *"id": *([^,]*),*/\1/p')"
-#         curl -sL -X DELETE -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches/$ASSID" && echo "Deleted ASSID=${ASSID:-null} ..." || true
+#         curl -sL -X DELETE -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2026-03-10"  "https://api.github.com/repos/${{ github.repository }}/actions/caches/$ASSID" && echo "Deleted ASSID=${ASSID:-null} ..." || true
 #     - name: cache_save
 #       uses: actions/cache/save@v4
 #       if: always()

--- a/.github/workflows/make_kernel.yml
+++ b/.github/workflows/make_kernel.yml
@@ -215,9 +215,9 @@ jobs:
 #         ACTIONS_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
 #         CACHE_KEY: ${{ github.workflow }}
 #       run: |
-#         ASSETS="$(curl -s  -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches")"
+#         ASSETS="$(curl -s  -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2026-03-10"  "https://api.github.com/repos/${{ github.repository }}/actions/caches")"
 #         ASSID="$(echo "$ASSETS" | grep -B7 "\"key\": *\"${CACHE_KEY}\"" | sed -rn 's/ *"id": *([^,]*),*/\1/p')"
-#         curl -sL -X DELETE -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/${{ github.repository }}/actions/caches/$ASSID" && echo "Deleted ASSID=${ASSID:-null} ..." || true
+#         curl -sL -X DELETE -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $ACTIONS_TOKEN"  -H "X-GitHub-Api-Version: 2026-03-10"  "https://api.github.com/repos/${{ github.repository }}/actions/caches/$ASSID" && echo "Deleted ASSID=${ASSID:-null} ..." || true
 #     - name: cache_save
 #       uses: actions/cache/save@v4
 #       if: always() && github.repository != 'freetz-ng/freetz-ng'

--- a/config/.img/generate.sh
+++ b/config/.img/generate.sh
@@ -113,10 +113,10 @@ unpack_() {
 	file="${line%% *}"
 	image="$IMAGES/$file"
 	if [ ! -s "${image}" ] && [ -n "$FREETZ_DLTOKEN" ]; then
-		[ -z "$ASSETS" ] && ASSETS="$(curl -s  -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $FREETZ_DLTOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/Freetz-NG/images/releases/tags/firmware")"
+		[ -z "$ASSETS" ] && ASSETS="$(curl -s  -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer $FREETZ_DLTOKEN"  -H "X-GitHub-Api-Version: 2026-03-10"  "https://api.github.com/repos/Freetz-NG/images/releases/tags/firmware")"
 		local ASSID="$(echo "$ASSETS" | grep -B7 "\"$file\"" | sed -rn 's/ *"id": *([^,]*),*/\1/p')"
 		echo "ASSETS       $ASSID"
-		[ -n "$ASSID" ] && curl -sLo "$image"  -H "Accept: application/octet-stream"     -H "Authorization: Bearer $FREETZ_DLTOKEN"  -H "X-GitHub-Api-Version: 2022-11-28"  "https://api.github.com/repos/Freetz-NG/images/releases/assets/$ASSID"
+		[ -n "$ASSID" ] && curl -sLo "$image"  -H "Accept: application/octet-stream"     -H "Authorization: Bearer $FREETZ_DLTOKEN"  -H "X-GitHub-Api-Version: 2026-03-10"  "https://api.github.com/repos/Freetz-NG/images/releases/assets/$ASSID"
 		rmdl='y'
 	fi
 	[ ! -s "${image}" ] && [ -n "$ACTIONS_IMAGE" ] && echo "SAVING       $file" && wget -q "$ACTIONS_IMAGE/$file" -O $image >/dev/null 2>&1 && rmdl='y'

--- a/tools/freetz_download
+++ b/tools/freetz_download
@@ -73,14 +73,14 @@ do_assets() {
 	[ -z "${TAG}" ] && echo "No tag url" 1>&11 && return 1
 	[ -e "${DST}" ] && echo "File already exists" 1>&11 && return 1
 
-	local ASSETS="$(curl -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer ${DLT}"  -H "X-GitHub-Api-Version: 2022-11-28"  "${TAG}" 2>&12)"
+	local ASSETS="$(curl -H "Accept: application/vnd.github+json"  -H "Authorization: Bearer ${DLT}"  -H "X-GitHub-Api-Version: 2026-03-10"  "${TAG}" 2>&12)"
 	[ -z "${ASSETS}" ] && echo "Download failed - No ASSETS" 1>&11 && return 1
 	local ASSID="$(echo "${ASSETS}" | grep -B7 "\"${SRC}\"" | sed -rn 's/ *"id": *([^,]*),*/\1/p')"
 	[ -z "${ASSID}" ] && echo "Download failed - No ASSID" 1>&11 && return 1
 	echo "Found ASSID:=${ASSID}" 1>&11
 
 	[ "$opt_trap_delete" == y ] && trap 'echo "Deleting file: \"${DST}\""; rm \"${DST\" 2>/dev/null; exit 1' TERM INT
-	curl -Lo "${DST}"    -H "Accept: application/octet-stream"     -H "Authorization: Bearer ${DLT}"  -H "X-GitHub-Api-Version: 2022-11-28"  "${ASS}/${ASSID}" 1>&11 2>&12
+	curl -Lo "${DST}"    -H "Accept: application/octet-stream"     -H "Authorization: Bearer ${DLT}"  -H "X-GitHub-Api-Version: 2026-03-10"  "${ASS}/${ASSID}" 1>&11 2>&12
 	curl_result=$?
 	[ "$opt_trap_delete" == y ] && trap - TERM INT
 


### PR DESCRIPTION
Dies betrifft nur ungenutzen Code in mehren Actions.
Es aktualisiert die zu nutzende GitHub API Version auf 2026-03-10

refs: https://github.blog/changelog/2026-03-12-rest-api-version-2026-03-10-is-now-available/