### PR TITLE
juis_bearer: Fix `HOME` path detection when run via webif

### DIFF
--- a/tools/juis_bearer
+++ b/tools/juis_bearer
@@ -3,6 +3,7 @@
 # by cuma, 2026
 
 MYPWD="$(dirname $(realpath $0))"
+[ -z "$HOME" ] && HOME="$(awk -F: -v uid="$(id -u)" '$3==uid {print $6}' /etc/passwd 2>/dev/null)"
 [ -e '/etc/.freetz-ng-version' ] && BASE="${HOME:-$(echo ~)}" || BASE="$(dirname $MYPWD)"
 DATA="$BASE/.juis_bearer"
 CERT="$DATA/cert"


### PR DESCRIPTION
Dies behebt das Problem das wenn über das WebIF das juis ausgeführt wird, das die `HOME` env fehlt und deshalb der juis_bearer den gespeicherten Token nicht abrufen konnte.

<img width="935" height="160" alt="Screenshot 2026-06-29 at 13-18-50 Freetz @fritz-bridge-lte – juis_check" src="https://github.com/user-attachments/assets/416edffa-f07a-4cd9-9412-77839b5f229e" />

refs: https://github.com/orgs/Freetz-NG/discussions/1415#discussioncomment-17468629