### PR TITLE
mod: Correct syntax errors in `pwchange.cgi` when querying `QUERY_STRING`.

### DIFF
--- a/make/pkgs/mod/files/root/usr/mww/cgi-bin/pwchange.cgi
+++ b/make/pkgs/mod/files/root/usr/mww/cgi-bin/pwchange.cgi
@@ -10,7 +10,7 @@ if [ "$1" = "successful" ]; then
 	exit
 fi
 
-if [ -n "$(echo $QUERY_STRING | sed -n 's%.*newhash=\([0-9a-f]*\).*%\1% p')" ]; then
+if [ -n "$(echo "$QUERY_STRING" | sed -n 's%.*newhash=\([0-9a-f]*\).*%\1%p')" ]; then
 	source /usr/mww/cgi-bin/pwchange_check.sh
 else
 	source /usr/mww/cgi-bin/pwchange_page.sh


### PR DESCRIPTION
A **try** to Fixes #1595

Ich habe zwar dafür den Github Copilot verwendet, aber mit den Ziel das Problem schnell zu finden und zu beheben, für eine Behebung was minimale Änderungen erfordert, ist dies eine der effizienten Lösungen.


<details><summary>Ki Ergebnis</summary>
<p>

## ✅ Ursache behoben

Der Fehler lag in `pwchange.cgi`: Dort wurde der Parameter `newhash` mit einer fehlerhaften `sed`-Anweisung ausgewertet (`% p` statt `%p`). Dadurch wurde der neue Webconfig-Hash nach einer frischen Installation nicht korrekt erkannt und die Passwortänderung blieb hängen.

Ich habe den Ausdruck korrigiert und die Auswertung auf das richtige Muster gesetzt.

---

## 🔎 Verifiziert

Mit diesem Repro war die Ursache bestätigt:

```sh
QUERY_STRING='oldhash=abc&newhash=deadbeef'; \
printf '%s\n' "$(echo "$QUERY_STRING" | sed -n 's%.*newhash=\([0-9a-f]*\).*%\1%p')"
```

Ausgabe:

```text
deadbeef
```

Das ist genau das erwartete Verhalten für den `newhash`-Parameter.

</p>
</details> 

-----