### PR TITLE
binutils: `disable-gprofng`

### DIFF
--- a/make/toolchain/target/binutils/binutils.mk
+++ b/make/toolchain/target/binutils/binutils.mk
@@ -66,6 +66,7 @@ $(BINUTILS_DIR1)/.configured: $(BINUTILS_DIR)/.unpacked
 		--target=$(REAL_GNU_TARGET_NAME) \
 		--disable-multilib \
 		--disable-libssp \
+		--disable-gprofng \
 		$(DISABLE_NLS) \
 		--disable-werror \
 		$(SILENT) \


### PR DESCRIPTION
Dies behebt das bauen der aktuellen Firmware (7.50) für FB6490 Cable:

<details><summary>Error Output</summary>
<p>


```
---> toolchain/target/binutils ...
building ... make -j5 MAKEINFO=true -C /workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1-build configure-host
make  all-am
make[4]: Nothing to be done for 'all'.
true "AR_FLAGS=rc" "CC_FOR_BUILD=gcc" "CFLAGS=-D_GNU_SOURCE -fno-stack-protector --std=gnu11  " "CXXFLAGS=-g -O2  " "CFLAGS_FOR_BUILD=-D_GNU_SOURCE -fno-stack-protector --std=gnu11" "CFLAGS_FOR_TARGET=-g -O2" "INSTALL=/usr/bin/install -c" "INSTALL_DATA=/usr/bin/install -c -m 644" "INSTALL_PROGRAM=/usr/bin/install -c" "INSTALL_SCRIPT=/usr/bin/install -c" "LDFLAGS=" "LIBCFLAGS=-D_GNU_SOURCE -fno-stack-protector --std=gnu11  " "LIBCFLAGS_FOR_TARGET=-g -O2" "MAKE=make" "MAKEINFO=true --split-size=5000000 " "PICFLAG=" "PICFLAG_FOR_TARGET=" "SHELL=/bin/bash" "EXPECT=expect" "RUNTEST=runtest" "RUNTESTFLAGS=" "exec_prefix=/workspaces/freetz-ng/toolchain/build/i686_gcc-13.4.0_uClibc-1.0.58-nptl/i686-linux-uclibc/usr" "infodir=/workspaces/freetz-ng/toolchain/build/i686_gcc-13.4.0_uClibc-1.0.58-nptl/i686-linux-uclibc/usr/share/info" "libdir=/workspaces/freetz-ng/toolchain/build/i686_gcc-13.4.0_uClibc-1.0.58-nptl/i686-linux-uclibc/usr/lib" "prefix=/workspaces/freetz-ng/toolchain/build/i686_gcc-13.4.0_uClibc-1.0.58-nptl/i686-linux-uclibc/usr" "tooldir=/workspaces/freetz-ng/toolchain/build/i686_gcc-13.4.0_uClibc-1.0.58-nptl/i686-linux-uclibc/usr/i686-linux-uclibc" "AR=ar --plugin /usr/libexec/gcc/x86_64-linux-gnu/15/liblto_plugin.so" "AS=as" "CC=gcc" "CXX=g++" "LD=/usr/bin/x86_64-linux-gnu-ld" "LIBCFLAGS=-D_GNU_SOURCE -fno-stack-protector --std=gnu11  " "NM=nm" "PICFLAG=" "RANLIB=ranlib --plugin /usr/libexec/gcc/x86_64-linux-gnu/15/liblto_plugin.so" "DESTDIR=" DO=all multi-do # make
Making info in po
make[4]: Nothing to be done for 'info'.
  MAKEINFO doc/bfd.info
make  all-recursive
Making all in po
make[5]: Nothing to be done for 'all'.
  MAKEINFO doc/bfd.info
make -j5 MAKEINFO=true -C /workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1-build all 
make[3]: Nothing to be done for 'all-target'.
make[4]: Nothing to be done for 'all'.
make  all-am
make[5]: Nothing to be done for 'all'.
true "AR_FLAGS=rc" "CC_FOR_BUILD=gcc" "CFLAGS=-D_GNU_SOURCE -fno-stack-protector --std=gnu11    " "CXXFLAGS=-g -O2    " "CFLAGS_FOR_BUILD=-D_GNU_SOURCE -fno-stack-protector --std=gnu11" "CFLAGS_FOR_TARGET=-g -O2" "INSTALL=/usr/bin/install -c" "INSTALL_DATA=/usr/bin/install -c -m 644" "INSTALL_PROGRAM=/usr/bin/install -c" "INSTALL_SCRIPT=/usr/bin/install -c" "LDFLAGS=" "LIBCFLAGS=-D_GNU_SOURCE -fno-stack-protector --std=gnu11  " "LIBCFLAGS_FOR_TARGET=-g -O2" "MAKE=make""MAKEINFO=true --split-size=5000000 --split-size=5000000 " "PICFLAG=" "PICFLAG_FOR_TARGET=" "SHELL=/bin/bash" "EXPECT=expect" "RUNTEST=runtest" "RUNTESTFLAGS=" "exec_prefix=/workspaces/freetz-ng/toolchain/build/i686_gcc-13.4.0_uClibc-1.0.58-nptl/i686-linux-uclibc/usr" "infodir=/workspaces/freetz-ng/toolchain/build/i686_gcc-13.4.0_uClibc-1.0.58-nptl/i686-linux-uclibc/usr/share/info" "libdir=/workspaces/freetz-ng/toolchain/build/i686_gcc-13.4.0_uClibc-1.0.58-nptl/i686-linux-uclibc/usr/lib" "prefix=/workspaces/freetz-ng/toolchain/build/i686_gcc-13.4.0_uClibc-1.0.58-nptl/i686-linux-uclibc/usr" "tooldir=/workspaces/freetz-ng/toolchain/build/i686_gcc-13.4.0_uClibc-1.0.58-nptl/i686-linux-uclibc/usr/i686-linux-uclibc" "AR=ar --plugin /usr/libexec/gcc/x86_64-linux-gnu/15/liblto_plugin.so" "AS=as" "CC=gcc" "CXX=g++" "LD=/usr/bin/x86_64-linux-gnu-ld" "LIBCFLAGS=-D_GNU_SOURCE -fno-stack-protector --std=gnu11  " "NM=nm" "PICFLAG=" "RANLIB=ranlib --plugin /usr/libexec/gcc/x86_64-linux-gnu/15/liblto_plugin.so" "DESTDIR=" DO=all multi-do # make
Making info in po
make[5]: Nothing to be done for 'info'.
  MAKEINFO doc/bfd.info
make  all-recursive
Making all in po
make[6]: Nothing to be done for 'all'.
  MAKEINFO doc/bfd.info
make  all-recursive
make  all-recursive
Making all in .
Making all in po
make[6]: Nothing to be done for 'all'.
make  all-recursive
Making all in po
make[6]: Nothing to be done for 'all'.
  GEN      doc/asconfig.texi
make jdk_inc="" LD_NO_AS_NEEDED="-Wl,--no-as-needed" GPROFNG_CFLAGS="-Wall" GPROFNG_CPPFLAGS="-U_ASM" all-recursive
Making all in libcollector
make  all-recursive
Making info in po
make[5]: Nothing to be done for 'info'.
make  all-am
Making all in po
make[6]: Nothing to be done for 'all'.
/bin/bash ./libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I. -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector  -U_ASM -I.. -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../common -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../src -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../../include  -I../../bfd -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../..  -Wall -Wno-nonnull-compare -D_GNU_SOURCE -fno-stack-protector --std=gnu11     -MT libgp_collector_la-iolib.lo -MD -MP -MF .deps/libgp_collector_la-iolib.Tpo -c -o libgp_collector_la-iolib.lo `test -f 'iolib.c' || echo '/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/'`iolib.c
/bin/bash ./libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I. -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector  -U_ASM -I.. -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../common -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../src -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../../include  -I../../bfd -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../..  -Wall -Wno-nonnull-compare -D_GNU_SOURCE -fno-stack-protector --std=gnu11     -MT libgp_collector_la-envmgmt.lo -MD -MP -MF .deps/libgp_collector_la-envmgmt.Tpo -c -o libgp_collector_la-envmgmt.lo `test -f 'envmgmt.c' || echo '/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/'`envmgmt.c
/bin/bash ./libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I. -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector  -U_ASM -I.. -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../common -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../src -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../../include  -I../../bfd -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../..  -Wall -Wno-nonnull-compare -D_GNU_SOURCE -fno-stack-protector --std=gnu11     -MT libgp_collector_la-linetrace.lo -MD -MP -MF .deps/libgp_collector_la-linetrace.Tpo -c -o libgp_collector_la-linetrace.lo `test -f 'linetrace.c' || echo '/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/'`linetrace.c
make[5]: Nothing to be done for 'info-am'.
make  all-recursive
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector -U_ASM -I.. -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../common -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../src -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../../include -I../../bfd -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../.. -Wall -Wno-nonnull-compare -D_GNU_SOURCE -fno-stack-protector --std=gnu11 -MT libgp_collector_la-iolib.lo -MD -MP -MF .deps/libgp_collector_la-iolib.Tpo -c /workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/iolib.c  -fPIC -DPIC -o .libs/libgp_collector_la-iolib.o
/bin/bash ./libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I. -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector  -U_ASM -I.. -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../common -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../src -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../../include  -I../../bfd -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../..  -Wall -Wno-nonnull-compare -D_GNU_SOURCE -fno-stack-protector --std=gnu11     -MT libgp_collector_la-libcol_hwcdrv.lo -MD -MP -MF .deps/libgp_collector_la-libcol_hwcdrv.Tpo -c -o libgp_collector_la-libcol_hwcdrv.lo `test -f 'libcol_hwcdrv.c' || echo '/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/'`libcol_hwcdrv.c
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector -U_ASM -I.. -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../common -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../src -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../../include -I../../bfd -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../.. -Wall -Wno-nonnull-compare -D_GNU_SOURCE -fno-stack-protector --std=gnu11 -MT libgp_collector_la-linetrace.lo -MD -MP -MF .deps/libgp_collector_la-linetrace.Tpo -c /workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/linetrace.c  -fPIC -DPIC -o .libs/libgp_collector_la-linetrace.o
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector -U_ASM -I.. -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../common -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../src -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../../include -I../../bfd -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../.. -Wall -Wno-nonnull-compare -D_GNU_SOURCE -fno-stack-protector --std=gnu11 -MT libgp_collector_la-envmgmt.lo -MD -MP -MF .deps/libgp_collector_la-envmgmt.Tpo -c /workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/envmgmt.c  -fPIC -DPIC -o .libs/libgp_collector_la-envmgmt.o
Making all in po
make[6]: Nothing to be done for 'all'.
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector -U_ASM -I.. -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../common -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../src -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../../include -I../../bfd -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../.. -Wall -Wno-nonnull-compare -D_GNU_SOURCE -fno-stack-protector --std=gnu11 -MT libgp_collector_la-libcol_hwcdrv.lo -MD -MP -MF .deps/libgp_collector_la-libcol_hwcdrv.Tpo -c /workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/libcol_hwcdrv.c  -fPIC -DPIC -o .libs/libgp_collector_la-libcol_hwcdrv.o
In file included from /usr/include/features.h:539,
                 from /usr/include/dlfcn.h:22,
                 from /workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/iolib.c:22:
/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/iolib.c: In function 'is_not_the_log_file':
/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/iolib.c:898:18: error: expected identifier before '_Generic'
  898 |   if (CALL_UTIL (strstr)(fname, SP_LOG_FILE) == NULL)
      |                  ^~~~~~
/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/iolib.c:898:7: note: in expansion of macro 'CALL_UTIL'
  898 |   if (CALL_UTIL (strstr)(fname, SP_LOG_FILE) == NULL)
      |       ^~~~~~~~~
/bin/bash ./libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I. -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector  -U_ASM -I.. -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../common -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../src -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../../include  -I../../bfd -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../..  -Wall -Wno-nonnull-compare -D_GNU_SOURCE -fno-stack-protector --std=gnu11     -MT libgp_collector_la-libcol_hwcfuncs.lo -MD -MP -MF .deps/libgp_collector_la-libcol_hwcfuncs.Tpo -c -o libgp_collector_la-libcol_hwcfuncs.lo `test -f 'libcol_hwcfuncs.c' || echo '/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/'`libcol_hwcfuncs.c
make[7]: *** [Makefile:645: libgp_collector_la-iolib.lo] Error 1
make[7]: *** Waiting for unfinished jobs....
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector -U_ASM -I.. -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../common -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../src -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../../include -I../../bfd -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../.. -Wall -Wno-nonnull-compare -D_GNU_SOURCE -fno-stack-protector --std=gnu11 -MT libgp_collector_la-libcol_hwcfuncs.lo -MD -MP -MF .deps/libgp_collector_la-libcol_hwcfuncs.Tpo -c /workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/libcol_hwcfuncs.c  -fPIC -DPIC -o .libs/libgp_collector_la-libcol_hwcfuncs.o
make  all-recursive
In file included from /usr/include/features.h:539,
                 from /usr/include/x86_64-linux-gnu/bits/libc-header-start.h:33,
                 from /usr/include/string.h:26,
                 from /workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/linetrace.c:26:
/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/linetrace.c: In function '__collector_ext_line_install':
/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/linetrace.c:219:45: error: expected identifier before '_Generic'
  219 |   if (java_follow_env != NULL && CALL_UTIL (strstr)(java_follow_env, COLLECTOR_JVMTI_OPTION))
      |                                             ^~~~~~
/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/linetrace.c:219:34: note: in expansion of macro 'CALL_UTIL'
  219 |   if (java_follow_env != NULL && CALL_UTIL (strstr)(java_follow_env, COLLECTOR_JVMTI_OPTION))
      |                                  ^~~~~~~~~
/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/linetrace.c: In function 'build_experiment_path':
/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/linetrace.c:553:30: error: expected identifierbefore '_Generic'
  553 |   const char *p = CALL_UTIL (strstr)(linetrace_exp_dir_name, DESCENDANT_EXPT_KEY);
      |                              ^~~~~~
/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/linetrace.c:553:19: note: in expansion of macro 'CALL_UTIL'
  553 |   const char *p = CALL_UTIL (strstr)(linetrace_exp_dir_name, DESCENDANT_EXPT_KEY);
      |                   ^~~~~~~~~
/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/linetrace.c: In function 'linetrace_ext_exec_prologue_end':
/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/linetrace.c:970:19: error: expected identifier before '_Generic'
  970 |   if (!CALL_UTIL (strstr)(variant, "posix_spawn"))
      |                   ^~~~~~
/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/linetrace.c:970:8: note: in expansion of macro'CALL_UTIL'
  970 |   if (!CALL_UTIL (strstr)(variant, "posix_spawn"))
      |        ^~~~~~~~~
/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/linetrace.c:976:18: error: expected identifier before '_Generic'
  976 |   if (CALL_UTIL (strstr)(variant, "posix_spawn"))
      |                  ^~~~~~
/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/linetrace.c:976:7: note: in expansion of macro 'CALL_UTIL'
  976 |   if (CALL_UTIL (strstr)(variant, "posix_spawn"))
      |       ^~~~~~~~~
/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/linetrace.c: In function 'linetrace_ext_exec_epilogue':
/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/linetrace.c:1030:19: error: expected identifier before '_Generic'
 1030 |   if (!CALL_UTIL (strstr)(variant, "posix_spawn"))
      |                   ^~~~~~
/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/linetrace.c:1030:8: note: in expansion of macro 'CALL_UTIL'
 1030 |   if (!CALL_UTIL (strstr)(variant, "posix_spawn"))
      |        ^~~~~~~~~
/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/linetrace.c:1036:18: error: expected identifier before '_Generic'
 1036 |   if (CALL_UTIL (strstr)(variant, "posix_spawn"))
      |                  ^~~~~~
/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/linetrace.c:1036:7: note: in expansion of macro 'CALL_UTIL'
 1036 |   if (CALL_UTIL (strstr)(variant, "posix_spawn"))
      |       ^~~~~~~~~
/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/linetrace.c:1053:19: error: expected identifier before '_Generic'
 1053 |   if (!CALL_UTIL (strstr)(variant, "posix_spawn"))
      |                   ^~~~~~
/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/linetrace.c:1053:8: note: in expansion of macro 'CALL_UTIL'
 1053 |   if (!CALL_UTIL (strstr)(variant, "posix_spawn"))
      |        ^~~~~~~~~
Making all in po
make[6]: Nothing to be done for 'all'.
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector -U_ASM -I.. -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../common -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../src -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../../include -I../../bfd -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../.. -Wall -Wno-nonnull-compare -D_GNU_SOURCE -fno-stack-protector --std=gnu11 -MT libgp_collector_la-libcol_hwcfuncs.lo -MD -MP -MF .deps/libgp_collector_la-libcol_hwcfuncs.Tpo -c /workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/libcol_hwcfuncs.c -o libgp_collector_la-libcol_hwcfuncs.o >/dev/null 2>&1
make[7]: *** [Makefile:687: libgp_collector_la-linetrace.lo] Error 1
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector -U_ASM -I.. -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../common -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../src -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../../include -I../../bfd -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../.. -Wall -Wno-nonnull-compare -D_GNU_SOURCE -fno-stack-protector --std=gnu11 -MT libgp_collector_la-envmgmt.lo -MD -MP -MF .deps/libgp_collector_la-envmgmt.Tpo -c /workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/envmgmt.c -o libgp_collector_la-envmgmt.o >/dev/null 2>&1
mv -f .deps/libgp_collector_la-libcol_hwcfuncs.Tpo .deps/libgp_collector_la-libcol_hwcfuncs.Plo
mv -f .deps/libgp_collector_la-envmgmt.Tpo .deps/libgp_collector_la-envmgmt.Plo
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector -U_ASM -I.. -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../common -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../src -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../../include -I../../bfd -I/workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/../.. -Wall -Wno-nonnull-compare -D_GNU_SOURCE -fno-stack-protector --std=gnu11 -MT libgp_collector_la-libcol_hwcdrv.lo -MD -MP -MF .deps/libgp_collector_la-libcol_hwcdrv.Tpo -c /workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1/gprofng/libcollector/libcol_hwcdrv.c -o libgp_collector_la-libcol_hwcdrv.o >/dev/null 2>&1
mv -f .deps/libgp_collector_la-libcol_hwcdrv.Tpo .deps/libgp_collector_la-libcol_hwcdrv.Plo
make[6]: *** [Makefile:478: all] Error 2
make[5]: *** [Makefile:472: all-recursive] Error 1
make[4]: *** [Makefile:404: all] Error 2
make[3]: *** [Makefile:7318: all-gprofng] Error 2
make[2]: *** [Makefile:1028: all] Error 2
make[1]: *** [make/toolchain/target/binutils/binutils.mk:78: /workspaces/freetz-ng/source/toolchain-i686_gcc-13.4.0_uClibc-1.0.58-nptl/binutils-2.43.1-build/.compiled] Error 2
make: *** [Makefile:49: envira] Terminated
```


</p>
</details> 