### PR TITLE
make_tester: Disable Upload artifacts as packaged zip file

### DIFF
--- a/.github/workflows/make_tester.yml
+++ b/.github/workflows/make_tester.yml
@@ -173,14 +173,14 @@ jobs:
           path: images/
           if-no-files-found: warn
           retention-days: 1
-          compression-level: 0
+          archive: false
           overwrite: true
           include-hidden-files: false
       - name: link
         if: github.repository != 'freetz-ng/freetz-ng'
         run: |
           echo "##########################################################"
-          FILE="${{ steps.vars.outputs.last }}.zip"
+          FILE="${{ steps.vars.outputs.last }}"
           ARTI="${{ steps.artifact.outputs.artifact-url }}"
           echo "Firmware := $FILE"
           echo "Artifact := $ARTI"


### PR DESCRIPTION
Dies deaktiviert das Hochladen von Artifacts als verpackte ZIP Datei.
Dadurch wird die Image Datei direkt als Datei ohne "ZIP Verpackung" hochgeladen.

refs to docs of `actions/upload-artifact@v7`: 
https://github.com/actions/upload-artifact/blob/bbbca2ddaa5d8feaa63e36b76fdaad77386f024f/action.yml#L48-L53