### PR TITLE
Update 320-remove_dsld.sh

### DIFF
--- a/patches/scripts/320-remove_dsld.sh
+++ b/patches/scripts/320-remove_dsld.sh
@@ -2,6 +2,7 @@
 echo1 "removing dsld files"
 
 rm_files $(find ${FILESYSTEM_MOD_DIR}/sbin ${FILESYSTEM_MOD_DIR}/lib/modules -name dsld)
+rm_files "${FILESYSTEM_MOD_DIR}/etc/modules-load.d/dsl.conf"
 rm_files "${FILESYSTEM_MOD_DIR}/etc/modules-load.d/dsld.conf"
 
 modsed 's/^ *eval.*dsld.*/echo -n/g' "$FILESYSTEM_MOD_DIR/etc/init.d/rc.net"

--- a/patches/scripts/320-remove_dsld.sh
+++ b/patches/scripts/320-remove_dsld.sh
@@ -2,7 +2,7 @@
 echo1 "removing dsld files"
 
 rm_files $(find ${FILESYSTEM_MOD_DIR}/sbin ${FILESYSTEM_MOD_DIR}/lib/modules -name dsld)
-rm_files "${FILESYSTEM_MOD_DIR}/etc/modules-load.d/dsl.conf"
+rm_files "${FILESYSTEM_MOD_DIR}/etc/modules-load.d/dsld.conf"
 
 modsed 's/^ *eval.*dsld.*/echo -n/g' "$FILESYSTEM_MOD_DIR/etc/init.d/rc.net"
 


### PR DESCRIPTION
- fix dsl.conf -> dsld.conf typo

a small typo that costed me nearly a week..

with this it is possible to use nat / masquerade as the kdsldmod is not autoloaded anymore so it is completely disabled.

proof

```
root@fritz:/var/mod/root# lsmod | grep kdsldmod
root@fritz:/var/mod/root# ls /proc/kdsld
ls: /proc/kdsld: No such file or directory
```

my usecase is: guest wlan with dhcp from dnsmasq, but internet from my router:

fritzbox in client ip mode: 10.0.0.40
router mikrotik ccr2004: 10.0.0.1
guest wlan ip: 10.0.1.1/24

besides this hack I had to do a lot of fixing like kernel replace, own modules, disable watchdog (did not crosstest it now after the module is gone if it is still triggered), etc..

.. the last border was the avm firewall which in the end was this little typo.

mission accomplished.

i have readen there was a lot of "voodoo" with this. now its crystal clear.

have fun with it ;)