### PR TITLE
make_precompiled: use new maximum queue field for github build-in concurrency

### DIFF
--- a/.github/workflows/make_precompiled.yml
+++ b/.github/workflows/make_precompiled.yml
@@ -20,9 +20,10 @@ on:
         required: true
         default: "dropbear"
 
-#concurrency:
-# group: ${{ github.workflow }}${{ github.event.pull_request.number && '-' }}${{ github.event.pull_request.number || '' }}
-# cancel-in-progress: ${{ github.event_name == 'pull_request' && true || false }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  queue: ${{ github.event_name != 'pull_request' && 'max' || 'single' }}
 
 jobs:
 
@@ -44,11 +45,6 @@ jobs:
       matrix: ${{ steps.parse.outputs.matrix }}
 
     steps:
-
-      - uses: ahmadnassri/action-workflow-queue@v1
-        with:
-          timeout: "18000000"
-          delay: "10000"
 
       - name: clone
         env:


### PR DESCRIPTION
Dies verwendet wieder die GitHub Build-in concurrency funktion aber diesmal mit einer neuen Option die Warteschlange auf maximum zu setzen.

<img width="1278" height="548" alt="Screenshot 2026-06-22 at 16-49-53 make_precompiled · Workflow runs · LizenzFass78851_freetz-ng" src="https://github.com/user-attachments/assets/cfe3c4ff-9ba7-418f-8480-f3ec55b9fd4b" />


Die Option wurde in Mai 2026 eingeführt.
Refs: https://github.blog/changelog/2026-05-07-github-actions-concurrency-groups-now-allow-larger-queues