### PR TITLE
docker: use `DEBIAN_FRONTEND` directly as `ARG`

### DIFF
--- a/.github/docker/dl-packs/Dockerfile
+++ b/.github/docker/dl-packs/Dockerfile
@@ -3,19 +3,20 @@ ARG BUILD_USR=freetz
 ARG BUILD_GRP=freetz
 ARG BUILD_UID=1001
 ARG BUILD_GID=1001
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN printf "deb http://old-releases.ubuntu.com/ubuntu hirsute main restricted universe multiverse\n" > /etc/apt/sources.list.d/hirsute.list \
  && printf "Package: gcc g++ cpp gcc-multilib\nPin: release n=hirsute,o=Ubuntu\nPin-Priority: 700\n\nPackage: *\nPin: release n=hirsute,o=Ubuntu\nPin-Priority: -10\n" > /etc/apt/preferences.d/hirsute
 
 RUN apt-get -y update && apt-get -y upgrade && apt-get -y dist-upgrade \
- && DEBIAN_FRONTEND=noninteractive apt-get -y install \
+ && apt-get -y install \
     bash locales libarchive-zip-perl  \
     pv cpio rsync kmod imagemagick inkscape graphicsmagick subversion git bc unar wget sudo gcc g++ binutils autoconf automake \
     autopoint libtool-bin make bzip2 libncurses-dev libreadline-dev zlib1g-dev flex bison patch texinfo tofrodos gettext pkg-config ecj \
     perl libstring-crc32-perl ruby gawk libusb-dev unzip intltool libacl1-dev libcap-dev libc6-dev-i386 lib32ncurses-dev \
     gcc-multilib bsdmainutils lib32stdc++6 libglib2.0-dev ccache cmake lib32z1-dev libsqlite3-dev sqlite3 libzstd-dev netcat-openbsd curl \
     uuid-dev libssl-dev libgnutls28-dev u-boot-tools device-tree-compiler openssl build-essential libelf-dev patchutils \
- && DEBIAN_FRONTEND=noninteractive apt-get -y clean \
+ && apt-get -y clean \
  && rm -rf /var/lib/apt/lists/* \
  && locale-gen en_US.utf8 && locale-gen de_DE.UTF-8 && update-locale \
  && groupadd $BUILD_GRP -o -g $BUILD_GID \

--- a/.github/docker/firmware/Dockerfile
+++ b/.github/docker/firmware/Dockerfile
@@ -3,19 +3,20 @@ ARG BUILD_USR=freetz
 ARG BUILD_GRP=freetz
 ARG BUILD_UID=1001
 ARG BUILD_GID=1001
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN printf "deb http://old-releases.ubuntu.com/ubuntu hirsute main restricted universe multiverse\n" > /etc/apt/sources.list.d/hirsute.list \
  && printf "Package: gcc g++ cpp gcc-multilib\nPin: release n=hirsute,o=Ubuntu\nPin-Priority: 700\n\nPackage: *\nPin: release n=hirsute,o=Ubuntu\nPin-Priority: -10\n" > /etc/apt/preferences.d/hirsute
 
 RUN apt-get -y update && apt-get -y upgrade && apt-get -y dist-upgrade \
- && DEBIAN_FRONTEND=noninteractive apt-get -y install \
+ && apt-get -y install \
     bash locales \
     pv cpio rsync kmod imagemagick inkscape graphicsmagick subversion git bc unar wget sudo gcc g++ binutils autoconf automake \
     autopoint libtool-bin make bzip2 libncurses-dev libreadline-dev zlib1g-dev flex bison patch texinfo tofrodos gettext pkg-config ecj \
     perl libstring-crc32-perl ruby gawk libusb-dev unzip intltool libacl1-dev libcap-dev libc6-dev-i386 \
     lib32ncurses-dev gcc-multilib bsdmainutils lib32stdc++6 libglib2.0-dev ccache cmake lib32z1-dev libsqlite3-dev sqlite3 libzstd-dev \
     netcat-openbsd curl uuid-dev libssl-dev libgnutls28-dev u-boot-tools device-tree-compiler libelf-dev patchutils \
- && DEBIAN_FRONTEND=noninteractive apt-get -y clean \
+ && apt-get -y clean \
  && rm -rf /var/lib/apt/lists/* \
  && locale-gen en_US.utf8 && locale-gen de_DE.UTF-8 && update-locale \
  && groupadd $BUILD_GRP -o -g $BUILD_GID \

--- a/.github/docker/generate/Dockerfile
+++ b/.github/docker/generate/Dockerfile
@@ -3,19 +3,20 @@ ARG BUILD_USR=freetz
 ARG BUILD_GRP=freetz
 ARG BUILD_UID=1001
 ARG BUILD_GID=1001
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN printf "deb http://old-releases.ubuntu.com/ubuntu hirsute main restricted universe multiverse\n" > /etc/apt/sources.list.d/hirsute.list \
  && printf "Package: gcc g++ cpp gcc-multilib\nPin: release n=hirsute,o=Ubuntu\nPin-Priority: 700\n\nPackage: *\nPin: release n=hirsute,o=Ubuntu\nPin-Priority: -10\n" > /etc/apt/preferences.d/hirsute
 
 RUN apt-get -y update && apt-get -y upgrade && apt-get -y dist-upgrade \
- && DEBIAN_FRONTEND=noninteractive apt-get -y install \
+ && apt-get -y install \
     git bash locales imagemagick netcat-openbsd curl bsdmainutils xxd libarchive-zip-perl wget \
     \
     \
     \
     \
     \
- && DEBIAN_FRONTEND=noninteractive apt-get -y clean \
+ && apt-get -y clean \
  && rm -rf /var/lib/apt/lists/* \
  && locale-gen en_US.utf8 && locale-gen de_DE.UTF-8 && update-locale \
  && groupadd $BUILD_GRP -o -g $BUILD_GID \

--- a/.github/workflows/avm_ftp.yml
+++ b/.github/workflows/avm_ftp.yml
@@ -32,8 +32,10 @@ jobs:
 #       run: apt-get -y update && apt-get -y upgrade && apt-get -y dist-upgrade
 #
 #     - name: install
+#       env:
+#         DEBIAN_FRONTEND: noninteractive
 #       run: |
-#         DEBIAN_FRONTEND=noninteractive apt-get -y install \
+#         apt-get -y install \
 #           git locales wget
 #
 #     - name: locale

--- a/.github/workflows/avm_juis-recache.yml
+++ b/.github/workflows/avm_juis-recache.yml
@@ -39,8 +39,10 @@ jobs:
 #       run: apt-get -y update && apt-get -y upgrade && apt-get -y dist-upgrade
 #
 #     - name: install
+#       env:
+#         DEBIAN_FRONTEND: noninteractive
 #       run: |
-#         DEBIAN_FRONTEND=noninteractive apt-get -y install \
+#         apt-get -y install \
 #           git locales netcat curl bsdmainutils xxd libarchive-zip-perl
 #
 #     - name: locale

--- a/.github/workflows/avm_juis.yml
+++ b/.github/workflows/avm_juis.yml
@@ -39,8 +39,10 @@ jobs:
 #       run: apt-get -y update && apt-get -y upgrade && apt-get -y dist-upgrade
 #
 #     - name: install
+#       env:
+#         DEBIAN_FRONTEND: noninteractive
 #       run: |
-#         DEBIAN_FRONTEND=noninteractive apt-get -y install \
+#         apt-get -y install \
 #           git locales netcat curl bsdmainutils xxd libarchive-zip-perl
 #
 #     - name: locale

--- a/.github/workflows/avm_osp.yml
+++ b/.github/workflows/avm_osp.yml
@@ -32,8 +32,10 @@ jobs:
 #       run: apt-get -y update && apt-get -y upgrade && apt-get -y dist-upgrade
 #
 #     - name: install
+#       env:
+#         DEBIAN_FRONTEND: noninteractive
 #       run: |
-#         DEBIAN_FRONTEND=noninteractive apt-get -y install \
+#         apt-get -y install \
 #           git locales wget
 #
 #     - name: locale

--- a/.github/workflows/dl-hosttools.yml
+++ b/.github/workflows/dl-hosttools.yml
@@ -33,8 +33,10 @@ jobs:
 #       run: apt-get -y update && apt-get -y upgrade && apt-get -y dist-upgrade
 #
 #     - name: install
+#       env:
+#         DEBIAN_FRONTEND: noninteractive
 #       run: |
-#         DEBIAN_FRONTEND=noninteractive apt-get -y install \
+#         apt-get -y install \
 #           locales bash \
 #           pv cpio rsync kmod imagemagick inkscape graphicsmagick subversion git bc unar wget sudo gcc g++ binutils autoconf automake \
 #           autopoint libtool-bin make bzip2 libncurses5-dev libreadline-dev zlib1g-dev flex bison patch texinfo tofrodos gettext pkg-config ecj \

--- a/.github/workflows/dl-toolchains.yml
+++ b/.github/workflows/dl-toolchains.yml
@@ -92,8 +92,10 @@ jobs:
 #       run: apt-get -y update && apt-get -y upgrade && apt-get -y dist-upgrade
 #
 #     - name: install
+#       env:
+#         DEBIAN_FRONTEND: noninteractive
 #       run: |
-#         DEBIAN_FRONTEND=noninteractive apt-get -y install \
+#         apt-get -y install \
 #           locales bash \
 #           pv cpio rsync kmod imagemagick inkscape graphicsmagick subversion git bc unar wget sudo gcc g++ binutils autoconf automake \
 #           autopoint libtool-bin make bzip2 libncurses5-dev libreadline-dev zlib1g-dev flex bison patch texinfo tofrodos gettext pkg-config ecj \

--- a/.github/workflows/github_link.yml
+++ b/.github/workflows/github_link.yml
@@ -29,8 +29,10 @@ jobs:
 #       run: apt-get -y update && apt-get -y upgrade && apt-get -y dist-upgrade
 #
 #     - name: install
+#       env:
+#         DEBIAN_FRONTEND: noninteractive
 #       run: |
-#         DEBIAN_FRONTEND=noninteractive apt-get -y install \
+#         apt-get -y install \
 #           git locales netcat curl bsdmainutils xxd libarchive-zip-perl
 #
 #     - name: locale

--- a/.github/workflows/make_freetz.yml
+++ b/.github/workflows/make_freetz.yml
@@ -36,8 +36,10 @@ jobs:
 #       run: apt-get -y update && apt-get -y upgrade && apt-get -y dist-upgrade
 #
 #     - name: install
+#       env:
+#         DEBIAN_FRONTEND: noninteractive
 #       run: |
-#         DEBIAN_FRONTEND=noninteractive apt-get -y install \
+#         apt-get -y install \
 #           locales \
 #           pv cpio rsync kmod imagemagick inkscape graphicsmagick subversion git bc unar wget sudo gcc g++ binutils autoconf automake \
 #           autopoint libtool-bin make bzip2 libncurses5-dev libreadline-dev zlib1g-dev flex bison patch texinfo tofrodos gettext pkg-config ecj \

--- a/.github/workflows/make_kernel.yml
+++ b/.github/workflows/make_kernel.yml
@@ -119,8 +119,10 @@ jobs:
 #       run: apt-get -y update && apt-get -y upgrade && apt-get -y dist-upgrade
 #
 #     - name: install
+#       env:
+#         DEBIAN_FRONTEND: noninteractive
 #       run: |
-#         DEBIAN_FRONTEND=noninteractive apt-get -y install \
+#         apt-get -y install \
 #           locales \
 #           pv cpio rsync kmod imagemagick inkscape graphicsmagick subversion git bc unar wget sudo gcc g++ binutils autoconf automake \
 #           autopoint libtool-bin make bzip2 libncurses5-dev libreadline-dev zlib1g-dev flex bison patch texinfo tofrodos gettext pkg-config ecj \

--- a/.github/workflows/make_precompiled.yml
+++ b/.github/workflows/make_precompiled.yml
@@ -116,8 +116,10 @@ jobs:
 #       run: apt-get -y update && apt-get -y upgrade && apt-get -y dist-upgrade
 #
 #     - name: install
+#       env:
+#         DEBIAN_FRONTEND: noninteractive
 #       run: |
-#         DEBIAN_FRONTEND=noninteractive apt-get -y install \
+#         apt-get -y install \
 #           locales \
 #           pv cpio rsync kmod imagemagick inkscape graphicsmagick subversion git bc unar wget sudo gcc g++ binutils autoconf automake \
 #           autopoint libtool-bin make bzip2 libncurses5-dev libreadline-dev zlib1g-dev flex bison patch texinfo tofrodos gettext pkg-config ecj \

--- a/.github/workflows/make_tester.yml
+++ b/.github/workflows/make_tester.yml
@@ -39,8 +39,10 @@ jobs:
 #       run: apt-get -y update && apt-get -y upgrade && apt-get -y dist-upgrade
 #
 #     - name: install
+#       env:
+#         DEBIAN_FRONTEND: noninteractive
 #       run: |
-#         DEBIAN_FRONTEND=noninteractive apt-get -y install \
+#         apt-get -y install \
 #           locales \
 #           pv cpio rsync kmod imagemagick inkscape graphicsmagick subversion git bc unar wget sudo gcc g++ binutils autoconf automake \
 #           autopoint libtool-bin make bzip2 libncurses5-dev libreadline-dev zlib1g-dev flex bison patch texinfo tofrodos gettext pkg-config ecj \

--- a/.github/workflows/postcommit_diffs.yml
+++ b/.github/workflows/postcommit_diffs.yml
@@ -32,8 +32,10 @@ jobs:
 #       run: apt-get -y update && apt-get -y upgrade && apt-get -y dist-upgrade
 #
 #     - name: install
+#       env:
+#         DEBIAN_FRONTEND: noninteractive
 #       run: |
-#         DEBIAN_FRONTEND=noninteractive apt-get -y install \
+#         apt-get -y install \
 #           git locales
 #
 #     - name: locale

--- a/.github/workflows/postcommit_docs.yml
+++ b/.github/workflows/postcommit_docs.yml
@@ -46,8 +46,10 @@ jobs:
 #       run: apt-get -y update && apt-get -y upgrade && apt-get -y dist-upgrade
 #
 #     - name: install
+#       env:
+#         DEBIAN_FRONTEND: noninteractive
 #       run: |
-#         DEBIAN_FRONTEND=noninteractive apt-get -y install \
+#         apt-get -y install \
 #           git locales imagemagick
 #
 #     - name: locale

--- a/.github/workflows/postcommit_img.yml
+++ b/.github/workflows/postcommit_img.yml
@@ -58,8 +58,10 @@ jobs:
 #       run: apt-get -y update && apt-get -y upgrade && apt-get -y dist-upgrade
 #
 #     - name: install
+#       env:
+#         DEBIAN_FRONTEND: noninteractive
 #       run: |
-#         DEBIAN_FRONTEND=noninteractive apt-get -y install \
+#         apt-get -y install \
 #           locales bash \
 #           pv cpio rsync kmod imagemagick inkscape graphicsmagick subversion git bc unar wget sudo gcc g++ binutils autoconf automake \
 #           autopoint libtool-bin make bzip2 libncurses5-dev libreadline-dev zlib1g-dev flex bison patch texinfo tofrodos gettext pkg-config ecj \

--- a/.github/workflows/postcommit_kos.yml
+++ b/.github/workflows/postcommit_kos.yml
@@ -31,8 +31,10 @@ jobs:
 #       run: apt-get -y update && apt-get -y upgrade && apt-get -y dist-upgrade
 #
 #     - name: install
+#       env:
+#         DEBIAN_FRONTEND: noninteractive
 #       run: |
-#         DEBIAN_FRONTEND=noninteractive apt-get -y install \
+#         apt-get -y install \
 #           git locales
 #
 #     - name: locale

--- a/.github/workflows/postcommit_stats.yml
+++ b/.github/workflows/postcommit_stats.yml
@@ -38,8 +38,10 @@ jobs:
 #       run: apt-get -y update && apt-get -y upgrade && apt-get -y dist-upgrade
 #
 #     - name: install
+#       env:
+#         DEBIAN_FRONTEND: noninteractive
 #       run: |
-#         DEBIAN_FRONTEND=noninteractive apt-get -y install \
+#         apt-get -y install \
 #           locales bash \
 #           pv cpio rsync kmod imagemagick inkscape graphicsmagick subversion git bc unar wget sudo gcc g++ binutils autoconf automake \
 #           autopoint libtool-bin make bzip2 libncurses5-dev libreadline-dev zlib1g-dev flex bison patch texinfo tofrodos gettext pkg-config ecj \


### PR DESCRIPTION
Dies ändert die Verwendung von `DEBIAN_FRONTEND` als `ARG` in die `Dockerfile`'s
Bei den Actions (den ungenutzten Code) ist es für den betreffenden Step auch als env definiert (das definierte `env` `DEBIAN_FRONTEND` gilt nur für den jeweiligen `install` Step)