### PR TITLE
docs(prerequisites): ```-symbol missing in section for ubuntu26

### DIFF
--- a/docs/prerequisites/README.tpl
+++ b/docs/prerequisites/README.tpl
@@ -169,6 +169,7 @@ sudo apt-get remove --allow-remove-essential coreutils-from-uutils
   - Ubuntu 26 64-Bit:
 ```
 sudo apt-get -y install %%Ubuntu26%%
+```
 
   - Ubuntu 23/24/25 64-Bit:
 ```


### PR DESCRIPTION
Dies fügt die vergessene ```-Symbole wieder in das readme.template für die docs prereqs ein.

Ohne den fix sieht die daraus generierte readme.md so aus:
<img width="500" alt="Screenshot 2026-04-11 at 11-58-27 Installation der benötigten Pakete - Freetz-NG Documentation" src="https://github.com/user-attachments/assets/2e726c70-26c3-4501-8f8a-c1353756a228" />
