### PR TITLE
dependabot: Update only for zensical long-term proven versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,17 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    allow:
+      - dependency-name: "zensical"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+    ignore:
+      - dependency-name: "zensical"
+        update-types:
+          - "version-update:semver-patch"
     cooldown:
       include:
         - "zensical"
-      default-days: 17
+      default-days: 90
 


### PR DESCRIPTION
Dies ändert das dependabot Updateverhalten für zensical so das erst wenn eine neue minor oder major version von zensical (0,1.X oder 1.X.X) erscheint, das erst nach 90 Tagen das Update anbietet wenn bis dahin schon 25 Patches oder mehr veröffentlicht wurden.

Das stellt sicher das nach 90 Tagen nach veröffentlichung einer neuen Minor oder Major Version wenn es quasi langzeit erprobt ist, das Update anbietet.
Update innerhalb der minor version (von 0.1.X zu 0.1.X) werden übersprungen bis es die nächste minor oder major version gibt, die auch wieder erst nach 90 Tage angeboten wird.

Mehr als 90 Tage cooldown lässt sich nicht einstellen, sonnt hätte ich für major ein halbes jahr und wie für minor vorgesehen, ein quartal definiert.

----

Alternativ kann man nur die minor versionen nach den shema durch dependabot updaten lassen und macht die major versionen aussschließlich manuell in den man folgende zeile weglässt:

```diff
     allow:
       - dependency-name: "zensical"
         update-types:
-          - "version-update:semver-major"
           - "version-update:semver-minor"
     ignore:
       - dependency-name: "zensical"
         update-types:
           - "version-update:semver-patch"
```

refs: https://github.com/Freetz-NG/freetz-ng/commit/d71def0383c6498dd2f545511123e4758aad784f#commitcomment-199221518