### PR TITLE
actions: set & correct concurrency queue for workflows [skip ci]

### DIFF
--- a/.github/workflows/avm_ftp.yml
+++ b/.github/workflows/avm_ftp.yml
@@ -13,6 +13,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
+  queue: single
 
 jobs:
   build:

--- a/.github/workflows/avm_juis-recache.yml
+++ b/.github/workflows/avm_juis-recache.yml
@@ -13,6 +13,7 @@ on:
 concurrency:
   group: avm_juis
   cancel-in-progress: true
+  queue: single
 
 jobs:
   build:

--- a/.github/workflows/avm_juis.yml
+++ b/.github/workflows/avm_juis.yml
@@ -13,6 +13,7 @@ on:
 concurrency:
   group: avm_juis
   cancel-in-progress: false
+  queue: max
 
 jobs:
   build:

--- a/.github/workflows/avm_osp.yml
+++ b/.github/workflows/avm_osp.yml
@@ -13,6 +13,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
+  queue: single
 
 jobs:
   build:

--- a/.github/workflows/dl-hosttools.yml
+++ b/.github/workflows/dl-hosttools.yml
@@ -13,6 +13,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
+  queue: single
 
 jobs:
   build:

--- a/.github/workflows/dl-toolchains.yml
+++ b/.github/workflows/dl-toolchains.yml
@@ -13,6 +13,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
+  queue: single
 
 jobs:
 

--- a/.github/workflows/github_docker.yml
+++ b/.github/workflows/github_docker.yml
@@ -15,9 +15,9 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}${{ github.event.pull_request.number && '-' }}${{ github.event.pull_request.number || '' }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' && false || true }}
-
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.run_attempt >= 2 && github.run_id || github.run_attempt }} 
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  queue: ${{ github.event_name != 'pull_request' && 'max' || 'single' }}
 
 jobs:
   matrizifizieren:

--- a/.github/workflows/github_ghpages.yml
+++ b/.github/workflows/github_ghpages.yml
@@ -15,6 +15,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
+  queue: max
 
 jobs:
   build:

--- a/.github/workflows/github_link.yml
+++ b/.github/workflows/github_link.yml
@@ -10,6 +10,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
+  queue: max
 
 jobs:
   build:

--- a/.github/workflows/github_lockdown.yml
+++ b/.github/workflows/github_lockdown.yml
@@ -5,6 +5,11 @@ on:
     types: opened
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+  queue: max
+
 jobs:
   build:
     permissions:

--- a/.github/workflows/github_stalled.yml
+++ b/.github/workflows/github_stalled.yml
@@ -9,6 +9,11 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+  queue: max
+
 jobs:
   build:
     permissions:

--- a/.github/workflows/github_zensical.yml
+++ b/.github/workflows/github_zensical.yml
@@ -17,6 +17,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
+  queue: max
 
 jobs:
   build:

--- a/.github/workflows/make_freetz.yml
+++ b/.github/workflows/make_freetz.yml
@@ -12,6 +12,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
+  queue: single
 
 jobs:
   build:

--- a/.github/workflows/make_kernel.yml
+++ b/.github/workflows/make_kernel.yml
@@ -41,6 +41,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
+  queue: max
 
 jobs:
 

--- a/.github/workflows/make_tester.yml
+++ b/.github/workflows/make_tester.yml
@@ -15,6 +15,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
+  queue: single
 
 jobs:
   build:

--- a/.github/workflows/postcommit_diffs.yml
+++ b/.github/workflows/postcommit_diffs.yml
@@ -13,6 +13,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
+  queue: single
 
 jobs:
   build:

--- a/.github/workflows/postcommit_docs.yml
+++ b/.github/workflows/postcommit_docs.yml
@@ -27,6 +27,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
+  queue: single
 
 jobs:
   build:

--- a/.github/workflows/postcommit_img.yml
+++ b/.github/workflows/postcommit_img.yml
@@ -40,6 +40,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
+  queue: max
 
 jobs:
   build:

--- a/.github/workflows/postcommit_kos.yml
+++ b/.github/workflows/postcommit_kos.yml
@@ -12,6 +12,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
+  queue: single
 
 jobs:
   build:

--- a/.github/workflows/postcommit_stats.yml
+++ b/.github/workflows/postcommit_stats.yml
@@ -23,6 +23,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
+  queue: single
 
 jobs:
   build:


### PR DESCRIPTION
Dies setzt & korrigiert für alle Workflows passende concurrency queue

Hinweis: `[skip ci]` ist gesetzt, daher sollten beim zusammenfügen (rebase merge) nicht automatisch alle workflows getriggert werden.