### PR TITLE
make_precompiled: correct concurrency group

### DIFF
--- a/.github/workflows/make_precompiled.yml
+++ b/.github/workflows/make_precompiled.yml
@@ -22,7 +22,7 @@ on:
 
 #concurrency:
 # group: ${{ github.workflow }}${{ github.event.pull_request.number && '-' }}${{ github.event.pull_request.number || '' }}
-# cancel-in-progress: ${{ (github.event_name == 'pull_request') && true || false }}
+# cancel-in-progress: ${{ github.event_name == 'pull_request' && true || false }}
 
 jobs:
 

--- a/.github/workflows/make_precompiled.yml
+++ b/.github/workflows/make_precompiled.yml
@@ -21,7 +21,7 @@ on:
         default: "dropbear"
 
 #concurrency:
-# group: ${{ (github.event_name == 'pull_request') && github.workflow && '-' && github.event.pull_request.number || github.run_id }}
+# group: ${{ github.workflow }}${{ github.event.pull_request.number && '-' }}${{ github.event.pull_request.number || '' }}
 # cancel-in-progress: ${{ (github.event_name == 'pull_request') && true || false }}
 
 jobs:


### PR DESCRIPTION
Betrifft auch nur ungenutzten Code.

Dies korigiert beim `make_precompiled` die concurrency group damit wenn PRs diesen Action triggern das jeder PR seperat behandelt wird während bei commits oder `workflow_dispatch` nur `github.workflow` verwendet wird.