### PR TITLE
make_precompiled: exclude reruns for GitHub build-in concurrency to run reruns without queues

### DIFF
--- a/.github/workflows/make_precompiled.yml
+++ b/.github/workflows/make_precompiled.yml
@@ -21,7 +21,7 @@ on:
         default: "dropbear"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.run_attempt >= 2 && github.run_id || github.run_attempt }} 
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
   queue: ${{ github.event_name != 'pull_request' && 'max' || 'single' }}
 


### PR DESCRIPTION
Dies exkludiert reruns für concurrency damit bei einen rerun eines runs dies ohne das es in der Warteschlange landet durchläuft. 

refs: https://github.com/Freetz-NG/freetz-ng/pull/1538#issuecomment-4770752490