### PR TITLE
fwmod: add color settings (pt. 1)

### DIFF
--- a/config/ui/fwmod.in
+++ b/config/ui/fwmod.in
@@ -5,6 +5,23 @@ menu "Firmware packaging (fwmod) options"
 		depends on FREETZ_FWMOD_SKIP_UNPACK
 		depends on !FREETZ_FWMOD_SKIP_ALL
 
+
+	choice
+		prompt "Color Options"
+		default FREETZ_FWMOD_COLOR_USE_FONT
+
+		config FREETZ_FWMOD_COLOR_USE_FONT
+			bool "Use Font Color"
+			help
+				Recommended for Dark Terminal Themes
+
+		config FREETZ_FWMOD_COLOR_USE_BG
+			bool "Use Background Color"
+			help
+				Recommended for Light Terminal Themes
+	
+	endchoice
+
 	config FREETZ_FWMOD_SKIP_ALL
 		bool
 		depends on FREETZ_FWMOD_SKIP_UNPACK && FREETZ_FWMOD_SKIP_MODIFY && FREETZ_FWMOD_SKIP_PACK && !FREETZ_FWMOD_USBROOT && !FREETZ_FWMOD_NFSROOT

--- a/fwmod
+++ b/fwmod
@@ -237,6 +237,11 @@ sed -nr 's/^([^=]+)=(.*)/: ${\1:=\2}/p' "$DOT_CONFIG" > "$DOT_CONFIG.fwmod"
 source "$DOT_CONFIG.fwmod"
 rm "$DOT_CONFIG.fwmod"
 
+# Reinitialize fwmod colors after config has been loaded.
+# This ensures the USE_BG option is applied even when the config
+# is sourced after tools/freetz_functions.
+init_freetz_fwmod_colors 2>/dev/null || true
+
 # Verbosity level of fwmod
 FREETZ_VERBOSITY_LEVEL="$FREETZ_VERBOSITY_FWMOD"
 # Set default verbosity level, just in case none was defined in the (possibly
@@ -286,8 +291,8 @@ fi
 # $3 (key) public key, format: "EXPONENTxMODULUS". If no EXPONENT is given, default 010001 will be used (as in all images at the moment)
 validate_signature() {
 	echo -n "checking signature: "
-	[ "$1" != "1" ] && echo -e "\033[1;33mdisabled\033[0m" &&  return
-	[ -z "$3" ] && echo -e "\033[1;34munknown\033[0m" &&  error 1 "no public key available to validate signature"
+	[ "$1" != "1" ] && echo -e "${FREETZ_FWMOD_COLOR_YELLOW}disabled${FREETZ_FWMOD_COLOR_RESET}" &&  return
+	[ -z "$3" ] && echo -e "${FREETZ_FWMOD_COLOR_BLUE}unknown${FREETZ_FWMOD_COLOR_RESET}" &&  error 1 "no public key available to validate signature"
 	# var
 	local TMP="$(mktemp -dt freetz-sig-XXX)"
 	local MOD="${3#*x}"
@@ -297,7 +302,7 @@ validate_signature() {
 		echo -e "$MOD\n$EXP" > "$TMP/sig"
 		${TOOLS_DIR}/yf/signimage/yf_check_signature "$2" -a "$TMP/sig" 2> "$TMP/out"
 		RET=$?
-		[ $RET -ne 0 ] && echo -e "\033[0;31mfailed\033[0m" && cat "$TMP/out"
+		[ $RET -ne 0 ] && echo -e "${FREETZ_FWMOD_COLOR_RED}failed${FREETZ_FWMOD_COLOR_RESET}" && cat "$TMP/out"
 		rm -rf "$TMP"
 		[ $RET -ne 0 ] && error $RET "image could not be verified with public key"
 	else
@@ -333,9 +338,9 @@ validate_signature() {
 		# clr
 		rm -rf "$TMP"
 		# act
-		[ "$RET" != "0" ] && echo -e "\033[0;31mfailed\033[0m\nOpenSSL: $VAL" && error 1 "image could not be verified with public key"
+		[ "$RET" != "0" ] && echo -e "${FREETZ_FWMOD_COLOR_RED}failed${FREETZ_FWMOD_COLOR_RESET}\nOpenSSL: $VAL" && error 1 "image could not be verified with public key"
 	fi
-	echo -e "\033[0;32mvalid\033[0m"
+	echo -e "${FREETZ_FWMOD_COLOR_GREEN}valid${FREETZ_FWMOD_COLOR_RESET}"
 }
 # validate_signature only
 [ $DO_VALIDATE -eq 1 -a $(($DO_UNPACK + $DO_MOD + $DO_PACK + $DO_ZIP)) -eq 0 ] && validate_signature "$DO_VALIDATE" "$FIRMWARE" "$FIRMWARE_PUB" && exit 0

--- a/tools/freetz_functions
+++ b/tools/freetz_functions
@@ -206,6 +206,13 @@ isFreetzType() {
 	return 1
 }
 
+isFreetzFwmodColor() {
+	for i; do
+		eval [ \"\$FREETZ_FWMOD_COLOR_$i\" == y ] && return 0
+	done
+	return 1
+}
+
 # little helper function used by many patches (maybe this should be sourced out)
 rm_files() {
 	for file in "$@"; do
@@ -315,6 +322,35 @@ mod_del_area() {
 	[ $? -ne 0 ] && error 1 "mod_del_area: error in sed expression"
 }
 
+# Set default color output settings, if not specified in config file
+init_freetz_fwmod_colors() {
+	: ${FREETZ_FWMOD_COLOR_BOLD:='\033[1m'}
+	: ${FREETZ_FWMOD_COLOR_RESET:='\033[0m'}
+
+	: ${FREETZ_FWMOD_COLOR_BLUE_FONT:='\033[94m'}
+	: ${FREETZ_FWMOD_COLOR_BLUE_BG:='\033[44m'}
+	: ${FREETZ_FWMOD_COLOR_YELLOW_FONT:='\033[33m'}
+	: ${FREETZ_FWMOD_COLOR_YELLOW_BG:='\033[43m'}
+	: ${FREETZ_FWMOD_COLOR_RED_FONT:='\033[0;31m'}
+	: ${FREETZ_FWMOD_COLOR_RED_BG:='\033[41m'}
+	: ${FREETZ_FWMOD_COLOR_GREEN_FONT:='\033[0;32m'}
+	: ${FREETZ_FWMOD_COLOR_GREEN_BG:='\033[42m'}
+
+	if isFreetzFwmodColor USE_BG; then
+		FREETZ_FWMOD_COLOR_BLUE="${FREETZ_FWMOD_COLOR_BLUE_BG}"
+		FREETZ_FWMOD_COLOR_YELLOW="${FREETZ_FWMOD_COLOR_YELLOW_BG}"
+		FREETZ_FWMOD_COLOR_RED="${FREETZ_FWMOD_COLOR_RED_BG}"
+		FREETZ_FWMOD_COLOR_GREEN="${FREETZ_FWMOD_COLOR_GREEN_BG}"
+	else
+		FREETZ_FWMOD_COLOR_BLUE="${FREETZ_FWMOD_COLOR_BLUE_FONT}"
+		FREETZ_FWMOD_COLOR_YELLOW="${FREETZ_FWMOD_COLOR_YELLOW_FONT}"
+		FREETZ_FWMOD_COLOR_RED="${FREETZ_FWMOD_COLOR_RED_FONT}"
+		FREETZ_FWMOD_COLOR_GREEN="${FREETZ_FWMOD_COLOR_GREEN_FONT}"
+	fi
+}
+
+init_freetz_fwmod_colors
+
 # General printing (info messages, warnings and errors)
 echoX() {
 	# If an error occurs because a parameter starting with "-" (but none of the
@@ -339,16 +375,16 @@ echoX() {
 			l) no_indent=1 ;;
 			p) prefix="$OPTARG" ;;
 			n) no_newline=-n ;;
-			b) bold='\033[1m'; unbold='\033[0m' ;;
-			h) [ "$FREETZ_VERBOSITY_LEVEL" -ge 2 ] && colour='\033[94m' && uncolour='\033[m' ;;
-			c) colour='\033[33m'; uncolour='\033[m' ;; # ANSI brown/yellow
+			b) bold="$FREETZ_FWMOD_COLOR_BOLD"; unbold="$FREETZ_FWMOD_COLOR_RESET" ;;
+			h) [ "$FREETZ_VERBOSITY_LEVEL" -ge 2 ] && colour="$FREETZ_FWMOD_COLOR_BLUE" && uncolour="$FREETZ_FWMOD_COLOR_RESET" ;;
+			c) colour="$FREETZ_FWMOD_COLOR_YELLOW"; uncolour="$FREETZ_FWMOD_COLOR_RESET" ;; # ANSI brown/yellow
 			?) break ;; # unknown parameter -> stop option parsing
 		esac
 	done
 	shift $((OPTIND-1))
 
 	[ $no_indent ] && indent=
-	[ "$FREETZ_VERBOSITY_LEVEL" -ge 2 -a "$STEP" == "2" -a -z "$indent" -a -z "$bold" -a -z "$colour" ] && colour='\033[94m' && uncolour='\033[m' # ANSI blue
+	[ "$FREETZ_VERBOSITY_LEVEL" -ge 2 -a "$STEP" == "2" -a -z "$indent" -a -z "$bold" -a -z "$colour" ] && colour="$FREETZ_FWMOD_COLOR_BLUE" && uncolour="$FREETZ_FWMOD_COLOR_RESET" # ANSI blue
 	echo -e $no_newline "${indent}${bold}${colour}${prefix}$*${uncolour}${unbold}"
 }
 


### PR DESCRIPTION
Dies fügt eine Option ein um für Terminals mit Hellen Hintergrund, eine Farboption mit Hintergrundfarbe auszuwählen.
Zusätzlich setzt es die Farbcodes als Environment um das besser abändern zu können.
refs: https://github.com/orgs/Freetz-NG/discussions/1039