### PR TITLE
bump pseudo

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -73,7 +73,7 @@ Latest changes
     * cmake 4.3.1
     * file 5.47
     * meson 1.10.2
-    * pseudo 1.9.3
+    * pseudo 1.9.3 master 414ce2d
     * python3 3.14.3
 
   - AVM sources:

--- a/make/host-tools/pseudo-host/pseudo-host.mk
+++ b/make/host-tools/pseudo-host/pseudo-host.mk
@@ -1,8 +1,9 @@
-$(call TOOLS_INIT, 1.9.3)
+$(call TOOLS_INIT, 414ce2da8e0ad1f3ba5d841f4db094987f33eafd)
 $(PKG)_SOURCE:=pseudo-$($(PKG)_VERSION).tar.gz
-$(PKG)_HASH:=097a56b64c67b718d95866454fe9ffb00e94b6b96753e06f8eb6082b84a6490e
+$(PKG)_HASH:=2e2196002ba14cc8a8fc73c8de7af7881ea25bcb74227af78dcc39265fe6d1e0
 $(PKG)_SITE:=https://git.yoctoproject.org/pseudo/snapshot,https://downloads.yoctoproject.org/releases/pseudo
 #$(PKG)_SITE:=git@https://git.yoctoproject.org/git/pseudo
+### VERSION:=1.9.3 master 414ce2d
 ### WEBSITE:=https://www.yoctoproject.org/software-item/pseudo/
 ### MANPAGE:=https://manpages.debian.org/testing/pseudo/pseudo.1.en.html
 ### CHANGES:=https://git.yoctoproject.org/pseudo/log/?h=master


### PR DESCRIPTION
Dies behebt unter ubuntu 26.04 folgenden Fehler:

<details><summary>Output</summary>
<p>

```bash
Freetz-NG 756-d7fb82fdff master 2026-04-01
.........................................................................................................
---> tools/kconfig-host ... building ... done.
---> tools/tar-host ... downloading ... preparing ... configuring ... building ... done.
---> tools/busybox-host ... downloading ... preparing ... building ... building ... done.
---> tools/pkgconf-host ... downloading ... preparing ... configuring ... building ... building ... done.
---> tools/m4-host ... downloading ... preparing ... configuring ... building ... done.
---> tools/autoconf-host ... downloading ... preparing ... configuring ... building ... building ... done.
---> tools/automake-host ... downloading ... preparing ... configuring ... building ... building ... done.
---> tools/patchelf-host ... downloading ... preparing ... configuring ... building ... done.
---> tools/openssl-host ... downloading ... preparing ... configuring ... building ... building ... done.
---> tools/ca-bundle-host ... downloading ... preparing ... done.
---> tools/cmake-host ... downloading ... preparing ... configuring ... building ... building ... done.
---> tools/file-host ... downloading ... preparing ... configuring ... building ... done.
---> tools/find-squashfs-host ... preparing ... building ... done.
---> tools/libtool-host ... downloading ... preparing ... configuring ... building ... building ... done.
---> tools/lzma2eva-host ... preparing ... building ... done.
---> tools/make-host ... downloading ... preparing ... configuring ... building ... building ... done.
---> tools/patchelf-target-host ... downloading ... preparing ... configuring ... building ... done.
---> tools/prelink-host ... downloading ... preparing ... configuring ... building ... done.
---> tools/pseudo-host ... downloading ... preparing ... configuring ... building ... 
enums/debug_type.in: Flags: set for debug_type
type: debug_type_t (prefix 'PDBG_ENUM')
  extra column: unsigned char symbolic (default '\0')
  extra column: const char * description (default NULL)
   consistency        file               op                 pid                
   client             server             db                 xattrdb            
   profile            syscall            env                chroot             
   path               sql                wrapper            ipc                
   invoke             benchmark          verbose            xattr              

enums/exit_status.in: type: exit_status_t (prefix 'PSEUDO_EXIT_ENUM')
  extra column: char * message (default "exit status unknown")
   general            fork_failed        lock_path          lock_held          
   lock_failed        timeout            waitpid            socket_create      
   socket_fd          socket_path        socket_unlink      socket_bind        
   socket_listen      listen_fd          pseudo_loaded      pseudo_prefix      
   pseudo_invocation  epoll_create       epoll_ctl                             

enums/msg_type.in: type: msg_type_t (prefix 'PSEUDO_MSG_ENUM')
   ping               shutdown           op                 ack                
   nak                fastop             

enums/op.in: type: op_t (prefix 'OP_ENUM')
  extra column: int wait (default 0)
   chdir              chmod              chown              chroot             
   close              creat              dup                fchmod             
   fchown             fstat              link               mkdir              
   mknod              open               rename             stat               
   unlink             symlink            exec               may-unlink         
   did-unlink         cancel-unlink      get-xattr          list-xattr         
   remove-xattr       set-xattr          create-xattr       replace-xattr      
   closefrom          

enums/query_field.in: type: query_field_t (prefix 'PSQF_ENUM')
   access             client             dev                fd                 
   ftype              gid                id                 inode              
   mode               op                 order              path               
   perm               program            result             severity           
   stamp              tag                text               type               
   uid                

enums/query_type.in: type: query_type_t (prefix 'PSQT_ENUM')
  extra column: const char * sql (default "LITTLE BOBBY TABLES")
   exact              less               greater            bitand             
   notequal           like               notlike            sqlpat             

enums/res.in: type: res_t (prefix 'RESULT_ENUM')
   succeed            fail               error              abort              

enums/sev.in: type: sev_t (prefix 'SEVERITY_ENUM')
   debug              info               warn               error              
   critical           

Writing datatypes...
done.  Cleaning up.
Checking for old/new clone mechanics... New clone.
Considering template: templates/port_wrappers
Considering template: templates/wrapper_table
Considering template: templates/func_deps
Considering template: templates/wrapfuncs.c
Considering template: templates/guts
Considering template: templates/port_deps
Considering template: templates/wrapfuncs.h
Considering template: templates/pseudo_ports
common
ports/common/wrapfuncs.in: .........
linux
ports/linux/wrapfuncs.in: ....................................................................
unix
ports/unix/wrapfuncs.in: ......................................................................
unix/syncfs
ports/unix/syncfs/wrapfuncs.in: .
uids_generic
ports/uids_generic/wrapfuncs.in: ........................
linux/newclone
ports/linux/newclone/wrapfuncs.in: .
linux/noxattr
ports/linux/noxattr/wrapfuncs.in: ............
linux/statvfs
ports/linux/statvfs/wrapfuncs.in: ..
linux/statx
ports/linux/statx/wrapfuncs.in: .
linux/openat2
ports/linux/openat2/wrapfuncs.in: .
Writing functions...
Warning: lchown from linux overriding unix
Warning: mknod from linux overriding unix
Warning: mknodat from linux overriding unix
Warning: tmpnam from linux overriding unix
Warning: lutimes from linux overriding unix
Warning: utimes from linux overriding unix
done.  Cleaning up.
pseudo_client.c: In function 'pseudo_client_path_set':
pseudo_client.c:904:74: warning: format '%ld' expects argument of type 'long int', but argument 2 has type 'unsigned int' [-Wformat=]
  904 |                         pseudo_diag("couldn't realloc fd path array to %ld entries\n", (fd + 1) * sizeof(char *));
      |                                                                        ~~^             ~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                          |                      |
      |                                                                          long int               unsigned int
      |                                                                        %d
pseudo_util.c: In function 'pseudo_append_elements':
pseudo_util.c:837:30: warning: initialization discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  837 |                 char *next = strchr(path, '/');
make[1]: *** [make/host-tools/pseudo-host/pseudo-host.mk:60: /__w/pfichtner-freetz/pfichtner-freetz/freetz/tools/build/lib/libpseudo.so] Terminated
make: *** [Makefile:49: envira] Terminated
      |                              ^~~~~~
pseudo_util.c:839:30: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  839 |                         next = strchr(path, '\0');
      |                              ^
In file included from pseudo_wrappers.c:297:
pseudo_wrapfuncs.c:11537:1: error: conflicting types for 'openat2'; have 'int(int,  const char *, struct open_how *, size_t)' {aka 'int(int,  const char *, struct open_how *, unsigned int)'}
11537 | openat2(int dirfd, const char *path, struct open_how *how, size_t size) {
      | ^~~~~~~
In file included from /usr/include/bits/fcntl-linux.h:492,
                 from /usr/include/bits/fcntl.h:61,
                 from /usr/include/fcntl.h:35,
                 from pseudo_wrappers.c:23:
/usr/include/bits/fcntl-linux-fortify.h:36:1: note: previous definition of 'openat2' with type 'int(int,  const char *, const struct open_how *, unsigned int)'
   36 | openat2 (int __dfd, const char *__filename, const struct open_how *__how,
      | ^~~~~~~
make[2]: *** [Makefile:162: pseudo_wrappers.o] Error 1
make[2]: *** Waiting for unfinished jobs....
```

</p>
</details> 

Getestet mit den GNU Coreutils (uutils hatte ich vorher deinstalliert)

In den Upstream Commits von pseudo ist auch was ähnliches wie aus den Output zu lesen:

<img width="403" alt="Screenshot 2026-04-02 at 13-48-19 pseudo - Allows emulation of root user operations" src="https://github.com/user-attachments/assets/75f8507b-51e5-46f7-8961-782b50344ada" />
