### PR TITLE
php: backport patches from php8.5

### DIFF
--- a/make/pkgs/php/patches/8.2/200-copy_file_range-check.patch
+++ b/make/pkgs/php/patches/8.2/200-copy_file_range-check.patch
@@ -1,0 +1,11 @@
+--- configure.ac
++++ configure.ac
+@@ -707,7 +707,7 @@
+ dnl on FreeBSD, copy_file_range() works only with the undocumented flag 0x01000000;
+ dnl until the problem is fixed properly, copy_file_range() is used only on Linux
+ AC_CACHE_CHECK([for copy_file_range], ac_cv_copy_file_range,
+-[AC_RUN_IFELSE([AC_LANG_SOURCE([[
++[AC_LINK_IFELSE([AC_LANG_SOURCE([
+ #ifdef __linux__
+ #ifndef _GNU_SOURCE
+ #define _GNU_SOURCE

--- a/make/pkgs/php/patches/8.2/300-no_ldcxx.patch
+++ b/make/pkgs/php/patches/8.2/300-no_ldcxx.patch
@@ -1,6 +1,6 @@
---- configure
-+++ configure
-@@ -101958,7 +101958,7 @@
+--- build/libtool.m4
++++ build/libtool.m4
+@@ -3810,7 +3810,7 @@
  GCC=$lt_save_GCC
  with_gnu_ldcxx=$with_gnu_ld
  with_gnu_ld=$lt_save_with_gnu_ld

--- a/make/pkgs/php/patches/8.3/200-copy_file_range-check.patch
+++ b/make/pkgs/php/patches/8.3/200-copy_file_range-check.patch
@@ -1,0 +1,11 @@
+--- configure.ac
++++ configure.ac
+@@ -722,7 +722,7 @@
+ dnl on FreeBSD, copy_file_range() works only with the undocumented flag 0x01000000;
+ dnl until the problem is fixed properly, copy_file_range() is used only on Linux
+ AC_CACHE_CHECK([for copy_file_range], ac_cv_copy_file_range,
+-[AC_RUN_IFELSE([AC_LANG_SOURCE([[
++[AC_LINK_IFELSE([AC_LANG_SOURCE([
+ #ifdef __linux__
+ #ifndef _GNU_SOURCE
+ #define _GNU_SOURCE

--- a/make/pkgs/php/patches/8.3/300-no_ldcxx.patch
+++ b/make/pkgs/php/patches/8.3/300-no_ldcxx.patch
@@ -1,6 +1,6 @@
---- configure
-+++ configure
-@@ -100235,7 +100235,7 @@
+--- build/libtool.m4
++++ build/libtool.m4
+@@ -3810,7 +3810,7 @@
  GCC=$lt_save_GCC
  with_gnu_ldcxx=$with_gnu_ld
  with_gnu_ld=$lt_save_with_gnu_ld

--- a/make/pkgs/php/patches/8.4/200-copy_file_range-check.patch
+++ b/make/pkgs/php/patches/8.4/200-copy_file_range-check.patch
@@ -1,0 +1,11 @@
+--- configure.ac
++++ configure.ac
+@@ -664,7 +664,7 @@
+ dnl on FreeBSD, copy_file_range() works only with the undocumented flag 0x01000000;
+ dnl until the problem is fixed properly, copy_file_range() is used only on Linux
+ AC_CACHE_CHECK([for copy_file_range], [php_cv_func_copy_file_range],
+-[AC_COMPILE_IFELSE([AC_LANG_SOURCE([
++[AC_LINK_IFELSE([AC_LANG_SOURCE([
+ #ifndef __linux__
+ # error "unsupported platform"
+ #endif

--- a/make/pkgs/php/patches/8.4/300-no_ldcxx.patch
+++ b/make/pkgs/php/patches/8.4/300-no_ldcxx.patch
@@ -1,6 +1,6 @@
---- configure
-+++ configure
-@@ -93097,7 +93097,7 @@
+--- build/libtool.m4
++++ build/libtool.m4
+@@ -3810,7 +3810,7 @@
  GCC=$lt_save_GCC
  with_gnu_ldcxx=$with_gnu_ld
  with_gnu_ld=$lt_save_with_gnu_ld

--- a/make/pkgs/php/patches/8.4/400-no-host-apache-checks.patch
+++ b/make/pkgs/php/patches/8.4/400-no-host-apache-checks.patch
@@ -1,0 +1,20 @@
+--- sapi/apache2handler/config.m4
++++ sapi/apache2handler/config.m4
+@@ -33,7 +33,7 @@
+ 
+   APXS_INCLUDEDIR=$($APXS -q INCLUDEDIR)
+   APXS_HTTPD=$($APXS -q SBINDIR)/$($APXS -q TARGET)
+-  AS_IF([test ! -x "$APXS_HTTPD"], [AC_MSG_ERROR(m4_text_wrap([
++  AS_IF([false], [AC_MSG_ERROR(m4_text_wrap([
+     $APXS_HTTPD executable not found. Please, install Apache HTTP Server
+     command-line utility.
+   ]))])
+@@ -120,7 +120,7 @@
+       -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1
+     ])
+ 
+-  AS_IF([$APXS_HTTPD -V 2>/dev/null | grep 'threaded:.*yes' >/dev/null 2>&1], [
++  AS_IF([false], [
+     APACHE_THREADED_MPM=yes
+     enable_zts=yes
+   ], [APACHE_THREADED_MPM=no])


### PR DESCRIPTION
Dies wendet die änderungen aus https://github.com/Freetz-NG/freetz-ng/commit/0e9e26cd9d6d2db0d533ccab0618cf89de23a93f und https://github.com/Freetz-NG/freetz-ng/commit/21bd16b18646fa85cd55cce1d584c850d56ce482 die patches für php 8.2 - 8.4 an.
refs: https://github.com/orgs/Freetz-NG/discussions/1541#discussioncomment-17841458

Ich hatte schon in https://github.com/Freetz-NG/freetz-ng/pull/1554#issuecomment-5083790420 php8.2 bis 8.4 grundlegend getestet. 
Allerdings vor den Änderungen seit nach der Zusammenfügung von https://github.com/Freetz-NG/freetz-ng/pull/1554

> <details><summary>Mit einer 7520 FOS8.02 getestet funktioniert auch das ausführen der php cli von Version 8.2 bis 8.4</summary>
> <p>
> 
> ```
> root@fritz-bridge-lte:/var/mod/root# php --version
> PHP 8.2.32 (cli) (built: Jul 26 2026 14:30:40) (NTS)
> Copyright (c) The PHP Group
> Zend Engine v4.2.32, Copyright (c) Zend Technologies
> root@fritz-bridge-lte:/var/mod/root# php fb_tools.php
> fb_tools.php <http://user:pass@fritz.box:port#otp> [mode] <Parameter> ... <Option>
> 
> Weitere Hilfe bekommen Sie mit --help oder mehr Hilfe mit -h:all
> ```
> 
> ```
> root@fritz-bridge-lte:/var/mod/root# php --version
> PHP 8.3.32 (cli) (built: Jul 26 2026 15:29:52) (NTS)
> Copyright (c) The PHP Group
> Zend Engine v4.3.32, Copyright (c) Zend Technologies
> root@fritz-bridge-lte:/var/mod/root# php fb_tools.php
> fb_tools.php <http://user:pass@fritz.box:port#otp> [mode] <Parameter> ... <Option>
> 
> Weitere Hilfe bekommen Sie mit --help oder mehr Hilfe mit -h:all
> ```
> 
> ```
> root@fritz-bridge-lte:/var/mod/root# php --version
> PHP 8.4.23 (cli) (built: Jul 26 2026 15:43:34) (NTS)
> Copyright (c) The PHP Group
> Zend Engine v4.4.23, Copyright (c) Zend Technologies
> root@fritz-bridge-lte:/var/mod/root# php fb_tools.php
> fb_tools.php <http://user:pass@fritz.box:port#otp> [mode] <Parameter> ... <Option>
> 
> Weitere Hilfe bekommen Sie mit --help oder mehr Hilfe mit -h:all
> ```
> 
> ```
> root@fritz-bridge-lte:/var/mod/root# php --version
> PHP 8.5.8 (cli) (built: Jul 26 2026 15:53:27) (NTS)
> Copyright (c) The PHP Group
> Zend Engine v4.5.8, Copyright (c) Zend Technologies
>     with Zend OPcache v8.5.8, Copyright (c), by Zend Technologies
> ```
> 
> </p>
> </details> 