### PR TITLE
fix dnsmasq startup before multid

### DIFF
--- a/make/pkgs/dnsmasq/files/root/etc/init.d/rc.dnsmasq
+++ b/make/pkgs/dnsmasq/files/root/etc/init.d/rc.dnsmasq
@@ -5,11 +5,31 @@ DAEMON_LONG_NAME=Dnsmasq
 PID_FILE=/var/run/$DAEMON/$DAEMON.pid
 . /etc/init.d/modlibrc
 
+dnsmasq_effective_dns_port() {
+	local port="${DNSMASQ_DNS_PORT:-53}"
+	case "$port" in
+		""|*[!0-9]*)
+			echo 53
+			return
+			;;
+	esac
+	[ "$port" -ge 1 ] && [ "$port" -le 65535 ] 2>/dev/null || {
+		echo 53
+		return
+	}
+	echo "$port"
+}
+
+dnsmasq_owns_dns53() {
+	[ "$(dnsmasq_effective_dns_port)" = "53" ]
+}
 
 [ -e /etc/init.d/rc.rextd ] && MASTER=rextd || MASTER=multid
 [ -r /etc/options.cfg ] && . /etc/options.cfg
 if [ "$FREETZ_AVMDAEMON_DISABLE_DNS" != "y" ]; then
-	[ "$(/etc/init.d/rc.$MASTER status)" != "running" -o "$DNSMASQ_MULTID_RESTART" != "yes" ] && nomultid=y
+	if [ "$(/etc/init.d/rc.$MASTER status)" != "running" ] || [ "$DNSMASQ_MULTID_RESTART" != "yes" ] || ! dnsmasq_owns_dns53; then
+		nomultid=y
+	fi
 else
 	nomultid=y
 fi
@@ -118,7 +138,12 @@ case $1 in
 		;;
 	restart)
 		if [ "$FREETZ_AVMDAEMON_DISABLE_DNS" != "y" ]; then
-			modlib_check_running && nomultid=y
+			if modlib_check_running; then
+				# Keep master restart enabled when dnsmasq is meant to own port 53.
+				if [ "$DNSMASQ_MULTID_RESTART" != "yes" ] || ! dnsmasq_owns_dns53; then
+					nomultid=y
+				fi
+			fi
 		fi
 		modlib_restart
 		;;

--- a/make/pkgs/mod/files/root/etc/init.d/rc.multid
+++ b/make/pkgs/mod/files/root/etc/init.d/rc.multid
@@ -75,7 +75,12 @@ start() {
 		local _bind_enabled="$(modconf value BIND_ENABLED bind 2>/dev/null)"
 		local _dnsmasq_enabled="$(modconf value DNSMASQ_ENABLED dnsmasq 2>/dev/null)"
 		local _dnsmasq_port="$(modconf value DNSMASQ_DNS_PORT dnsmasq 2>/dev/null)"
-		local _dnsmasq_dns_enabled=$([ "$_dnsmasq_enabled" = yes -a "$_dnsmasq_port" -eq 53 ] 2>/dev/null && echo yes || echo no)
+		local _dnsmasq_port_norm=53
+		case "$_dnsmasq_port" in
+			""|*[!0-9]*) ;;
+			*) [ "$_dnsmasq_port" -ge 1 ] && [ "$_dnsmasq_port" -le 65535 ] 2>/dev/null && _dnsmasq_port_norm="$_dnsmasq_port" ;;
+		esac
+		local _dnsmasq_dns_enabled=$([ "$_dnsmasq_enabled" = yes -a "$_dnsmasq_port_norm" = 53 ] && echo yes || echo no)
 		local _unbound_enabled="$(modconf value UNBOUND_ENABLED unbound 2>/dev/null)"
 		if [ "$_resolv_conf_dns" == "127.0.0.1" -a "$_bind_enabled" != yes -a "$_dnsmasq_dns_enabled" != yes -a "$_unbound_enabled" != yes ]; then
 			echo -n "discarded libmultid, no enabled dns server ... "

--- a/make/pkgs/mod/files/root/etc/init.d/rc.rextd
+++ b/make/pkgs/mod/files/root/etc/init.d/rc.rextd
@@ -39,7 +39,12 @@ start() {
 		local _bind_enabled="$(modconf value BIND_ENABLED bind 2>/dev/null)"
 		local _dnsmasq_enabled="$(modconf value DNSMASQ_ENABLED dnsmasq 2>/dev/null)"
 		local _dnsmasq_port="$(modconf value DNSMASQ_DNS_PORT dnsmasq 2>/dev/null)"
-		local _dnsmasq_dns_enabled=$([ "$_dnsmasq_enabled" = yes -a "$_dnsmasq_port" -eq 53 ] 2>/dev/null && echo yes || echo no)
+		local _dnsmasq_port_norm=53
+		case "$_dnsmasq_port" in
+			""|*[!0-9]*) ;;
+			*) [ "$_dnsmasq_port" -ge 1 ] && [ "$_dnsmasq_port" -le 65535 ] 2>/dev/null && _dnsmasq_port_norm="$_dnsmasq_port" ;;
+		esac
+		local _dnsmasq_dns_enabled=$([ "$_dnsmasq_enabled" = yes -a "$_dnsmasq_port_norm" = 53 ] && echo yes || echo no)
 		local _unbound_enabled="$(modconf value UNBOUND_ENABLED unbound 2>/dev/null)"
 		if [ "$_resolv_conf_dns" == "127.0.0.1" -a "$_bind_enabled" != yes -a "$_dnsmasq_dns_enabled" != yes -a "$_unbound_enabled" != yes ]; then
 			echo -n "discarded libmultid, no enabled dns server ... "


### PR DESCRIPTION
dnsmasq does not start when port 53 and start before multid are chosen. 
with this i think the "start before multid" button is obsolete I think.