### PR TITLE
php: add php8

### DIFF
--- a/make/pkgs/php8/Config.in
+++ b/make/pkgs/php8/Config.in
@@ -1,0 +1,204 @@
+config FREETZ_PACKAGE_PHP8
+	bool "PHP8 (binary only)"
+	select FREETZ_PACKAGE_PHP8_cgi
+	select FREETZ_LIB_libonig
+	select FREETZ_LIB_libxml2
+	select FREETZ_LIB_libxml2_WITH_HTML
+	select FREETZ_LIB_libxml2_WITH_RELAXNG
+	default n
+	help
+		PHP: Hypertext Preprocessor
+
+		PHP is a widely-used general-purpose scripting language that is especially
+		suited for Web development and can be embedded into HTML. Much of its syntax
+		is borrowed from C, Java and Perl with a couple of unique PHP-specific features
+		thrown in. The goal of the language is to allow web developers to write
+		dynamically generated pages quickly.
+
+if FREETZ_PACKAGE_PHP8
+
+	choice
+		prompt "Version"
+
+		config FREETZ_PACKAGE_PHP8_VERSION_83
+			bool "8.3"
+
+		config FREETZ_PACKAGE_PHP8_VERSION_84
+			bool "8.4"
+
+		config FREETZ_PACKAGE_PHP8_VERSION_85
+			bool "8.5"
+
+	endchoice
+
+menu "Binaries"
+
+config FREETZ_PACKAGE_PHP8_cgi
+	bool "PHP CGI"
+	select FREETZ_LIB_libdl   if FREETZ_TARGET_UCLIBC_HAS_multiple_libs
+	select FREETZ_LIB_libpcre2
+	default y
+
+config FREETZ_PACKAGE_PHP8_cli
+	bool "PHP CLI"
+	select FREETZ_LIB_libdl   if FREETZ_TARGET_UCLIBC_HAS_multiple_libs
+	select FREETZ_LIB_libpcre2
+	default n
+
+config FREETZ_PACKAGE_PHP8_apxs2
+	bool "Apache2 module"
+	depends on !FREETZ_PACKAGE_PHP5_apxs2 && !FREETZ_PACKAGE_PHP_apxs2
+	select FREETZ_LIB_libapr_WITH_DSO
+	select FREETZ_LIB_libpcre2
+	select FREETZ_LIB_libcurl            if FREETZ_PACKAGE_PHP8_WITH_CURL
+	select FREETZ_LIB_libxml2            if FREETZ_PACKAGE_PHP8_WITH_LIBXML
+	select FREETZ_LIB_libiconv           if FREETZ_PACKAGE_PHP8_WITH_LIBICONV
+	select FREETZ_LIB_libsqlite3         if FREETZ_PACKAGE_PHP8_WITH_SQLITE3
+	select FREETZ_LIB_libcrypto          if FREETZ_PACKAGE_PHP8_WITH_SSL
+	select FREETZ_LIB_libssl             if FREETZ_PACKAGE_PHP8_WITH_SSL
+	select FREETZ_LIB_libz               if FREETZ_PACKAGE_PHP8_WITH_ZLIB
+	default n
+
+endmenu
+
+menu "PHP features"
+
+config FREETZ_PACKAGE_PHP8_WITH_CURL
+	bool "build with CURL support"
+	select FREETZ_LIB_libcurl
+	default n
+	help
+		This option enables the CURL support for PHP
+
+config FREETZ_PACKAGE_PHP8_WITH_FILEINFO
+	bool "build with FILEINFO support"
+	default n
+	help
+		This option enables the FILEINFO support for PHP
+
+config FREETZ_PACKAGE_PHP8_WITH_FTP
+	bool "build with FTP support"
+	depends on !FREETZ_PACKAGE_PHP8_VERSION_85
+	default n
+	help
+		This option enables the FTP support for PHP.
+		Note: The FTP extension was removed in PHP 8.5.
+
+config FREETZ_PACKAGE_PHP8_WITH_GD
+	bool "build with GD support"
+	select FREETZ_LIB_libpng16
+	default n
+	help
+		This option enables the bundled GD support for PHP
+
+config FREETZ_PACKAGE_PHP8_WITH_GETTEXT
+	bool "build with gettext support"
+	select FREETZ_LIB_libintl
+	default n
+	help
+		This option enables the gettext support for PHP
+
+config FREETZ_PACKAGE_PHP8_WITH_ICONV
+	bool "build with ICONV support"
+	select FREETZ_PACKAGE_PHP8_WITH_LIBICONV if FREETZ_TARGET_UCLIBC_0_9_28
+	default n
+	help
+		This option enables the ICONV support for PHP
+
+	config FREETZ_PACKAGE_PHP8_WITH_LIBICONV
+		bool "prefer libiconv to libc"
+		depends on FREETZ_PACKAGE_PHP8_WITH_ICONV
+		depends on FREETZ_TARGET_UCLIBC_0_9_28
+		select FREETZ_LIB_libiconv
+		default n
+		help
+			This option causes PHP to use libiconv implementation of iconv function
+			instead of the libc one. Select this option if you need more charsets
+			than supported by libc (ISO-8859-1 and UTF-8 only) or your application
+			relies on libiconv specific features like TRANSLIT, IGNORE, etc.
+
+config FREETZ_PACKAGE_PHP8_WITH_LIBXML
+	bool "build with XML support"
+	select FREETZ_LIB_libxml2
+	select FREETZ_LIB_libxml2_WITH_HTML
+	select FREETZ_LIB_libxml2_WITH_RELAXNG
+	default n
+	help
+		This option enables the XML, DOM, SimpleXML, XMLReader and XMLWriter
+		support for PHP.
+		Note: libxml2 is always linked into PHP regardless of this setting,
+		as PHP's core requires it internally. Disabling this option only
+		omits the higher-level XML extension APIs.
+
+config FREETZ_PACKAGE_PHP8_WITH_PCNTL
+	bool "build with PCNTL support"
+	default n
+	help
+		This option enables the PCNTL support for PHP
+
+config FREETZ_PACKAGE_PHP8_WITH_SESSION
+	bool "build with SESSION support"
+	default n
+	help
+		This option enables the SESSION support for PHP
+
+config FREETZ_PACKAGE_PHP8_WITH_SOCKETS
+	bool "build with SOCKETS support"
+	default n
+	help
+		This option enables the SOCKETS support for PHP
+
+config FREETZ_PACKAGE_PHP8_WITH_SQLITE3
+	bool "build with SQLite (v3) support"
+	select FREETZ_LIB_libsqlite3
+	default n
+	help
+		This option enables the SQLite (v3) support for PHP
+
+config FREETZ_PACKAGE_PHP8_WITH_SSL
+	bool "build with SSL support"
+	select FREETZ_LIB_libcrypto
+	select FREETZ_LIB_libssl
+	default n
+	help
+		This option enables the SSL support for PHP
+
+config FREETZ_PACKAGE_PHP8_WITH_SYSVIPC
+	bool "build with SYSVIPC support"
+	default n
+	help
+		This option enables the SYSVIPC support for PHP
+
+config FREETZ_PACKAGE_PHP8_WITH_ZLIB
+	bool "build with ZLIB support"
+	select FREETZ_LIB_libz
+	default n
+	help
+		This option enables the ZLIB support for PHP
+
+config FREETZ_PACKAGE_PHP8_WITH_ZIP
+	bool "build with ZIP support"
+	select FREETZ_LIB_libzip
+	select FREETZ_PACKAGE_PHP8_WITH_ZLIB
+	default n
+	help
+		This option enables the ZIP support for PHP
+
+config FREETZ_PACKAGE_PHP8_WITH_FFI
+	bool "build with FFI support"
+	select FREETZ_LIB_libffi
+	default n
+	help
+		This option enables the Foreign Function Interface (FFI) support for PHP
+
+config FREETZ_PACKAGE_PHP8_WITH_MYSQLI
+	bool "build with MySQLi/PDO_MySQL support (mysqlnd)"
+	default n
+	help
+		Enables the mysqli and PDO_MySQL extensions using the bundled
+		mysqlnd driver. No external MySQL library is required.
+		For SSL-encrypted connections, also enable SSL support.
+
+endmenu
+
+endif # FREETZ_PACKAGE_PHP8

--- a/make/pkgs/php8/Config.in
+++ b/make/pkgs/php8/Config.in
@@ -1,5 +1,5 @@
 config FREETZ_PACKAGE_PHP8
-	bool "PHP8 (binary only)"
+	bool "PHP8 8.3.31/8.4.22/8.5.7 (binary only)"
 	select FREETZ_PACKAGE_PHP8_cgi
 	select FREETZ_LIB_libonig
 	select FREETZ_LIB_libxml2

--- a/make/pkgs/php8/external.files
+++ b/make/pkgs/php8/external.files
@@ -1,0 +1,11 @@
+if [ "$FREETZ_PACKAGE_PHP5_cgi" = "y" ]; then
+	[ "$EXTERNAL_FREETZ_PACKAGE_PHP8_cgi" = "y" ] && EXTERNAL_FILES+=" /usr/bin/php8-cgi"
+else
+	[ "$EXTERNAL_FREETZ_PACKAGE_PHP8_cgi" = "y" ] && EXTERNAL_FILES+=" /usr/bin/php-cgi"
+fi
+if [ "$FREETZ_PACKAGE_PHP5_cli" = "y" ]; then
+	[ "$EXTERNAL_FREETZ_PACKAGE_PHP8_cli" = "y" ] && EXTERNAL_FILES+=" /usr/bin/php8"
+else
+	[ "$EXTERNAL_FREETZ_PACKAGE_PHP8_cli" = "y" ] && EXTERNAL_FILES+=" /usr/bin/php"
+fi
+[ "$EXTERNAL_FREETZ_PACKAGE_PHP8_apxs2" = "y" ] && EXTERNAL_FILES+=" /usr/lib/apache2/libphp.so"

--- a/make/pkgs/php8/external.in
+++ b/make/pkgs/php8/external.in
@@ -1,0 +1,32 @@
+config EXTERNAL_FREETZ_PACKAGE_PHP8
+	depends on EXTERNAL_ENABLED && FREETZ_PACKAGE_PHP8
+	bool "PHP8"
+	default n
+
+if EXTERNAL_FREETZ_PACKAGE_PHP8
+
+config EXTERNAL_FREETZ_PACKAGE_PHP8_cgi
+	depends on FREETZ_PACKAGE_PHP8_cgi
+	bool "PHP CGI"
+	default y
+	help
+		externals the following file(s):
+		 /usr/bin/php-cgi  (or php8-cgi if PHP5-CGI is also active)
+
+config EXTERNAL_FREETZ_PACKAGE_PHP8_cli
+	depends on FREETZ_PACKAGE_PHP8_cli
+	bool "PHP CLI"
+	default y
+	help
+		externals the following file(s):
+		 /usr/bin/php  (or php8 if PHP5-CLI is also active)
+
+config EXTERNAL_FREETZ_PACKAGE_PHP8_apxs2
+	depends on FREETZ_PACKAGE_PHP8_apxs2
+	bool "Apache2 module"
+	default y
+	help
+		externals the following file(s):
+		 /usr/lib/apache2/libphp.so
+
+endif # EXTERNAL_FREETZ_PACKAGE_PHP8

--- a/make/pkgs/php8/external.services
+++ b/make/pkgs/php8/external.services
@@ -1,0 +1,1 @@
+[ "$EXTERNAL_FREETZ_PACKAGE_PHP8_cgi" == "y" ] && EXTERNAL_SERVICES+=" php8"

--- a/make/pkgs/php8/files/.language
+++ b/make/pkgs/php8/files/.language
@@ -1,0 +1,8 @@
+languages
+{ de en }
+default
+{ en }
+files
+{
+        etc/default.php8/php8_config.def
+}

--- a/make/pkgs/php8/files/root/etc/default.php8/php.ini
+++ b/make/pkgs/php8/files/root/etc/default.php8/php.ini
@@ -1,0 +1,100 @@
+[PHP]
+date.timezone = 'Europe/Berlin'
+zend.enable_gc = On
+zend.exception_ignore_args = On
+zend.exception_string_param_max_len = 0
+short_open_tag = Off
+precision = 14
+output_buffering = 4096
+zlib.output_compression = On
+implicit_flush = Off
+unserialize_callback_func=
+serialize_precision = -1
+disable_functions =
+disable_classes =
+expose_php = Off
+max_execution_time = 30
+max_input_time = 60
+memory_limit = 16M
+error_reporting = E_ALL & ~E_DEPRECATED
+display_errors = Off
+display_startup_errors = Off
+log_errors = On
+log_errors_max_len = 1024
+ignore_repeated_errors = Off
+ignore_repeated_source = Off
+report_memleaks = On
+variables_order = "GPCS"
+request_order = "GP"
+register_argc_argv = Off
+post_max_size = 8M
+auto_prepend_file =
+auto_append_file =
+default_mimetype = "text/html"
+default_charset = "UTF-8"
+doc_root =
+user_dir =
+extension_dir =
+file_uploads = On
+upload_tmp_dir = /var/tmp/php
+upload_max_filesize = 2M
+allow_url_fopen = On
+default_socket_timeout = 60
+cgi.fix_pathinfo = 1 ;This option is relevant for lighttpd
+[Date]
+[filter]
+[iconv]
+[Pcre]
+[mail function]
+SMTP = localhost
+smtp_port = 25
+[ODBC]
+odbc.allow_persistent = On
+odbc.check_persistent = On
+odbc.max_persistent = -1
+odbc.max_links = -1
+odbc.defaultlrl = 4096
+odbc.defaultbinmode = 1
+[MySQLi]
+mysqli.max_links = -1
+mysqli.default_port = 3306
+mysqli.default_socket =
+mysqli.default_host =
+mysqli.default_user =
+mysqli.default_pw =
+[PostgresSQL]
+pgsql.allow_persistent = On
+pgsql.auto_reset_persistent = Off
+pgsql.max_persistent = -1
+pgsql.max_links = -1
+pgsql.ignore_notice = 0
+pgsql.log_notice = 0
+[bcmath]
+bcmath.scale = 0
+[browscap]
+[Session]
+session.save_handler = files
+session.use_cookies = 1
+session.name = PHPSESSID
+session.auto_start = 0
+session.cookie_lifetime = 0
+session.cookie_path = /
+session.cookie_domain =
+session.cookie_httponly =
+session.serialize_handler = php
+session.gc_probability = 1
+session.gc_divisor = 1000
+session.gc_maxlifetime = 1440
+session.referer_check =
+session.cache_limiter = nocache
+session.cache_expire = 180
+session.use_trans_sid = 0
+[Assertion]
+[mbstring]
+[gd]
+[exif]
+[Tidy]
+[soap]
+soap.wsdl_cache_enabled=1
+soap.wsdl_cache_dir="/tmp"
+soap.wsdl_cache_ttl=86400

--- a/make/pkgs/php8/files/root/etc/default.php8/php8_config.def
+++ b/make/pkgs/php8/files/root/etc/default.php8/php8_config.def
@@ -1,0 +1,8 @@
+CAPTION='php.ini'
+DESCRIPTION="$(lang de:"Die Konfigurationsparameter f&uuml;r PHP werden im Flash gespeichert. Damit diese nicht allzuviel Platz belegen sind alle Kommentare entfernt worden. Eine Dokumentation der php.ini ist auf der <a href=\"https://www.php.net/ini.core\">PHP Webseite</a> zu finden.<br />Nach erfolgter Konfiguration muss der Webserver neu gestartet werden." en:"These configuration parameters are stored in Flash RAM where there is not too much space. Therefore, all comments have been removed from the php.ini file. A documentation of the php.ini file can be found on the <a href=\"https://www.php.net/ini.core\">PHP website</a><br />After re-configuration, the webserver has to be restarted.")"
+
+CONFIG_FILE='/tmp/flash/php8/php.ini'
+CONFIG_SAVE='modsave flash'
+CONFIG_TYPE='text'
+
+TEXT_ROWS=30

--- a/make/pkgs/php8/files/root/etc/init.d/rc.php8
+++ b/make/pkgs/php8/files/root/etc/init.d/rc.php8
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+DAEMON=php8
+
+
+case $1 in
+	""|load)
+		[ ! -d /tmp/flash/$DAEMON ] && mkdir -p /tmp/flash/$DAEMON
+		[ ! -e /tmp/flash/$DAEMON/php.ini ] && cat /mod/etc/default.$DAEMON/php.ini > /tmp/flash/$DAEMON/php.ini
+
+		modreg daemon --hide $DAEMON
+		modreg file $DAEMON config 'php.ini' 0 "php8_config"
+		;;
+	unload)
+		modunreg file $DAEMON
+		modunreg daemon $DAEMON
+		;;
+	*)
+		echo "Usage: $0 [load|unload]" 1>&2
+		exit 1
+		;;
+esac
+
+exit 0

--- a/make/pkgs/php8/php8.mk
+++ b/make/pkgs/php8/php8.mk
@@ -1,0 +1,259 @@
+PHP8_VERSION_83 := 8.3.31
+PHP8_HASH_83    := 66410cee07f4b2baeb0843140bb2a2b52ef930b5cf9b3d6e6d158b33aae8fa37
+PHP8_VERSION_84 := 8.4.22
+PHP8_HASH_84    := 696c0f6ad92e94c59059c1eb6e300842b8d050934226efcdf00f2a413cb083cf
+PHP8_VERSION_85 := 8.5.7
+PHP8_HASH_85    := 01ba2ed1c2658dacf91bebc8be6a4885f69b811c7993831fc48e26107ab29985
+
+PHP8_VERSION := $(if $(FREETZ_PACKAGE_PHP8_VERSION_85),$(PHP8_VERSION_85),$(if $(FREETZ_PACKAGE_PHP8_VERSION_84),$(PHP8_VERSION_84),$(PHP8_VERSION_83)))
+PHP8_HASH    := $(if $(FREETZ_PACKAGE_PHP8_VERSION_85),$(PHP8_HASH_85),$(if $(FREETZ_PACKAGE_PHP8_VERSION_84),$(PHP8_HASH_84),$(PHP8_HASH_83)))
+
+$(call PKG_INIT_BIN, $(PHP8_VERSION))
+$(PKG)_SOURCE:=php-$($(PKG)_VERSION).tar.xz
+$(PKG)_HASH:=$(PHP8_HASH)
+$(PKG)_SITE:=https://www.php.net/distributions,https://de.php.net/distributions,https://de2.php.net/distributions
+### WEBSITE:=https://www.php.net
+### MANPAGE:=https://www.php.net/docs.php
+### CHANGES:=https://github.com/php/php-src/releases
+### CVSREPO:=https://github.com/php/php-src
+
+PHP8_CGI_NAME := $(if $(FREETZ_PACKAGE_PHP5_cgi)$(FREETZ_PACKAGE_PHP_cgi),php8-cgi,php-cgi)
+PHP8_CLI_NAME := $(if $(FREETZ_PACKAGE_PHP5_cli)$(FREETZ_PACKAGE_PHP_cli),php8,php)
+
+$(PKG)_BINARY              := $($(PKG)_DIR)/sapi/cgi/php-cgi
+$(PKG)_TARGET_BINARY       := $($(PKG)_DEST_DIR)/usr/bin/$(PHP8_CGI_NAME)
+
+$(PKG)_CLI_BINARY          := $($(PKG)_DIR)/sapi/cli/php
+$(PKG)_CLI_TARGET_BINARY   := $($(PKG)_DEST_DIR)/usr/bin/$(PHP8_CLI_NAME)
+
+$(PKG)_APXS2_BINARY        := $($(PKG)_DIR)/libs/libphp.so
+$(PKG)_APXS2_TARGET_BINARY := $($(PKG)_DEST_DIR)/usr/lib/apache2/libphp.so
+
+$(PKG)_STARTLEVEL=90 # before lighttpd
+
+$(PKG)_EXTRA_CFLAGS  := -ffunction-sections -fdata-sections
+$(PKG)_EXTRA_LDFLAGS := -Wl,--gc-sections
+
+$(PKG)_DEPENDS_ON += pcre2
+$(PKG)_CONFIGURE_OPTIONS += --with-external-pcre="$(TARGET_TOOLCHAIN_STAGING_DIR)/usr"
+$(PKG)_CONFIGURE_OPTIONS += --without-pcre-jit
+
+$(PKG)_CONFIGURE_OPTIONS += --enable-cli
+$(PKG)_EXCLUDED += $(if $(FREETZ_PACKAGE_PHP8_cli),,$($(PKG)_CLI_TARGET_BINARY))
+
+ifeq ($(strip $(FREETZ_PACKAGE_PHP8_apxs2)),y)
+$(PKG)_DEPENDS_ON += apache2
+$(PKG)_CONFIGURE_OPTIONS += --with-apxs2="$(TARGET_TOOLCHAIN_STAGING_DIR)/usr/bin/apxs"
+endif
+
+ifeq ($(strip $(FREETZ_PACKAGE_PHP8_WITH_CURL)),y)
+$(PKG)_REBUILD_SUBOPTS += $(filter FREETZ_LIB_libcurl_%,$(CURL_REBUILD_SUBOPTS))
+$(PKG)_DEPENDS_ON += curl
+$(PKG)_CONFIGURE_OPTIONS += --with-curl="$(TARGET_TOOLCHAIN_STAGING_DIR)/usr"
+endif
+
+$(PKG)_CONFIGURE_OPTIONS += $(if $(FREETZ_PACKAGE_PHP8_WITH_FILEINFO),--enable-fileinfo,--disable-fileinfo)
+
+$(PKG)_CONFIGURE_OPTIONS += $(if $(FREETZ_PACKAGE_PHP8_WITH_FTP),--enable-ftp,--disable-ftp)
+
+ifeq ($(strip $(FREETZ_PACKAGE_PHP8_WITH_GD)),y)
+$(PKG)_DEPENDS_ON += libpng
+$(PKG)_CONFIGURE_OPTIONS += --enable-gd
+endif
+
+ifeq ($(strip $(FREETZ_PACKAGE_PHP8_WITH_GETTEXT)),y)
+$(PKG)_DEPENDS_ON += gettext
+$(PKG)_CONFIGURE_OPTIONS += --with-gettext="$(TARGET_TOOLCHAIN_STAGING_DIR)/usr"
+endif
+
+ifeq ($(strip $(FREETZ_PACKAGE_PHP8_WITH_ICONV)),y)
+$(PKG)_CONFIGURE_OPTIONS += --with-iconv
+
+$(PKG)_CONFIGURE_ENV += ac_cv_func_iconv=$(if $(FREETZ_PACKAGE_PHP8_WITH_LIBICONV),no,yes)
+$(PKG)_CONFIGURE_ENV += ac_cv_func_libiconv=$(if $(FREETZ_PACKAGE_PHP8_WITH_LIBICONV),yes,no)
+
+ifeq ($(strip $(FREETZ_PACKAGE_PHP8_WITH_LIBICONV)),y)
+$(PKG)_DEPENDS_ON += iconv
+$(PKG)_CONFIGURE_ENV += iconv_impl_name=gnu_libiconv
+$(PKG)_CONFIGURE_OPTIONS += --with-iconv="$(TARGET_TOOLCHAIN_STAGING_DIR)$(LIBICONV_PREFIX)"
+$(PKG)_EXTRA_LDFLAGS += -L$(TARGET_TOOLCHAIN_STAGING_DIR)$(LIBICONV_PREFIX)/lib
+else
+$(PKG)_CONFIGURE_ENV += ICONV_IN_LIBC_DIR="$(TARGET_TOOLCHAIN_STAGING_DIR)/usr"
+$(PKG)_CONFIGURE_OPTIONS += --with-iconv="$(TARGET_TOOLCHAIN_STAGING_DIR)/usr"
+endif
+
+else
+$(PKG)_CONFIGURE_OPTIONS += --without-iconv
+endif
+
+$(PKG)_DEPENDS_ON += libxml2
+ifeq ($(strip $(FREETZ_PACKAGE_PHP8_WITH_LIBXML)),y)
+$(PKG)_CONFIGURE_OPTIONS += --with-libxml
+endif
+$(PKG)_XML_SUPPORT:=$(if $(FREETZ_PACKAGE_PHP8_WITH_LIBXML),enable,disable)
+$(PKG)_CONFIGURE_OPTIONS += --$($(PKG)_XML_SUPPORT)-xml
+$(PKG)_CONFIGURE_OPTIONS += --$($(PKG)_XML_SUPPORT)-dom
+$(PKG)_CONFIGURE_OPTIONS += --$($(PKG)_XML_SUPPORT)-simplexml
+$(PKG)_CONFIGURE_OPTIONS += --$($(PKG)_XML_SUPPORT)-xmlreader
+$(PKG)_CONFIGURE_OPTIONS += --$($(PKG)_XML_SUPPORT)-xmlwriter
+
+$(PKG)_CONFIGURE_OPTIONS += $(if $(FREETZ_PACKAGE_PHP8_WITH_PCNTL),--enable-pcntl,--disable-pcntl)
+
+$(PKG)_CONFIGURE_OPTIONS += $(if $(FREETZ_PACKAGE_PHP8_WITH_SESSION),--enable-session,--disable-session)
+
+$(PKG)_CONFIGURE_OPTIONS += $(if $(FREETZ_PACKAGE_PHP8_WITH_SOCKETS),--enable-sockets,--disable-sockets)
+
+ifeq ($(strip $(FREETZ_PACKAGE_PHP8_WITH_SQLITE3)),y)
+$(PKG)_DEPENDS_ON += sqlite
+$(PKG)_CONFIGURE_OPTIONS += --with-sqlite3="$(TARGET_TOOLCHAIN_STAGING_DIR)/usr"
+$(PKG)_CONFIGURE_OPTIONS += --with-pdo-sqlite="$(TARGET_TOOLCHAIN_STAGING_DIR)/usr"
+else
+$(PKG)_CONFIGURE_OPTIONS += --without-sqlite3
+$(PKG)_CONFIGURE_OPTIONS += --without-pdo-sqlite
+endif
+
+ifeq ($(strip $(FREETZ_PACKAGE_PHP8_WITH_SSL)),y)
+$(PKG)_REBUILD_SUBOPTS += FREETZ_OPENSSL_SHORT_VERSION
+$(PKG)_DEPENDS_ON += openssl
+$(PKG)_CONFIGURE_OPTIONS += --with-openssl="$(TARGET_TOOLCHAIN_STAGING_DIR)/usr"
+endif
+
+$(PKG)_SYSVIPC_SUPPORT:=$(if $(FREETZ_PACKAGE_PHP8_WITH_SYSVIPC),enable,disable)
+$(PKG)_CONFIGURE_OPTIONS += --$($(PKG)_SYSVIPC_SUPPORT)-sysvsem
+$(PKG)_CONFIGURE_OPTIONS += --$($(PKG)_SYSVIPC_SUPPORT)-sysvshm
+$(PKG)_CONFIGURE_OPTIONS += --$($(PKG)_SYSVIPC_SUPPORT)-sysvmsg
+
+ifeq ($(strip $(FREETZ_PACKAGE_PHP8_WITH_ZLIB)),y)
+$(PKG)_DEPENDS_ON += zlib
+$(PKG)_CONFIGURE_OPTIONS += --with-zlib
+endif
+
+ifeq ($(strip $(FREETZ_PACKAGE_PHP8_WITH_ZIP)),y)
+$(PKG)_DEPENDS_ON += libzip
+$(PKG)_CONFIGURE_OPTIONS += --with-zip
+endif
+
+ifeq ($(strip $(FREETZ_PACKAGE_PHP8_WITH_FFI)),y)
+$(PKG)_DEPENDS_ON += libffi
+$(PKG)_CONFIGURE_OPTIONS += --with-ffi
+endif
+
+ifeq ($(strip $(FREETZ_PACKAGE_PHP8_WITH_MYSQLI)),y)
+$(PKG)_CONFIGURE_OPTIONS += --with-mysqli=mysqlnd
+$(PKG)_CONFIGURE_OPTIONS += --with-pdo-mysql=mysqlnd
+else
+$(PKG)_CONFIGURE_OPTIONS += --without-mysqli
+$(PKG)_CONFIGURE_OPTIONS += --without-pdo-mysql
+endif
+
+
+$(PKG)_REBUILD_SUBOPTS += FREETZ_PACKAGE_PHP8_VERSION_83
+$(PKG)_REBUILD_SUBOPTS += FREETZ_PACKAGE_PHP8_VERSION_84
+$(PKG)_REBUILD_SUBOPTS += FREETZ_PACKAGE_PHP8_VERSION_85
+$(PKG)_REBUILD_SUBOPTS += FREETZ_PACKAGE_PHP8_apxs2
+$(PKG)_REBUILD_SUBOPTS += FREETZ_PACKAGE_PHP8_WITH_CURL
+$(PKG)_REBUILD_SUBOPTS += FREETZ_PACKAGE_PHP8_WITH_FILEINFO
+$(PKG)_REBUILD_SUBOPTS += FREETZ_PACKAGE_PHP8_WITH_FTP
+$(PKG)_REBUILD_SUBOPTS += FREETZ_PACKAGE_PHP8_WITH_GD
+$(PKG)_REBUILD_SUBOPTS += FREETZ_PACKAGE_PHP8_WITH_GETTEXT
+$(PKG)_REBUILD_SUBOPTS += FREETZ_PACKAGE_PHP8_WITH_ICONV FREETZ_PACKAGE_PHP8_WITH_LIBICONV
+$(PKG)_REBUILD_SUBOPTS += FREETZ_PACKAGE_PHP8_WITH_LIBXML FREETZ_LIB_libxml2_WITH_HTML FREETZ_LIB_libxml2_WITH_RELAXNG
+$(PKG)_REBUILD_SUBOPTS += FREETZ_PACKAGE_PHP8_WITH_PCNTL
+$(PKG)_REBUILD_SUBOPTS += FREETZ_PACKAGE_PHP8_WITH_SESSION
+$(PKG)_REBUILD_SUBOPTS += FREETZ_PACKAGE_PHP8_WITH_SOCKETS
+$(PKG)_REBUILD_SUBOPTS += FREETZ_PACKAGE_PHP8_WITH_SQLITE3
+$(PKG)_REBUILD_SUBOPTS += FREETZ_PACKAGE_PHP8_WITH_SYSVIPC
+$(PKG)_REBUILD_SUBOPTS += FREETZ_PACKAGE_PHP8_WITH_SSL
+$(PKG)_REBUILD_SUBOPTS += FREETZ_PACKAGE_PHP8_WITH_ZLIB
+$(PKG)_REBUILD_SUBOPTS += FREETZ_PACKAGE_PHP8_WITH_ZIP
+$(PKG)_REBUILD_SUBOPTS += FREETZ_PACKAGE_PHP8_WITH_FFI
+$(PKG)_REBUILD_SUBOPTS += FREETZ_PACKAGE_PHP8_WITH_MYSQLI
+$(PKG)_REBUILD_SUBOPTS += FREETZ_TARGET_IPV6_SUPPORT
+$(PKG)_REBUILD_SUBOPTS += FREETZ_LIB_libonig
+$(PKG)_REBUILD_SUBOPTS += FREETZ_PACKAGE_PHP5_cgi
+$(PKG)_REBUILD_SUBOPTS += FREETZ_PACKAGE_PHP5_cli
+$(PKG)_REBUILD_SUBOPTS += FREETZ_PACKAGE_PHP_cgi
+$(PKG)_REBUILD_SUBOPTS += FREETZ_PACKAGE_PHP_cli
+
+$(PKG)_CONFIGURE_ENV += php_cv_sizeof_ssize_t=$(if $(FREETZ_TARGET_BITS_32),4,8)
+$(PKG)_CONFIGURE_ENV += php_cv_sizeof_ptrdiff_t=4
+$(PKG)_CONFIGURE_ENV += ac_cv_c_bigendian_php=$(if $(FREETZ_TARGET_ARCH_BE),yes,no)
+$(PKG)_CONFIGURE_ENV += php_cv_sizeof_intmax_t=8
+$(PKG)_CONFIGURE_ENV += ac_cv_func_fnmatch_works=no
+$(PKG)_CONFIGURE_ENV += ac_cv_func_getaddrinfo=yes
+$(PKG)_CONFIGURE_ENV += ac_cv_func_sigsetjmp=yes
+$(PKG)_CONFIGURE_ENV += ac_cv_c_stack_direction=-1
+$(PKG)_CONFIGURE_ENV += ac_cv_ebcdic=no
+$(PKG)_CONFIGURE_ENV += ac_cv_header_atomic_h=no
+$(PKG)_CONFIGURE_ENV += ac_cv_header_stdc=yes
+$(PKG)_CONFIGURE_ENV += ac_cv_func_memcmp_clean=no
+$(PKG)_CONFIGURE_ENV += ac_cv_func_utime_null=no
+$(PKG)_CONFIGURE_ENV += ac_cv_time_r_type=POSIX
+$(PKG)_CONFIGURE_ENV += ac_cv_what_readdir_r=POSIX
+$(PKG)_CONFIGURE_ENV += ac_cv_write_stdout=yes
+$(PKG)_CONFIGURE_ENV += ac_cv_lib_gd_gdImageCreateFromXpm=no
+$(PKG)_CONFIGURE_ENV += ac_cv_lib_png_png_write_image=yes
+$(PKG)_CONFIGURE_ENV += cookie_io_functions_use_off64_t=yes
+$(PKG)_CONFIGURE_ENV += lt_cv_prog_gnu_ldcxx=yes
+$(PKG)_CONFIGURE_ENV += lt_cv_path_NM="$(TARGET_NM) -B"
+
+# prevent pdo_cv_inc_path from being cached in config.cache by renaming it to something that doesn't contain _cv_
+# caching the value breaks a version bump as it points to a directory containing the php version number in it
+$(PKG)_CONFIGURE_PRE_CMDS += $(SED) -i -r -e 's,pdo_cv_inc_path,php_pdo_inc_path,g' ./configure;
+
+$(PKG)_CONFIGURE_DEFOPTS:=n
+$(PKG)_CONFIGURE_OPTIONS += --target=$(GNU_TARGET_NAME)
+$(PKG)_CONFIGURE_OPTIONS += --host=$(GNU_TARGET_NAME)
+$(PKG)_CONFIGURE_OPTIONS += --build=$(GNU_HOST_NAME)
+$(PKG)_CONFIGURE_OPTIONS += --prefix=/usr
+$(PKG)_CONFIGURE_OPTIONS += --exec-prefix=/usr
+$(PKG)_CONFIGURE_OPTIONS += --bindir=/usr/bin
+$(PKG)_CONFIGURE_OPTIONS += --libdir=/usr/lib
+$(PKG)_CONFIGURE_OPTIONS += --with-gnu-ld
+
+$(PKG)_CONFIGURE_PRE_CMDS += $(call PKG_PREVENT_RPATH_HARDCODING,./configure)
+ifneq ($(strip $(FREETZ_TARGET_IPV6_SUPPORT)),y)
+$(PKG)_CONFIGURE_OPTIONS += --disable-ipv6
+endif
+$(PKG)_DEPENDS_ON += libonig
+$(PKG)_CONFIGURE_OPTIONS += --enable-exif
+$(PKG)_CONFIGURE_OPTIONS += --enable-mbstring
+$(PKG)_CONFIGURE_OPTIONS += --disable-phar
+$(PKG)_CONFIGURE_OPTIONS += --disable-rpath
+$(PKG)_CONFIGURE_OPTIONS += --with-config-file-path=/tmp/flash/php8
+$(PKG)_CONFIGURE_OPTIONS += --with-config-file-scan-dir=/tmp/flash/php8/conf.d
+$(PKG)_CONFIGURE_OPTIONS += --without-pear
+
+
+$(PKG_SOURCE_DOWNLOAD)
+$(PKG_UNPACKED)
+$(PKG_CONFIGURED_CONFIGURE)
+
+$($(PKG)_BINARY) $($(PKG)_CLI_BINARY) $($(PKG)_APXS2_BINARY): $($(PKG)_DIR)/.configured
+	$(SUBMAKE) -C $(PHP8_DIR) \
+		EXTRA_CFLAGS="$(PHP8_EXTRA_CFLAGS)" \
+		EXTRA_LDFLAGS_PROGRAM="$(PHP8_EXTRA_LDFLAGS)" \
+		ZEND_EXTRA_LIBS="$(PHP8_LIBS)"
+
+$($(PKG)_TARGET_BINARY): $($(PKG)_BINARY)
+	$(INSTALL_BINARY_STRIP)
+
+$($(PKG)_CLI_TARGET_BINARY): $($(PKG)_CLI_BINARY)
+	$(INSTALL_BINARY_STRIP)
+
+$($(PKG)_APXS2_TARGET_BINARY): $($(PKG)_APXS2_BINARY)
+	$(INSTALL_BINARY_STRIP)
+
+$(pkg):
+
+$(pkg)-precompiled: $($(PKG)_TARGET_BINARY) $($(PKG)_CLI_TARGET_BINARY) $(if $(FREETZ_PACKAGE_PHP8_apxs2),$($(PKG)_APXS2_TARGET_BINARY))
+
+
+$(pkg)-clean:
+	-$(SUBMAKE) -C $(PHP8_DIR) clean
+	$(RM) $(PHP8_FREETZ_CONFIG_FILE)
+
+$(pkg)-uninstall:
+	$(RM) $(PHP8_TARGET_BINARY) $(PHP8_CLI_TARGET_BINARY) $(PHP8_APXS2_TARGET_BINARY)
+
+$(PKG_FINISH)

--- a/make/pkgs/php8/php8.mk
+++ b/make/pkgs/php8/php8.mk
@@ -1,24 +1,17 @@
-PHP8_VERSION_83 := 8.3.31
-PHP8_HASH_83    := 66410cee07f4b2baeb0843140bb2a2b52ef930b5cf9b3d6e6d158b33aae8fa37
-PHP8_VERSION_84 := 8.4.22
-PHP8_HASH_84    := 696c0f6ad92e94c59059c1eb6e300842b8d050934226efcdf00f2a413cb083cf
-PHP8_VERSION_85 := 8.5.7
-PHP8_HASH_85    := 01ba2ed1c2658dacf91bebc8be6a4885f69b811c7993831fc48e26107ab29985
-
-PHP8_VERSION := $(if $(FREETZ_PACKAGE_PHP8_VERSION_85),$(PHP8_VERSION_85),$(if $(FREETZ_PACKAGE_PHP8_VERSION_84),$(PHP8_VERSION_84),$(PHP8_VERSION_83)))
-PHP8_HASH    := $(if $(FREETZ_PACKAGE_PHP8_VERSION_85),$(PHP8_HASH_85),$(if $(FREETZ_PACKAGE_PHP8_VERSION_84),$(PHP8_HASH_84),$(PHP8_HASH_83)))
-
-$(call PKG_INIT_BIN, $(PHP8_VERSION))
+$(call PKG_INIT_BIN, $(if $(FREETZ_PACKAGE_PHP8_VERSION_85),8.5.7,$(if $(FREETZ_PACKAGE_PHP8_VERSION_84),8.4.22,8.3.31)))
 $(PKG)_SOURCE:=php-$($(PKG)_VERSION).tar.xz
-$(PKG)_HASH:=$(PHP8_HASH)
+$(PKG)_HASH_83:=66410cee07f4b2baeb0843140bb2a2b52ef930b5cf9b3d6e6d158b33aae8fa37
+$(PKG)_HASH_84:=696c0f6ad92e94c59059c1eb6e300842b8d050934226efcdf00f2a413cb083cf
+$(PKG)_HASH_85:=01ba2ed1c2658dacf91bebc8be6a4885f69b811c7993831fc48e26107ab29985
+$(PKG)_HASH:=$(if $(FREETZ_PACKAGE_PHP8_VERSION_85),$(PHP8_HASH_85),$(if $(FREETZ_PACKAGE_PHP8_VERSION_84),$(PHP8_HASH_84),$(PHP8_HASH_83)))
 $(PKG)_SITE:=https://www.php.net/distributions,https://de.php.net/distributions,https://de2.php.net/distributions
 ### WEBSITE:=https://www.php.net
 ### MANPAGE:=https://www.php.net/docs.php
 ### CHANGES:=https://github.com/php/php-src/releases
 ### CVSREPO:=https://github.com/php/php-src
 
-PHP8_CGI_NAME := $(if $(FREETZ_PACKAGE_PHP5_cgi)$(FREETZ_PACKAGE_PHP_cgi),php8-cgi,php-cgi)
-PHP8_CLI_NAME := $(if $(FREETZ_PACKAGE_PHP5_cli)$(FREETZ_PACKAGE_PHP_cli),php8,php)
+$(PKG)_CGI_NAME := $(if $(FREETZ_PACKAGE_PHP5_cgi)$(FREETZ_PACKAGE_PHP_cgi),php8-cgi,php-cgi)
+$(PKG)_CLI_NAME := $(if $(FREETZ_PACKAGE_PHP5_cli)$(FREETZ_PACKAGE_PHP_cli),php8,php)
 
 $(PKG)_BINARY              := $($(PKG)_DIR)/sapi/cgi/php-cgi
 $(PKG)_TARGET_BINARY       := $($(PKG)_DEST_DIR)/usr/bin/$(PHP8_CGI_NAME)


### PR DESCRIPTION
Dies fügt php8 aus den Patch von https://github.com/orgs/Freetz-NG/discussions/1541#discussion-10333942 hinzu.