### PR TITLE
prerequisites(debian/ubuntu): use always apt instead of apt-get if available

### DIFF
--- a/tools/prerequisites
+++ b/tools/prerequisites
@@ -3,6 +3,7 @@ SCRIPT="$(readlink -f $0)"
 PARENT="$(dirname ${SCRIPT%/*})"
 PACKAGES="$PARENT/tools/.prerequisites"
 [ -x "$(command -v sudo)" ] && SUDO="sudo" || SUDO=""
+[ -x "$(command -v apt)"  ] && APT="apt"   || APT="apt-get"
 
 
 check_requisite() {
@@ -118,10 +119,10 @@ install_requisite() {
 	echo -e "\nPackages for '$OSV':\n$vals\n"
 	[ "${ARG:0:1}" == "s" ] && exit 0
 	case "$OSV" in
-		Fedora*)                                       $SUDO dnf --refresh  install $DOY $vals || exit 1 ;;
-		Debian*|Devuan*|LMDE*) $SUDO apt-get update && $SUDO apt            install $DOY $vals || exit 1 ;;
-		Ubuntu*|Mint*)         $SUDO apt-get update && $SUDO apt-get        install $DOY $vals || exit 1 ;;
-		*)                     echo 'No known installer'                                       && exit 1 ;;
+		Fedora*)                                    $SUDO dnf --refresh  install $DOY $vals || exit 1 ;;
+		Debian*|Devuan*|LMDE*) $SUDO $APT update && $SUDO $APT           install $DOY $vals || exit 1 ;;
+		Ubuntu*|Mint*)         $SUDO $APT update && $SUDO $APT           install $DOY $vals || exit 1 ;;
+		*)                     echo 'No known installer'                                    && exit 1 ;;
 	esac
 	exit 0
 }

--- a/tools/zensical_httpserver.sh
+++ b/tools/zensical_httpserver.sh
@@ -17,13 +17,14 @@ install_python() {
 	local SUDO DOY="$1"
 	local OSV="$(detect_linux)"
 	[ -z "$OSV" ] && echo 'Can not detect your Linux version, failed.' && exit 1
-	[ -x "$(command -v sudo)" ] && SUDO="sudo"
+	[ -x "$(command -v sudo)" ] && SUDO="sudo" || SUDO=""
+	[ -x "$(command -v apt)"  ] && APT="apt"   || APT="apt-get"
 
 	case "${OSV##*/}" in
-		Fedora*)                                       $SUDO dnf --refresh  install $DOY python3 python3-pip python3-virtualenv || exit 1 ;;
-		Debian*|Devuan*|LMDE*) $SUDO apt-get update && $SUDO apt            install $DOY python3 python3-pip python3-venv       || exit 1 ;;
-		Ubuntu*|Mint*)         $SUDO apt-get update && $SUDO apt-get        install $DOY python3 python3-pip python3-venv       || exit 1 ;;
-		*)                     echo 'You Linux distribution is not yet supported'                                               && exit 1 ;;
+		Fedora*)                                    $SUDO dnf --refresh  install $DOY python3 python3-pip python3-virtualenv || exit 1 ;;
+		Debian*|Devuan*|LMDE*) $SUDO $APT update && $SUDO $APT           install $DOY python3 python3-pip python3-venv       || exit 1 ;;
+		Ubuntu*|Mint*)         $SUDO $APT update && $SUDO $APT           install $DOY python3 python3-pip python3-venv       || exit 1 ;;
+		*)                     echo 'You Linux distribution is not yet supported'                                            && exit 1 ;;
 	esac
 }
 


### PR DESCRIPTION
Dies verwendet wenn verfügbar bei debian und ubuntu immer apt statt apt-get wenn verfügbar

(Auch für zensical_httpserver)