### PR TITLE
add discussion templates

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/push-firmware.yml
+++ b/.github/DISCUSSION_TEMPLATE/push-firmware.yml
@@ -1,0 +1,166 @@
+title: "[push_firmware] "
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Problem mit `tools/push_firmware`
+
+        Bitte fülle das Formular möglichst vollständig aus.
+
+        **Besonders wichtig für die Fehlersuche:**
+        - die verwendete `.config` als Datei anhängen
+        - die vollständige Ausgabe von `push_firmware` angeben
+        - Gerät und FRITZ!OS-Version angeben
+
+  - type: input
+    id: device
+    attributes:
+      label: FRITZ!Box / Gerät
+      description: Welches Gerät soll geflasht werden?
+      placeholder: "z. B. FRITZ!Box 7590"
+    validations:
+      required: true
+
+  - type: input
+    id: fritzos
+    attributes:
+      label: FRITZ!OS-Version
+      placeholder: "z. B. 8.00"
+    validations:
+      required: true
+
+  - type: input
+    id: freetz-version
+    attributes:
+      label: Freetz-NG Version / Commit
+      description: "z. B. Ausgabe von: git rev-parse --short HEAD"
+      placeholder: "z. B. abc1234"
+    validations:
+      required: true
+
+  - type: input
+    id: build-system
+    attributes:
+      label: Build-System
+      description: Betriebssystem bzw. Umgebung, in der Freetz-NG gebaut wurde.
+      placeholder: "z. B. Debian 12 / Ubuntu 24.04 / Docker"
+    validations:
+      required: true
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Freetz-NG `.config`
+      description: |
+        **Bitte unbedingt die verwendete `.config` als Datei anhängen.**
+
+        Die Datei befindet sich im Hauptverzeichnis deines Freetz-NG-Builds.
+        Du kannst sie per Drag & Drop in dieses Feld ziehen.
+
+        Bitte keinen Screenshot der `.config` verwenden.
+      placeholder: |
+        .config hier anhängen ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: command
+    attributes:
+      label: Verwendeter `push_firmware`-Befehl
+      description: Bitte den vollständigen Befehl angeben.
+      placeholder: |
+        tools/push_firmware
+
+        oder z. B.
+        tools/push_firmware ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: output
+    attributes:
+      label: Vollständige Ausgabe
+      description: |
+        Bitte die vollständige Konsolenausgabe von `push_firmware` einfügen.
+        Nicht nur die letzte Fehlermeldung.
+      placeholder: |
+        $ tools/push_firmware
+        ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: Was passiert beim Ausführen von `push_firmware`?
+      placeholder: |
+        Beschreibe möglichst genau:
+        - Wo bricht der Vorgang ab?
+        - Welche Fehlermeldung erscheint?
+        - Startet die FRITZ!Box neu?
+        - Ist die Box danach noch erreichbar?
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Erwartetes Verhalten
+      description: Was sollte stattdessen passieren?
+      placeholder: |
+        Das Freetz-NG-Image sollte erfolgreich auf die FRITZ!Box übertragen
+        und anschließend gestartet werden.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: tests
+    attributes:
+      label: Bereits ausprobiert
+      options:
+        - label: push_firmware erneut ausgeführt
+          required: false
+        - label: push_firmware ohne zusätzliche Parameter getestet
+          required: false
+        - label: anderes Freetz-NG-Image getestet
+          required: false
+        - label: AVM-Recovery durchgeführt
+          required: false
+        - label: anderes LAN-Kabel getestet
+          required: false
+
+  - type: textarea
+    id: more_tests
+    attributes:
+      label: 🔧 Noch mehr ausprobiert
+      description: Welche weiteren Lösungsversuche wurden bereits durchgeführt?
+      placeholder: |
+        - ...
+        - ...
+        - ...
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: ℹ️ Weitere Informationen
+      description: Weitere Logs, Screenshots oder Informationen.
+      placeholder: |
+        Weitere Informationen ...
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checkliste
+      options:
+        - label: Ich habe die vollständige Ausgabe von `push_firmware` angegeben.
+          required: true
+        - label: Ich habe die verwendete `.config` als Datei angehängt.
+          required: true
+        - label: Ich habe nach bereits vorhandenen Discussions zu diesem Problem gesucht.
+          required: true

--- a/.github/DISCUSSION_TEMPLATE/ungelöste-probleme.yml
+++ b/.github/DISCUSSION_TEMPLATE/ungelöste-probleme.yml
@@ -1,0 +1,176 @@
+title: "[Problem] "
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Ungelöstes Problem
+
+        Du hast ein Problem mit Freetz-NG, für das du bisher keine Lösung gefunden hast?
+        Beschreibe das Problem bitte möglichst vollständig, damit andere Nutzer bei der Fehlersuche helfen können.
+
+        **Bitte vorher prüfen:**
+        - Wurde das Problem bereits in den Discussions oder Issues beschrieben?
+        - Verwendest du eine möglichst aktuelle Freetz-NG-Version?
+        - Hast du die verfügbaren Dokumentationen und bekannten Probleme geprüft?
+
+  - type: input
+    id: freetz-version
+    attributes:
+      label: Freetz-NG-Version
+      description: Welche Freetz-NG-Version bzw. welchen Commit verwendest du?
+      placeholder: "z. B. master / Commit abc1234"
+    validations:
+      required: true
+
+  - type: input
+    id: fritzbox-model
+    attributes:
+      label: FRITZ!Box-Modell
+      description: Welches FRITZ!Box-Modell ist betroffen?
+      placeholder: "z. B. FRITZ!Box 7590"
+    validations:
+      required: true
+
+  - type: input
+    id: firmware-version
+    attributes:
+      label: FRITZ!OS-Version
+      description: Welche originale FRITZ!OS-Version läuft auf der Box?
+      placeholder: "z. B. 8.20"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: problem-area
+    attributes:
+      label: Betroffener Bereich
+      description: Welcher Bereich von Freetz-NG ist hauptsächlich betroffen?
+      options:
+        - Build / Freetz-NG-Image
+        - Installation / Flashen
+        - Netzwerk
+        - WLAN
+        - Telefonie / DECT
+        - DSL / WAN
+        - USB
+        - Pakete / Add-ons
+        - Webinterface
+        - Dienste
+        - Kernel / Treiber
+        - Boot / Recovery
+        - Sonstiges
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem-theory-description
+    attributes:
+      label: Erwartetes Verhalten
+      description: Was genau funktioniert nicht? Was erwartest du?
+      placeholder: |
+        ...
+
+        Tatsächliches Verhalten:
+        ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem-real-description
+    attributes:
+      label: Tatsächliches Verhalten
+      description: Was genau funktioniert nicht? Was passiert stattdessen?
+      placeholder: |
+        ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Schritte zur Reproduktion
+      description: Wie lässt sich das Problem reproduzieren?
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevante Logs / Fehlermeldungen
+      description: Füge relevante Logausgaben oder Fehlermeldungen ein. Bitte persönliche Daten, Passwörter und öffentliche IP-Adressen entfernen.
+      placeholder: |
+        ```
+        Hier Logs oder Fehlermeldungen einfügen
+        ```
+      render: text
+    validations:
+      required: false
+
+  - type: textarea
+    id: troubleshooting
+    attributes:
+      label: Bereits getestete Lösungsansätze
+      description: Was hast du bereits ausprobiert und mit welchem Ergebnis?
+      placeholder: |
+        - Ansatz 1: ...
+          Ergebnis: ...
+
+        - Ansatz 2: ...
+          Ergebnis: ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Freetz-NG `.config`
+      description: |
+        **Sollte es sich um ein Freetz Build Problen handeln, dann unbedingt die verwendete `.config` als Datei anhängen.**
+
+        Die Datei befindet sich im Hauptverzeichnis deines Freetz-NG-Builds.
+        Du kannst sie per Drag & Drop in dieses Feld ziehen.
+
+        Bitte keinen Screenshot der `.config` verwenden.
+      placeholder: |
+        .config hier anhängen ...
+    validations:
+      required: false
+
+  - type: textarea
+    id: settings
+    attributes:
+      label: Weitere relevante Konfiguration
+      description: Falls relevant, füge die betroffenen Einstellungen oder Konfigurationsausschnitte ein.
+      placeholder: |
+        ```
+        Relevante Konfiguration
+        ```
+      render: text
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-info
+    attributes:
+      label: Weitere Informationen
+      description: Alles Weitere, was bei der Analyse helfen könnte.
+      placeholder: "Weitere Informationen, Links, Screenshots oder Hinweise ..."
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Vor dem Absenden
+      options:
+        - label: Ich habe nach bereits vorhandenen Discussions/Issues zu diesem Problem gesucht.
+          required: true
+        - label: Ich habe keine vertraulichen Daten, Passwörter oder Zugangsdaten veröffentlicht.
+          required: true
+        - label: Ich habe die verfügbaren Informationen möglichst vollständig angegeben.
+          required: true


### PR DESCRIPTION
Dies fügt Discussuin Templates für folgende Kategorien hinzu:

- push firmware (funktioniert) 
- Ungelöste Probleme (funktioniert nicht wegen **Ö** in Namen)

<details><summary>So sieht das Form von push firmware aus</summary>

<img width="880" height="2513" alt="642797927-148564aa-854f-41d0-8795-c7289e816a2c" src="https://github.com/user-attachments/assets/bdb3be1c-147a-4441-82b6-9a7dafefc881" />

</details>

https://github.com/Freetz-NG/freetz-ng/commit/3ed49317cb1b091d7ab3d3af2e5aba2b13df21a9#commitcomment-198098211

-----

**Dies kann auch beliebig angepasst werden.**
Wie bereits erwähnt, es ist ein Form Template (Form = Formular)