### PR TITLE
Update discussion templates

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/offene-probleme.yml
+++ b/.github/DISCUSSION_TEMPLATE/offene-probleme.yml
@@ -4,7 +4,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        ## Unresolved Problem
+        ## Open Problem
 
         Do you have a problem with Freetz-NG for which you have not yet found a solution?
         Please describe the problem as completely as possible so that other users can help with troubleshooting.
@@ -128,7 +128,7 @@ body:
   - type: textarea
     id: config
     attributes:
-      label: Freetz-NG `.config`
+      label: Freetz-NG ".config"
       description: |
         **If this is a Freetz build problem, please make sure to attach the `.config` file that was used.**
 
@@ -137,7 +137,7 @@ body:
 
         Please do not provide a screenshot of the `.config` file.
       placeholder: |
-        Attach the `.config` file here ...
+        Attach the ".config" file here ...
     validations:
       required: false
 

--- a/.github/DISCUSSION_TEMPLATE/push-firmware.yml
+++ b/.github/DISCUSSION_TEMPLATE/push-firmware.yml
@@ -51,7 +51,7 @@ body:
   - type: textarea
     id: config
     attributes:
-      label: Freetz-NG `.config`
+      label: Freetz-NG ".config"
       description: |
         **Please make sure to attach the `.config` file used for the build.**
 
@@ -60,14 +60,14 @@ body:
 
         Please do not provide a screenshot of the `.config` file.
       placeholder: |
-        Attach the `.config` file here ...
+        Attach the ".config" file here ...
     validations:
       required: true
 
   - type: textarea
     id: command
     attributes:
-      label: "`push_firmware` Command Used"
+      label: '"push_firmware" Command Used'
       description: Please provide the complete command.
       placeholder: |
         tools/push_firmware
@@ -94,7 +94,7 @@ body:
     id: problem
     attributes:
       label: Problem
-      description: What happens when running `push_firmware`?
+      description: What happens when running "push_firmware"?
       placeholder: |
         Describe the problem as precisely as possible:
         - Where does the process stop?
@@ -158,9 +158,9 @@ body:
     attributes:
       label: Checklist
       options:
-        - label: I have provided the complete output of `push_firmware`.
+        - label: I have provided the complete output of "push_firmware".
           required: true
-        - label: I have attached the `.config` used as a file.
+        - label: I have attached the ".config" used as a file.
           required: true
         - label: I have searched for existing Discussions about this issue.
           required: true


### PR DESCRIPTION
Das benennt das Template für ungelöste Probleme in offene Probleme um so das es nun erkannt wird.
Bei den textabschnitten wo `.config` nicht erkannt wird, wird durch ".config" ersetzt.

Bei der commit history wird bei mir trotz des einen einzigen commits das unbenennen der Datei als unbenannt angezeigt.
https://github.com/Freetz-NG/freetz-ng/pull/1590/changes#diff-970e421aa2a73df2ce562cf055f45646068320dcbda84d8572152aa7f9fac527
<img width="789" height="28" alt="Screenshot 2026-09-06 at 07-29-39 Update discussion templates by LizenzFass78851 · Pull Request #1590 · Freetz-NG_freetz-ng" src="https://github.com/user-attachments/assets/cbe5f46a-b4c0-4bdd-b683-a2c4e95a4c04" />

refs: #1583 