### PR TITLE
zensical: bump to 0.0.59

### DIFF
--- a/zensical.txt
+++ b/zensical.txt
@@ -1,2 +1,2 @@
-zensical==0.0.52
+zensical==0.0.59
 


### PR DESCRIPTION
Ich habe zensical bei mir auf die angegebene Version aktualisiert und habe manuell das zensical action laufen lassen und da gab es keine Probleme oder Fehlermeldungen. 
Ebenso nach dem ich mir das Ergebnis (https://lizenzfass78851.github.io/freetz-ng/) angeschaut habe gab es auch da keine auffälligkeiten.
[logs_92157539663.zip](https://github.com/user-attachments/files/31875071/logs_92157539663.zip)

Auch das `tools/zensical_httpserver.sh run` funktioniert nach den Update weiterhin. 
Das lokale Ergebnis ist ebenfalls ohne auffälligkeiten.

- [Release notes](https://github.com/zensical/zensical/releases)
- [Commits](https://github.com/zensical/zensical/compare/v0.0.52...v0.0.59)

refs: https://github.com/Freetz-NG/freetz-ng/commit/d71def0383c6498dd2f545511123e4758aad784f#commitcomment-199221518 