### PR TITLE
docker: add arm64 support

### DIFF
--- a/.github/docker/firmware/Dockerfile
+++ b/.github/docker/firmware/Dockerfile
@@ -12,10 +12,11 @@ RUN apt-get -y update && apt-get -y upgrade && apt-get -y dist-upgrade \
     bash locales \
     pv cpio rsync kmod imagemagick inkscape graphicsmagick subversion git bc unar wget sudo gcc g++ binutils autoconf automake \
     autopoint libtool-bin make bzip2 libncurses-dev libreadline-dev zlib1g-dev flex bison patch texinfo tofrodos gettext pkg-config ecj \
-    perl libstring-crc32-perl ruby gawk libusb-dev unzip intltool libacl1-dev libcap-dev libc6-dev-i386 lib32ncurses-dev \
-    gcc-multilib bsdmainutils lib32stdc++6 libglib2.0-dev ccache cmake lib32z1-dev libsqlite3-dev sqlite3 libzstd-dev netcat-openbsd curl \
+    perl libstring-crc32-perl ruby gawk libusb-dev unzip intltool libacl1-dev libcap-dev \
+    bsdmainutils libglib2.0-dev ccache cmake libsqlite3-dev sqlite3 libzstd-dev netcat-openbsd curl \
     uuid-dev libssl-dev libgnutls28-dev u-boot-tools device-tree-compiler libelf-dev patchutils \
     openssl build-essential libarchive-zip-perl \
+    $(if [ "$(uname -m)" = "amd64" ]; then echo "libc6-dev-i386 lib32ncurses-dev gcc-multilib lib32stdc++6 lib32z1-dev"; fi) \
  && DEBIAN_FRONTEND=noninteractive apt-get -y clean \
  && rm -rf /var/lib/apt/lists/* \
  && locale-gen en_US.utf8 && locale-gen de_DE.UTF-8 && update-locale \

--- a/.github/docker/generate/Dockerfile
+++ b/.github/docker/generate/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get -y update && apt-get -y upgrade && apt-get -y dist-upgrade \
     \
     \
     \
+    \
  && DEBIAN_FRONTEND=noninteractive apt-get -y clean \
  && rm -rf /var/lib/apt/lists/* \
  && locale-gen en_US.utf8 && locale-gen de_DE.UTF-8 && update-locale \

--- a/.github/workflows/github_docker.yml
+++ b/.github/workflows/github_docker.yml
@@ -70,6 +70,14 @@ jobs:
         with:
           ref: ${{ fromJson(needs.matrizifizieren.outputs.gitsha) }}
 
+      - name: qemu
+        uses: docker/setup-qemu-action@v4
+        with:
+          cache-image: false
+
+      - name: buildx
+        uses: docker/setup-buildx-action@v4
+
       - name: login
         uses: docker/login-action@v4
         with:
@@ -84,5 +92,5 @@ jobs:
           context: .github/docker/${{ matrix.image }}
           tags: ghcr.io/freetz-ng/internal/${{ matrix.image }}:latest
           push: ${{ github.repository == 'freetz-ng/freetz-ng' && github.event_name != 'pull_request' }}
-
+          platforms: linux/amd64,linux/arm64
 


### PR DESCRIPTION
Dies fügt den arm64 support für die dockerfiles hinzu damit es gebaut und intern mit verwendet werden kann
(z.b. für free arm64 github runners (`runs-on: ubuntu-24.04-arm`) oder andere zwecke)