### PR TITLE
prereqs(fedora): fix `cannot find /usr/lib64/libatomic.so.1.2.0` error on build

### DIFF
--- a/tools/.prerequisites/Fedora-42
+++ b/tools/.prerequisites/Fedora-42
@@ -22,6 +22,7 @@ inkscape
 javapackages-tools
 kmod
 libacl-devel
+libatomic
 libatomic.i686
 libattr-devel
 libcap-devel


### PR DESCRIPTION
Dies fügt neben `libatomic.i686` auch `libatomic` (für x64) hinzu. 
Ohne diese Änderung kann man freetz nicht mit fedora44 bauen.

refs: https://github.com/Freetz-NG/freetz-ng/pull/1572 https://github.com/pfichtner/pfichtner-freetz/pull/121

----

<sub>Nebenbei bemerkt (falls ungelesen): [beim Testen mit Debian14 mit einer neuen und alten gclib Version verlief ohne Fehler](https://github.com/Freetz-NG/freetz-ng/pull/1572#issuecomment-5328422187).</sub>